### PR TITLE
Noparseconstructor

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -139,6 +139,14 @@ public class JCommander {
   /**
    * @param object The arg object expected to contain {@link @Parameter} annotations.
    * @param bundle The bundle to use for the descriptions. Can be null.
+   */
+  public JCommander(Object object, ResourceBundle bundle) {
+      init(object, bundle);
+  }
+
+  /**
+   * @param object The arg object expected to contain {@link @Parameter} annotations.
+   * @param bundle The bundle to use for the descriptions. Can be null.
    * @param args The arguments to parse (optional).
    */
   public JCommander(Object object, ResourceBundle bundle, String... args) {

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -20,6 +20,7 @@ package com.beust.jcommander;
 
 import com.beust.jcommander.args.Args1;
 import com.beust.jcommander.args.Args2;
+import com.beust.jcommander.args.ArgsHelp;
 import com.beust.jcommander.args.ArgsLongDescription;
 import com.beust.jcommander.args.ArgsArityString;
 import com.beust.jcommander.args.ArgsBooleanArity;
@@ -146,6 +147,26 @@ public class JCommanderTest {
 
   public void i18nWithResourceAnnotationNew() {
     i18n2(new ArgsI18N2New());
+  }
+
+  /**
+   * Test a use case where there are required parameters, but you still want
+   * to interrogate the options which are specified.
+   */
+  @Test
+  public void usageWithRequiredArgsAndResourceBundle() {
+    System.out.println("In the test");
+    ArgsHelp argsHelp = new ArgsHelp();
+    JCommander jc = new JCommander(new Object[]{argsHelp, new ArgsRequired()}, java.util.ResourceBundle.getBundle("MessageBundle"));
+    // Should be able to display usage without triggering validation
+    jc.usage();
+    try {
+      jc.parse("-h");
+      Assert.fail("Should have thrown a required parameter exception");
+    } catch (ParameterException e) {
+      Assert.assertTrue(e.getMessage().contains("are required"));
+    }
+    Assert.assertTrue(argsHelp.help);
   }
 
   public void multiObjects() {

--- a/src/test/java/com/beust/jcommander/args/ArgsHelp.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsHelp.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.beust.jcommander.args;
+
+import com.beust.jcommander.Parameter;
+
+/**
+ * Test a help option which overrides other options and option validations
+ */
+public class ArgsHelp {
+
+  @Parameter(names = "-h", description = "Display help")
+  public boolean help;
+}


### PR DESCRIPTION
There are two changes here:
1. parse() wasn't checking of createDescription() was already called.  It was possible, using main params, to use a sequence of valid calls which would trigger an exception.  Also added unit test to check for that condition.
2. Added a constructor which takes a bundle, but no args.  It mirrors the JCommander(Object object) constructor.  Added a unit test demonstrating a use case where this is useful (interrogating options even when a required option is missing).

Regarding testing these changes:
Because of the dependencies in the pom and the issue with the testng dependency on jcommander, I couldn't build and test these changes with the existing pom.  Locally, I created a gradle build file, and a junit test class to build and test this, all passed.  
