### PR TITLE
Changed the format produced by "usage"

### DIFF
--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -139,7 +139,7 @@ public class ParameterDescription {
     String[] names = m_parameterAnnotation.names();
     for (int i = 0; i < names.length; i++) {
       if (i > 0) sb.append(", ");
-      if (names.length == 1 && names[i].startsWith("--")) sb.append("    ");
+//      if (names.length == 1 && names[i].startsWith("--")) sb.append("    ");
       sb.append(names[i]);
     }
     return sb.toString();


### PR DESCRIPTION
Now the option name is written on its own line, and the description is
indented and starts on the next line.

Also removed the duplicated function for producing string of spaces.

This is what we've spoken about per email on 1-st and 2-nd September 2011
