### PR TITLE
Initializing command default values

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -261,6 +261,10 @@ public class JCommander {
       for (ParameterDescription pd : m_descriptions.values()) {
         initializeDefaultValue(pd);
       }
+
+      for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+        entry.getValue().initializeDefaultValues();
+      }
     }
   }
 
@@ -925,6 +929,10 @@ public class JCommander {
    */
   public void setDefaultProvider(IDefaultProvider defaultProvider) {
     m_defaultProvider = defaultProvider;
+
+    for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+      entry.getValue().setDefaultProvider(defaultProvider);
+    }
   }
 
   public void addConverterFactory(IStringConverterFactory converterFactory) {
@@ -1033,6 +1041,7 @@ public class JCommander {
   public void addCommand(String name, Object object, String... aliases) {
     JCommander jc = new JCommander(object);
     jc.setProgramName(name, aliases);
+    jc.setDefaultProvider(m_defaultProvider);
     ProgramName progName = jc.m_programName;
     m_commands.put(progName, jc);
 


### PR DESCRIPTION
This patch fixes initializing default values for commands.

E.g. I had situation where a command (A) had no arguments, and another command (B) had several arguments out of which some had default value specified (using properties file based DefaultProvider).

If I constructed JCommander with B as arguments object, and A added using addCommand, when A was passed in parsing would fail with missing (Bs mandatory) arguments error. When I constructed JCommander using default constructor and added both commands with addCommand, running command B would pass, while running command A would not get default values initialized.
