### PR TITLE
partial parsing of arguments

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -592,7 +592,7 @@ public class JCommander {
       i++;
     }
 
-      //Flag the parameter descriptions held in field as assigned
+      //Flag the parameter descriptions held in m_fields as assigned
       for (ParameterDescription parameterDescription : m_descriptions.values()) {
           if(parameterDescription.isAssigned()){
             m_fields.get(parameterDescription.getField()).setAssigned(true);


### PR DESCRIPTION
Hi Cedric-

   I am trying to integrate jline "tab" completion with JCommander. The idea being passing whatever args are present to JCommander.parseWithoutValidation(), and then calling getParsedParameterDescriptions() to determine which descriptions have m_assigned = true, so you can exclude them from the candidate set for tab completions.

This pull request adds the 2 methods mentioned above.

 I have this working with the current JCommander snapshot by swallowing the exception that happens in parse() when you pass incomplete args, and reflectively accessing m_descriptions.

2 Questions/Observations...
JCommander.getParameters() does not return the main parameter description...is this on purpose?

JCommander.getParameters() returns m_fields.values(). The ParameterDescription instances here are different from the ones in m_descriptions, and dont ever seem to get their m_assigned field set, since the ones in m_descriptions are the ones being manipulated in parseValues(args).  If the ones in m_fields could get set too, then the getParsedParameters method would be unnecessary (if getParamaters can also return the main param description too)
