### PR TITLE
Gpg profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,22 +115,6 @@
           <excludePackageNames>*.internal</excludePackageNames>
         </configuration>
       </plugin>
-
-      <!-- Signing with gpg -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 
@@ -180,6 +164,30 @@
               <execution>
                 <goals>
                   <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- Signing with gpg -->
+    <!--
+    Sign the artifacts by calling
+    mvn -P sign-artifacts [..]
+    -->
+    <profile>
+      <id>sign-artifacts</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
                 </goals>
               </execution>
             </executions>


### PR DESCRIPTION
I've moved the gpg-stuff into a separate profile because currently I have to comment out the gpg-section after every pull before I can do a
mvn clean install
to test your changes.

You'd now use
mvn -P sign-artifacts clean install
to actually perform the signing.
