### PR TITLE
Added support for option groups in usage output and some other fixes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ Added: @Parameter(commandNames) so that command names can be specified with anno
 Added: Support for enums (Adrian Muraru)
 Fixed: Throw if an unknown option is found
 Fixed: Main parameters are now validated as well (Connor Mullen)
+Added: Support for option groups in usage output (rodionmoiseev)
+Fixed: Passing bundle to constructor causes error when no key command description is given (rodionmoiseev)
+Fixed: Command description and options fail to lookup key in the bundle (rodionmoiseev)
 
 1.19
 2011/10/10

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -456,13 +456,16 @@ public class JCommander {
     m_descriptions = Maps.newHashMap();
 
     for (Object object : m_objects) {
-      addDescription(object);
+      addDescription(object, Lists.<Parameters>newArrayList());
     }
   }
 
-  private void addDescription(Object object) {
+  private void addDescription(Object object, List<Parameters> parentParameters) {
     Class<?> cls = object.getClass();
-
+    Parameters parametersAnnotation = cls.getAnnotation(Parameters.class);
+    List<Parameters> parametersAnnotations = Lists.newArrayList(parentParameters);
+    if (parametersAnnotation != null)
+      parametersAnnotations.add(parametersAnnotation);
     while (!Object.class.equals(cls)) {
       for (Field f : cls.getDeclaredFields()) {
         p("Field:" + cls.getSimpleName() + "." + f.getName());
@@ -480,14 +483,14 @@ public class JCommander {
             m_mainParameterField = f;
             m_mainParameterObject = object;
             m_mainParameterAnnotation = p;
-            m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this);
+            m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this, parametersAnnotations);
           } else {
             for (String name : p.names()) {
               if (m_descriptions.containsKey(name)) {
                 throw new ParameterException("Found the option " + name + " multiple times");
               }
               p("Adding description for " + name);
-              ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this);
+              ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this, parametersAnnotations);
               m_fields.put(f, pd);
               m_descriptions.put(name, pd);
 
@@ -500,7 +503,7 @@ public class JCommander {
             if (delegateObject == null){
               throw new ParameterException("Delegate field '" + f.getName() + "' cannot be null.");
             }
-            addDescription(delegateObject);
+            addDescription(delegateObject, parametersAnnotations);
           } catch (IllegalAccessException e) {
           }
         }
@@ -823,13 +826,20 @@ public class JCommander {
    * every line with "indent".
    */
   public void usage(String commandName, StringBuilder out, String indent) {
+    Map<String, ParameterDescMap> optGroupMap = Maps.newTreeMap();
+    printUsage(commandName, out, indent, optGroupMap);
+    printOptionGroups(out, indent, optGroupMap);
+  }
+
+  private void printUsage(String commandName, StringBuilder out, String indent,
+                          Map<String, ParameterDescMap> optGroupMap) {
     String description = getCommandDescription(commandName);
     JCommander jc = findCommandByAlias(commandName);
     if (description != null) {
       out.append(indent).append(description);
-      out.append("\n");
     }
-    jc.usage(out, indent);
+    out.append("\n");
+    jc.printUsage(out, indent, optGroupMap);
   }
 
   /**
@@ -853,7 +863,7 @@ public class JCommander {
    * return def.
    */
   private String getI18nString(String key, String def) {
-    String s = m_bundle != null ? m_bundle.getString(key) : null;
+    String s = m_bundle != null && m_bundle.containsKey(key) ? m_bundle.getString(key) : null;
     return s != null ? s : def;
   }
 
@@ -874,27 +884,103 @@ public class JCommander {
   }
 
   public void usage(StringBuilder out, String indent) {
+    Map<String, ParameterDescMap> optGroupMap = Maps.newTreeMap();
+    printUsage(out, indent, optGroupMap);
+    printOptionGroups(out, indent, optGroupMap);
+  }
+
+  private void printUsage(StringBuilder out, String indent, Map<String, ParameterDescMap> optGroupMap) {
     if (m_descriptions == null) createDescriptions();
     boolean hasCommands = !m_commands.isEmpty();
+
+    //
+    // Separate inline parameters from option groups
+    //
+    List<ParameterDescription> parameterDescriptions = Lists.newArrayList();
+    for (ParameterDescription pd : m_fields.values()) {
+      if (! "".equals(pd.getOptionGroupName())) {
+        //Add parameter to its respective option group
+        ParameterDescMap paramDescMap = optGroupMap.get(pd.getOptionGroupName());
+        if (paramDescMap == null) {
+            paramDescMap = new ParameterDescMap(pd.getOptionGroupName(), pd.getOptionGroupDescription());
+            optGroupMap.put(pd.getOptionGroupName(), paramDescMap);
+        }
+        paramDescMap.put(pd.getNames(), pd);
+      } else {
+        //An inline usage parameter
+        parameterDescriptions.add(pd);
+      }
+    }
 
     //
     // First line of the usage
     //
     String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
-    out.append(indent).append("Usage: " + programName + " [options]");
+    StringBuilder optionGroupUsage = new StringBuilder();
+    optionGroupUsage.append("Usage: ").append(programName);
+    if (!parameterDescriptions.isEmpty()) {
+      optionGroupUsage.append(" [options]");
+    }
+    for (String optGroupName : optGroupMap.keySet()) {
+      optionGroupUsage.append(" [").append(optGroupName.toLowerCase()).append("]");
+    }
+    out.append(indent).append(optionGroupUsage);
     if (hasCommands) out.append(indent).append(" [command] [command options]");
-//    out.append("\n");
-    if (m_mainParameterDescription != null) {
+
+    if (m_mainParameterDescription != null &&
+            !"".equals(m_mainParameterDescription.getDescription())) {
       out.append(" " + m_mainParameterDescription.getDescription());
     }
+    out.append("\n");
 
+    //
+    // Show inline parameter descriptions first
+    //
+    printParameterDescriptions(out, indent, parameterDescriptions, "Options");
+
+    //
+    // If commands were specified, show them as well
+    //
+    if (hasCommands) {
+      out.append("  Commands:\n");
+      // The magic value 3 is the number of spaces between the name of the option
+      // and its description
+      for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
+        ProgramName progName = commands.getKey();
+        String dispName = progName.getDisplayName();
+        out.append(indent).append("    " + dispName);
+
+        Map<String, ParameterDescMap> cmdOptGroupMap = Maps.newTreeMap();
+        // Options for this command
+        printUsage(progName.getName(), out, "      ", cmdOptGroupMap);
+        optGroupMap.putAll(cmdOptGroupMap);
+      }
+    }
+  }
+
+  private void printOptionGroups(StringBuilder out, String indent, Map<String, ParameterDescMap> optGroupMap) {
+    if (!optGroupMap.isEmpty()) {
+      out.append("\n");
+      //
+      // Show option groups at the end
+      //
+      for (ParameterDescMap optionGroup : optGroupMap.values()) {
+        out.append(optionGroup.groupDesc).append("\n");
+        printParameterDescriptions(out, indent, optionGroup.values(), optionGroup.groupName);
+      }
+    }
+  }
+
+  private void printParameterDescriptions(StringBuilder out, String indent,
+                                          Iterable<ParameterDescription> parameterDescriptions,
+                                          String optGroupName){
     //
     // Align the descriptions at the "longestName" column
     //
     int longestName = 0;
     List<ParameterDescription> sorted = Lists.newArrayList();
-    for (ParameterDescription pd : m_fields.values()) {
-      if (! pd.getParameter().hidden()) {
+    for (ParameterDescription pd : parameterDescriptions) {
+      if (!pd.getParameter().hidden()) {
         sorted.add(pd);
         // + to have an extra space between the name and the description
         int length = pd.getNames().length() + 2;
@@ -912,7 +998,8 @@ public class JCommander {
     //
     // Display all the names and descriptions
     //
-    if (sorted.size() > 0) out.append(indent).append("\n  Options:\n");
+    if (sorted.size() > 0)
+      out.append(indent).append("  ").append(optGroupName).append(":\n");
     for (ParameterDescription pd : sorted) {
       int l = pd.getNames().length();
       int spaceCount = longestName - l;
@@ -923,27 +1010,9 @@ public class JCommander {
       int indentCount = out.length() - start;
       wrapDescription(out, indentCount, pd.getDescription());
       Object def = pd.getDefault();
-      if (def != null) out.append("\n" + spaces(indentCount + 1))
+      if (def != null) out.append("\n").append(spaces(indentCount + 1))
           .append("Default: " + def);
       out.append("\n");
-    }
-
-    //
-    // If commands were specified, show them as well
-    //
-    if (hasCommands) {
-      out.append("  Commands:\n");
-      // The magic value 3 is the number of spaces between the name of the option
-      // and its description
-      for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
-        ProgramName progName = commands.getKey();
-        String dispName = progName.getDisplayName();
-        out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");
-
-        // Options for this command
-        usage(progName.getName(), out, "      ");
-        out.append("\n");
-      }
     }
   }
 
@@ -993,7 +1062,7 @@ public class JCommander {
    * format (e.g. HTML).
    */
   public List<ParameterDescription> getParameters() {
-    return new ArrayList<ParameterDescription>(m_fields.values());
+    return Lists.newArrayList(m_fields.values());
   }
 
   /**
@@ -1187,7 +1256,7 @@ public class JCommander {
    * Add a command object and its aliases.
    */
   public void addCommand(String name, Object object, String... aliases) {
-    JCommander jc = new JCommander(object);
+    JCommander jc = new JCommander(object, m_bundle);
     jc.setProgramName(name, aliases);
     jc.setDefaultProvider(m_defaultProvider);
     ProgramName progName = jc.m_programName;
@@ -1340,5 +1409,24 @@ public class JCommander {
       return getDisplayName();
       
     }
+  }
+}
+
+class ParameterDescMap {
+  final String groupName;
+  final String groupDesc;
+  final Map<String, ParameterDescription> map = Maps.newLinkedHashMap();
+
+  ParameterDescMap(String groupName, String groupDesc) {
+    this.groupName = groupName;
+    this.groupDesc = groupDesc;
+  }
+
+  public void put(String names, ParameterDescription pd) {
+    map.put(names, pd);
+  }
+
+  public Collection<ParameterDescription> values() {
+    return map.values();
   }
 }

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -43,10 +43,12 @@ public class ParameterDescription {
   private Object m_default;
   /** Longest of the names(), used to present usage() alphabetically */
   private String m_longestName = "";
+  private String m_optionGroupName = "";
+  private String m_optionsGroupDesc = "";
 
   public ParameterDescription(Object object, Parameter annotation, Field field,
-      ResourceBundle bundle, JCommander jc) {
-    init(object, annotation, field, bundle, jc);
+      ResourceBundle bundle, JCommander jc, List<Parameters> parametersAnnotations) {
+    init(object, annotation, field, bundle, jc, parametersAnnotations);
   }
 
   /**
@@ -76,7 +78,7 @@ public class ParameterDescription {
   }
 
   private void init(Object object, Parameter annotation, Field field, ResourceBundle bundle,
-      JCommander jCommander) {
+      JCommander jCommander, List<Parameters> parametersAnnotations) {
     m_object = object;
     m_parameterAnnotation = annotation;
     m_field = field;
@@ -85,17 +87,16 @@ public class ParameterDescription {
       m_bundle = findResourceBundle(object);
     }
     m_jCommander = jCommander;
-
-    m_description = annotation.description();
-    if (! "".equals(annotation.descriptionKey())) {
-      if (m_bundle != null) {
-        m_description = m_bundle.getString(annotation.descriptionKey());
-      } else {
-//        System.out.println("Warning: field " + object.getClass() + "." + field.getName()
-//            + " has a descriptionKey but no bundle was defined with @ResourceBundle, using " +
-//            "default description:'" + m_description + "'");
+    if (parametersAnnotations != null) {
+      for (Parameters pa : parametersAnnotations) {
+        if (! "".equals(pa.optionGroupName())) {
+          m_optionGroupName = pa.optionGroupName();
+          m_optionsGroupDesc = getValueFromBundle(pa.optionGroupDescriptionKey(), pa.optionGroupDescription());
+        }
       }
     }
+
+    m_description = getValueFromBundle(annotation.descriptionKey(), annotation.description());
 
     for (String name : annotation.names()) {
       if (name.length() > m_longestName.length()) m_longestName = name;
@@ -130,6 +131,14 @@ public class ParameterDescription {
 
   public Object getObject() {
     return m_object;
+  }
+
+  public String getOptionGroupName(){
+    return m_optionGroupName;
+  }
+
+  public String getOptionGroupDescription(){
+    return m_optionsGroupDesc;
   }
 
   public String getNames() {
@@ -264,6 +273,17 @@ public class ParameterDescription {
     if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
       System.out.println("[ParameterDescription] " + string);
     }
+  }
+
+  private String getValueFromBundle(String key, String defaultValue){
+    if (key != null && ! "".equals(key) && m_bundle != null) {
+      return m_bundle.getString(key);
+    } else {
+//    System.out.println("Warning: field " + object.getClass() + "." + field.getName()
+//      + " has a descriptionKey but no bundle was defined with @ResourceBundle, using " +
+//        "default description:'" + m_description + "'");
+    }
+    return defaultValue;
   }
 
   @Override

--- a/src/main/java/com/beust/jcommander/Parameters.java
+++ b/src/main/java/com/beust/jcommander/Parameters.java
@@ -65,4 +65,25 @@ public @interface Parameters {
    * An array of allowed command names.
    */
   String[] commandNames() default {};
+
+  /**
+   * <p>If specified, all options declared in the annotated class will be displayed
+   * as a separate group of options at the end of usage output.</p>
+   *
+   * <p>Option group will be displayed only once if several commands share the
+   * same option group. Use option groups to make usage output less verbose.</p>
+   */
+  String optionGroupName() default "";
+
+  /**
+   * A brief description for this option group to be displayed in the usage
+   * output. Only takes effect when {@link #optionGroupName()} was specified
+   * to a non-empty string.
+   */
+  String optionGroupDescription() default "";
+
+  /**
+   * The key used to find the option group description ({@link #optionGroupDescription()})
+   */
+  String optionGroupDescriptionKey() default "";
 }

--- a/src/main/java/com/beust/jcommander/internal/Maps.java
+++ b/src/main/java/com/beust/jcommander/internal/Maps.java
@@ -21,6 +21,7 @@ package com.beust.jcommander.internal;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class Maps {
 
@@ -32,4 +33,7 @@ public class Maps {
     return new LinkedHashMap<K, V>();
   }
 
+  public static <K, V> Map<K,V> newTreeMap() {
+    return new TreeMap<K, V>();
+  }
 }

--- a/src/test/java/com/beust/jcommander/OptionGroupPackageManagerScenario2Test.java
+++ b/src/test/java/com/beust/jcommander/OptionGroupPackageManagerScenario2Test.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.beust.jcommander;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author rodion
+ */
+public class OptionGroupPackageManagerScenario2Test {
+  private static final String NL = "\n";
+
+  private static class GeneralOptions{
+    @ParametersDelegate
+    public HelpOpt helpOpts = new HelpOpt();
+    @Parameter(names="--pkg-root", description = "Package installation root")
+    public String pkgRoot = "/tmp/pkgs";
+  }
+
+  private static class VerbosityOptions {
+    @Parameter(names="-V", description = "Make output more verbose")
+    public boolean verbose;
+  }
+
+  @Parameters(optionGroupName = "Filter Options", optionGroupDescription = "Options for filtering things")
+  private static class FilterOptions {
+    @Parameter(names = "-v", description = "Filter by version")
+    public String version;
+    @Parameter(names = {"-i", "--id"}, description = "Filter by package id")
+    public int pkgId;
+    @Parameter(names = "--name", description = "Filter by package name")
+    public String pkgName;
+    @Parameter(names = {"-t", "--type"}, description = "Filter by package type")
+    public List<String> pkgTypes = new ArrayList<String>() {{
+      add("type1");
+    }};
+    /*
+     * Delegated parameters are included as part of this option group,
+     * unless they re-declare optionGroupName to a different name.
+     */
+    @ParametersDelegate
+    public VerbosityOptions verbosityOptions = new VerbosityOptions();
+  }
+
+  @Parameters(optionGroupName = "Terminal Options", optionGroupDescription = "Terminal related options")
+  private static class TerminalOptions {
+    enum TerminalType {
+      ANSI, VT100, VT320, WY370
+    }
+
+    @Parameter(names = "--term-coloring")
+    public TerminalType coloringForTermType = TerminalType.ANSI;
+    @Parameter(names = "--no-decorations", description = "Disable terminal colouring")
+    public boolean noDecorations;
+    @Parameter(names = "--no-progress-bar", description = "Disable progress bars")
+    public boolean noProgressBars;
+  }
+
+  @Parameters(optionGroupName = "Help Options", optionGroupDescriptionKey = "optionGroups.help")
+  private static class HelpOpt {
+    @Parameter(names = {"-h", "--h"}, description = "Show help")
+    public boolean showHelp;
+  }
+
+  @Parameters(commandDescription = "List available packages")
+  private static class PackagesCmd {
+    @Parameter(description = "main parameters")
+    public List<String> mainParams = new ArrayList<String>();
+    @ParametersDelegate
+    public FilterOptions filterOpts = new FilterOptions();
+    @ParametersDelegate
+    public HelpOpt helpOpts = new HelpOpt();
+  }
+
+  @Parameters(commandDescription = "Install package")
+  private static class InstallPackageCmd {
+    @ParametersDelegate
+    public FilterOptions filterOpts = new FilterOptions();
+    @ParametersDelegate
+    public HelpOpt helpOpts = new HelpOpt();
+    @ParametersDelegate
+    public TerminalOptions termOpts = new TerminalOptions();
+    @Parameter(names = "-f", description = "Answer all prompts with 'yes'")
+    public boolean force;
+  }
+
+  @Parameters(commandDescription = "Show locally installed packages")
+  private static class LocalPackagesCmd {
+    @Parameter(description = "pkg names")
+    public List<String> pkgNameFilters = new ArrayList<String>();
+    @ParametersDelegate
+    public HelpOpt helpOpts = new HelpOpt();
+    @ParametersDelegate
+    public TerminalOptions termOpts = new TerminalOptions();
+  }
+
+  @Parameters(commandDescription = "Show running instances")
+  private static class InstancesCmd {
+    @Parameter(description = "instance types")
+    public List<String> instanceTypes = new ArrayList<String>();
+  }
+
+  private GeneralOptions generalOptions;
+  private PackagesCmd pkgCmd;
+  private InstallPackageCmd installCmd;
+  private LocalPackagesCmd localCmd;
+  private InstancesCmd instancesCmd;
+  private JCommander cmd;
+
+  @BeforeTest
+  public void beforeTest() {
+    java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("MessageBundle", new Locale("en", "US"));
+    generalOptions = new GeneralOptions();
+    pkgCmd = new PackagesCmd();
+    installCmd = new InstallPackageCmd();
+    localCmd = new LocalPackagesCmd();
+    instancesCmd = new InstancesCmd();
+    cmd = new JCommander(generalOptions, bundle);
+    cmd.setProgramName("packageManager");
+    cmd.addCommand("pkg", pkgCmd);
+    cmd.addCommand("install", installCmd, "I");
+    cmd.addCommand("local", localCmd);
+    cmd.addCommand("instances", instancesCmd);
+  }
+
+  @Test
+  public void packageCommandUsage() {
+    StringBuilder cmdUsage = new StringBuilder();
+    cmd.usage("pkg", cmdUsage);
+    Assert.assertEquals(cmdUsage.toString(),
+            "List available packages" + NL +
+                    "Usage: pkg [filter options] [help options] main parameters" + NL +
+                    "" + NL +
+                    "Options for filtering things" + NL +
+                    "  Filter Options:" + NL +
+                    "    -i, --id     Filter by package id" + NL +
+                    "                 Default: 0" + NL +
+                    "        --name   Filter by package name" + NL +
+                    "    -t, --type   Filter by package type" + NL +
+                    "                 Default: [type1]" + NL +
+                    "    -V           Make output more verbose" + NL +
+                    "                 Default: false" + NL +
+                    "    -v           Filter by version" + NL +
+                    "Help related options" + NL +
+                    "  Help Options:" + NL +
+                    "    -h, --h   Show help" + NL +
+                    "              Default: false" + NL);
+  }
+
+  @Test
+  public void installCommandUsage() {
+    StringBuilder cmdUsage = new StringBuilder();
+    cmd.usage("install", cmdUsage);
+    Assert.assertEquals(cmdUsage.toString(),
+            "Install package" + NL +
+                    "Usage: install(I) [options] [filter options] [help options] [terminal options]" + NL +
+                    "  Options:" + NL +
+                    "    -f   Answer all prompts with 'yes'" + NL +
+                    "         Default: false" + NL +
+                    "" + NL +
+                    "Options for filtering things" + NL +
+                    "  Filter Options:" + NL +
+                    "    -i, --id     Filter by package id" + NL +
+                    "                 Default: 0" + NL +
+                    "        --name   Filter by package name" + NL +
+                    "    -t, --type   Filter by package type" + NL +
+                    "                 Default: [type1]" + NL +
+                    "    -V           Make output more verbose" + NL +
+                    "                 Default: false" + NL +
+                    "    -v           Filter by version" + NL +
+                    "Help related options" + NL +
+                    "  Help Options:" + NL +
+                    "    -h, --h   Show help" + NL +
+                    "              Default: false" + NL +
+                    "Terminal related options" + NL +
+                    "  Terminal Options:" + NL +
+                    "        --no-decorations    Disable terminal colouring" + NL +
+                    "                            Default: false" + NL +
+                    "        --no-progress-bar   Disable progress bars" + NL +
+                    "                            Default: false" + NL +
+                    "        --term-coloring     " + NL +
+                    "                            Default: ANSI" + NL);
+  }
+
+  @Test
+  public void mainUsage() {
+    StringBuilder cmdUsage = new StringBuilder();
+    cmd.usage(cmdUsage);
+    Assert.assertEquals(cmdUsage.toString(),
+            "Usage: packageManager [options] [help options] [command] [command options]" + NL +
+                    "  Options:" + NL +
+                    "        --pkg-root   Package installation root" + NL +
+                    "                     Default: /tmp/pkgs" + NL +
+                    "  Commands:" + NL +
+                    "    pkg      List available packages" + NL +
+                    "      Usage: pkg [filter options] [help options] main parameters" + NL +
+                    "    install(I)      Install package" + NL +
+                    "      Usage: install(I) [options] [filter options] [help options] [terminal options]" + NL +
+                    "        Options:" + NL +
+                    "          -f   Answer all prompts with 'yes'" + NL +
+                    "               Default: false" + NL +
+                    "    local      Show locally installed packages" + NL +
+                    "      Usage: local [help options] [terminal options] pkg names" + NL +
+                    "    instances      Show running instances" + NL +
+                    "      Usage: instances instance types" + NL +
+                    "" + NL +
+                    "Options for filtering things" + NL +
+                    "  Filter Options:" + NL +
+                    "    -i, --id     Filter by package id" + NL +
+                    "                 Default: 0" + NL +
+                    "        --name   Filter by package name" + NL +
+                    "    -t, --type   Filter by package type" + NL +
+                    "                 Default: [type1]" + NL +
+                    "    -V           Make output more verbose" + NL +
+                    "                 Default: false" + NL +
+                    "    -v           Filter by version" + NL +
+                    "Help related options" + NL +
+                    "  Help Options:" + NL +
+                    "    -h, --h   Show help" + NL +
+                    "              Default: false" + NL +
+                    "Terminal related options" + NL +
+                    "  Terminal Options:" + NL +
+                    "        --no-decorations    Disable terminal colouring" + NL +
+                    "                            Default: false" + NL +
+                    "        --no-progress-bar   Disable progress bars" + NL +
+                    "                            Default: false" + NL +
+                    "        --term-coloring     " + NL +
+                    "                            Default: ANSI" + NL);
+
+  }
+}

--- a/src/test/java/com/beust/jcommander/OptionGroupPackageManagerScenarioTest.java
+++ b/src/test/java/com/beust/jcommander/OptionGroupPackageManagerScenarioTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.beust.jcommander;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author rodion
+ */
+public class OptionGroupPackageManagerScenarioTest {
+  private static final String NL = "\n";
+
+  @Parameters(optionGroupName = "Filter Options", optionGroupDescription = "Options for filtering things")
+  private static class FilterOptions {
+    @Parameter(names = "-v", description = "Filter by version")
+    public String version;
+    @Parameter(names = {"-i", "--id"}, description = "Filter by package id")
+    public int pkgId;
+  }
+
+  private static class HelpOpt {
+    @Parameter(names = {"-h", "--h"}, description = "Show help")
+    public boolean showHelp;
+  }
+
+  @Parameters(commandDescription = "List available packages")
+  private static class PackagesCmd {
+    @Parameter(description = "main parameters")
+    public List<String> mainParams = new ArrayList<String>();
+    @ParametersDelegate
+    public FilterOptions filterOpts = new FilterOptions();
+    @ParametersDelegate
+    public HelpOpt helpOpts = new HelpOpt();
+  }
+
+  @Parameters(commandDescription = "Install package")
+  private static class InstallPackageCmd {
+    @ParametersDelegate
+    public FilterOptions filterOpts = new FilterOptions();
+    @ParametersDelegate
+    public HelpOpt helpOpts = new HelpOpt();
+    @Parameter(names = "-f", description = "Answer all prompts with 'yes'")
+    public boolean force;
+  }
+
+  private PackagesCmd pkgCmd;
+  private InstallPackageCmd installCmd;
+  private JCommander cmd;
+
+  @BeforeTest
+  public void beforeTest() {
+    pkgCmd = new PackagesCmd();
+    installCmd = new InstallPackageCmd();
+    cmd = new JCommander();
+    cmd.setProgramName("packageManager");
+    cmd.addCommand("pkg", pkgCmd);
+    cmd.addCommand("install", installCmd);
+  }
+
+  @Test
+  public void packageCommandUsage() {
+    StringBuilder cmdUsage = new StringBuilder();
+    cmd.usage("pkg", cmdUsage);
+    Assert.assertEquals( cmdUsage.toString(),
+            "List available packages" + NL +
+                    "Usage: pkg [options] [filter options] main parameters" + NL +
+                    "  Options:" + NL +
+                    "    -h, --h   Show help" + NL +
+                    "              Default: false" + NL +
+                    "" + NL +
+                    "Options for filtering things" + NL +
+                    "  Filter Options:" + NL +
+                    "    -i, --id   Filter by package id" + NL +
+                    "               Default: 0" + NL +
+                    "    -v         Filter by version" + NL);
+  }
+
+  @Test
+  public void installCommandUsage() {
+    StringBuilder cmdUsage = new StringBuilder();
+    cmd.usage("install", cmdUsage);
+    Assert.assertEquals(cmdUsage.toString(),
+            "Install package" + NL +
+                    "Usage: install [options] [filter options]" + NL +
+                    "  Options:" + NL +
+                    "    -h, --h   Show help" + NL +
+                    "              Default: false" + NL +
+                    "    -f        Answer all prompts with 'yes'" + NL +
+                    "              Default: false" + NL +
+                    "" + NL +
+                    "Options for filtering things" + NL +
+                    "  Filter Options:" + NL +
+                    "    -i, --id   Filter by package id" + NL +
+                    "               Default: 0" + NL +
+                    "    -v         Filter by version" + NL);
+  }
+
+  @Test
+  public void mainUsage() {
+    StringBuilder cmdUsage = new StringBuilder();
+    cmd.usage(cmdUsage);
+    Assert.assertEquals(cmdUsage.toString(),
+            "Usage: packageManager [command] [command options]" + NL +
+                    "  Commands:" + NL +
+                    "    pkg      List available packages" + NL +
+                    "      Usage: pkg [options] [filter options] main parameters" + NL +
+                    "        Options:" + NL +
+                    "          -h, --h   Show help" + NL +
+                    "                    Default: false" + NL +
+                    "    install      Install package" + NL +
+                    "      Usage: install [options] [filter options]" + NL +
+                    "        Options:" + NL +
+                    "          -h, --h   Show help" + NL +
+                    "                    Default: false" + NL +
+                    "          -f        Answer all prompts with 'yes'" + NL +
+                    "                    Default: false" + NL +
+                    "" + NL +
+                    "Options for filtering things" + NL +
+                    "  Filter Options:" + NL +
+                    "    -i, --id   Filter by package id" + NL +
+                    "               Default: 0" + NL +
+                    "    -v         Filter by version" + NL);
+  }
+}

--- a/src/test/java/com/beust/jcommander/ParametersDelegateTest.java
+++ b/src/test/java/com/beust/jcommander/ParametersDelegateTest.java
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.beust.jcommander;
 
 import org.testng.Assert;

--- a/src/test/java/com/beust/jcommander/UsageTest.java
+++ b/src/test/java/com/beust/jcommander/UsageTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.beust.jcommander;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author rodion
+ */
+public class UsageTest {
+  private static final String NL = "\n";
+  private StringBuilder sb = null;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    sb = new StringBuilder();
+  }
+
+  @Test
+  public void emptyUsage() {
+    new JCommander().usage(sb);
+    Assert.assertEquals(sb.toString(), "Usage: <main class>" + NL);
+  }
+
+  @Test
+  public void usageWithBasicArguments() {
+    class SimpleUsage {
+      @Parameter(names = "-h", description = "debug option")
+      public boolean debug;
+      @Parameter(names = "-v")
+      public String version;
+    }
+    JCommander cmd = new JCommander(new SimpleUsage());
+    cmd.setProgramName("prog");
+    cmd.usage(sb);
+    Assert.assertEquals(sb.toString(),
+            "Usage: prog [options]" + NL +
+                    "  Options:" + NL +
+                    "    -h   debug option" + NL +
+                    "         Default: false" + NL +
+                    "    -v   " + NL);
+  }
+
+  @Test
+  public void usageOnlyWithMainArguments() {
+    class SimpleUsage {
+      @Parameter(description = "main args")
+      public List<String> mainArgs;
+    }
+    JCommander cmd = new JCommander(new SimpleUsage());
+    cmd.setProgramName("prog");
+    cmd.usage(sb);
+    Assert.assertEquals(sb.toString(),
+            "Usage: prog main args" + NL);
+  }
+
+  @Test
+  public void usageBasicArgumentsAndMainParams() {
+    class SimpleUsage {
+      @Parameter(description = "main args")
+      public List<String> mainArgs;
+      @Parameter(names = "-h", description = "debug option")
+      public boolean debug;
+    }
+    JCommander cmd = new JCommander(new SimpleUsage());
+    cmd.setProgramName("prog");
+    cmd.usage(sb);
+    Assert.assertEquals(sb.toString(),
+            "Usage: prog [options] main args" + NL +
+                    "  Options:" + NL +
+                    "    -h   debug option" + NL +
+                    "         Default: false" + NL);
+  }
+
+  @Test
+  public void usageWithCommandsOnly() {
+    @Parameters(commandDescription = "cmd1 description")
+    class Cmd1 {
+      @Parameter(names = {"-d", "--debug"}, description = "enable debug")
+      public boolean debug;
+    }
+    class Cmd2 {
+      @Parameter(names = {"-h", "--help"}, description = "show help")
+      public boolean debug;
+    }
+    JCommander cmd = new JCommander();
+    cmd.addCommand("cmd1", new Cmd1());
+    cmd.addCommand("cmd2", new Cmd2());
+    cmd.usage(sb);
+    Assert.assertEquals(sb.toString(), "Usage: <main class> [command] [command options]" + NL +
+            "  Commands:" + NL +
+            "    cmd1      cmd1 description" + NL +
+            "      Usage: cmd1 [options]" + NL +
+            "        Options:" + NL +
+            "          -d, --debug   enable debug" + NL +
+            "                        Default: false" + NL +
+            "    cmd2" + NL +
+            "      Usage: cmd2 [options]" + NL +
+            "        Options:" + NL +
+            "          -h, --help   show help" + NL +
+            "                       Default: false" + NL);
+  }
+
+  @Test
+  public void usageWithPrettyMuchEverything() {
+    @Parameters(commandDescription = "cmd1 description")
+    class Cmd1 {
+      @Parameter(description = "cmd1 main params")
+      public List<String> mainParams;
+      @Parameter(names = {"-d", "--debug"}, description = "enable debug")
+      public boolean debug;
+    }
+    @Parameters(commandDescription = "cmd2 description")
+    class Cmd2 {
+      @Parameter
+      public List<String> mainParams;
+      @Parameter(names = {"-h", "--help"}, description = "show help")
+      public boolean debug;
+    }
+    class Main {
+      @Parameter(description = "the main params")
+      public List<String> mainParams;
+      @Parameter(names = "+X", description = "display extra options")
+      public boolean extraOptions = true;
+    }
+    JCommander cmd = new JCommander(new Main());
+    cmd.setProgramName("theProg");
+    cmd.addCommand("cmd1", new Cmd1(), "a", "bc", "def");
+    cmd.addCommand("cmd2", new Cmd2(), "ghk");
+    cmd.usage(sb);
+    Assert.assertEquals(sb.toString(),
+            "Usage: theProg [options] [command] [command options] the main params" + NL +
+                    "  Options:" + NL +
+                    "    +X   display extra options" + NL +
+                    "         Default: true" + NL +
+                    "  Commands:" + NL +
+                    "    cmd1(a,bc,def)      cmd1 description" + NL +
+                    "      Usage: cmd1(a,bc,def) [options] cmd1 main params" + NL +
+                    "        Options:" + NL +
+                    "          -d, --debug   enable debug" + NL +
+                    "                        Default: false" + NL +
+                    "    cmd2(ghk)      cmd2 description" + NL +
+                    "      Usage: cmd2(ghk) [options]" + NL +
+                    "        Options:" + NL +
+                    "          -h, --help   show help" + NL +
+                    "                       Default: false" + NL);
+  }
+
+  @Test
+  public void commandI18N() {
+    @Parameters(commandDescriptionKey = "commands.testCmd")
+    class TestCmd {
+      @Parameter(names = "-d", descriptionKey = "commands.testCmd.debug")
+      public boolean debug;
+    }
+    java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("MessageBundle", new Locale("en", "US"));
+    JCommander cmd = new JCommander();
+    cmd.setDescriptionsBundle(bundle);
+    cmd.addCommand("test", new TestCmd());
+    cmd.usage(sb);
+    Assert.assertEquals(sb.toString(),
+            "Usage: <main class> [command] [command options]" + NL +
+                    "  Commands:" + NL +
+                    "    test      Test command" + NL +
+                    "      Usage: test [options]" + NL +
+                    "        Options:" + NL +
+                    "          -d   Enable debugging" + NL +
+                    "               Default: false" + NL);
+  }
+}

--- a/src/test/resources/MessageBundle_en_US.properties
+++ b/src/test/resources/MessageBundle_en_US.properties
@@ -16,4 +16,7 @@
 # limitations under the License.
 #
 
+commands.testCmd = Test command
+commands.testCmd.debug = Enable debugging
 host = Host
+optionGroups.help = Help related options

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -11,6 +11,9 @@
       <class name="com.beust.jcommander.DefaultValueTest" />
       <class name="com.beust.jcommander.JCommanderTest" />
       <class name="com.beust.jcommander.ParametersDelegateTest" />
+      <class name="com.beust.jcommander.UsageTest" />
+      <class name="com.beust.jcommander.OptionGroupPackageManagerScenarioTest" />
+      <class name="com.beust.jcommander.OptionGroupPackageManagerScenario2Test" />
     </classes>
   </test>
 


### PR DESCRIPTION
I'd be interested to know what you think of this feature: option groups. Of course, the idea comes from an actual demand for it from the piece of software I am working on.

The idea is to minimise and simplify usage output in cases when several commands share a common set of parameters, by extracting such set into its own usage section (=option group), and adding a pointer that option group from each command that uses it. Option group usage is then printed at the end of usage output.

Just to provide a simple example, say you have a package management system like `yum` or `apt-get` with two commands: `list` and `install`, to list and install remote packages to local machine. Both commands share a set of parameters for filtering packages by several criteria, such as: name, description, version, etc. So we end up with usage like:

```
Command: list
Usage: pkgmng list [options]
Options:
  -n  NAME filter by name
  -v  VER  filter by version
  -d  DESC filter by description
  -x            some list specific option

Command: install
Usage: pkgmng install [options]
Options:
  -n  NAME filter by name
  -v  VER  filter by version
  -d  DESC filter by description
  -y            some install specific option
```

With option groups feature this can be _refactored_ into simply:

```
Usage: pkgmng list [options] [filter options]
Options:
  -x            some list specific option

Command: install
Usage: pkgmng install [options] [filter options]
Options:
  -y            some install specific option

Filter Options:
  -n  NAME filter by name
  -v  VER  filter by version
  -d  DESC filter by description
```

To create such output the user simply declares which parameter set he/she wishes to be printed separately by declaring an option group name:

```
@Parameters(optionGroupName = "Filter Options")
public class FilterOptions{ 
  //-n, -v, -d options declared here
}

public class InstallCommand{
  @ParametersDelegate
  public FilterOptions filterOptions = new FilterOptions();
}

//...
```

and then uses inheritance or parameter delegates to reference it as usual. Option groups also take a description parameter similar to commands.

I've added couple of scenario tests which should give you a good idea of the usage. However, the tests are fairly brittle and will probably break every time output formatting is modified.

Note: commit also includes couple of fixes (see CHANGELOG). If you don't accept this request I'll make a new patch for them.

Looking forward to your feedback.

Regards
