### PR TITLE
allow converterfactories to override the defaults

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -40,8 +40,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.ResourceBundle;
+
+
 
 /**
  * The main class for JCommander. It's responsible for parsing the object that contains
@@ -123,10 +126,10 @@ public class JCommander {
   /**
    * The factories used to look up string converters.
    */
-  private static List<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newArrayList();
+  private static LinkedList<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newLinkedList();
 
   static {
-    CONVERTER_FACTORIES.add(new DefaultConverterFactory());
+    CONVERTER_FACTORIES.addFirst(new DefaultConverterFactory());
   };
 
   /**
@@ -877,7 +880,7 @@ public class JCommander {
   }
 
   public void addConverterFactory(IStringConverterFactory converterFactory) {
-    CONVERTER_FACTORIES.add(converterFactory);
+    CONVERTER_FACTORIES.addFirst(converterFactory);
   }
 
   public <T> Class<? extends IStringConverter<T>> findConverter(Class<T> cls) {

--- a/src/main/java/com/beust/jcommander/internal/Lists.java
+++ b/src/main/java/com/beust/jcommander/internal/Lists.java
@@ -20,19 +20,30 @@ package com.beust.jcommander.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 
 public class Lists {
 
-  public static <K> List<K> newArrayList() {
-    return new ArrayList<K>();
-  }
-  
-  public static <K> List<K> newArrayList(Collection<K> c) {
-    return new ArrayList<K>(c);
-  }
+    public static <K> List<K> newArrayList() {
+        return new ArrayList<K>();
+    }
 
-  public static <K> List<K> newArrayList(int size) {
-    return new ArrayList<K>(size);
-  }
+    public static <K> List<K> newArrayList(Collection<K> c) {
+        return new ArrayList<K>(c);
+    }
+
+    public static <K> List<K> newArrayList(int size) {
+        return new ArrayList<K>(size);
+    }
+
+    public static <K> LinkedList<K> newLinkedList() {
+        return new LinkedList<K>();
+    }
+
+    public static <K> LinkedList<K> newLinkedList(Collection<K> c) {
+        return new LinkedList<K>(c);
+    }
+
+
 }


### PR DESCRIPTION
Hi Cedric-

   This tweak reverses the search order for converters such that if I add a converter factory that contains a 
converter of a type already present in the default converter factory, mine will get found first.

SC 
