### PR TITLE
Default description for Enum Args

### DIFF
--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -21,6 +21,7 @@ package com.beust.jcommander;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -121,7 +122,13 @@ public class ParameterDescription {
     m_jCommander = jCommander;
 
     if (m_parameterAnnotation != null) {
-      initDescription(m_parameterAnnotation.description(), m_parameterAnnotation.descriptionKey(),
+      String description;
+      if (Enum.class.isAssignableFrom(field.getType()) &&  m_parameterAnnotation.description().isEmpty()) {
+        description = "Options: " + EnumSet.allOf((Class<? extends Enum>) field.getType());
+      }else {
+        description = m_parameterAnnotation.description();
+      }
+      initDescription(description, m_parameterAnnotation.descriptionKey(),
           m_parameterAnnotation.names());
     } else if (m_dynamicParameterAnnotation != null) {
       initDescription(m_dynamicParameterAnnotation.description(),

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -64,6 +64,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -556,9 +557,12 @@ public class JCommanderTest {
   public void enumArgs() {
     ArgsEnum args = new ArgsEnum();
     String[] argv = { "-choice", "ONE"};
-    new JCommander(args, argv);
+    JCommander jc = new JCommander(args, argv);
 
     Assert.assertEquals(args.choice, ArgsEnum.ChoiceType.ONE);
+    
+    Assert.assertEquals(jc.getParameters().get(0).getDescription(), "Options: " + EnumSet.allOf((Class<? extends Enum>) ArgsEnum.ChoiceType.class));
+    
   }
 
   @Test(expectedExceptions = ParameterException.class)

--- a/src/test/java/com/beust/jcommander/args/ArgsEnum.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsEnum.java
@@ -18,7 +18,12 @@
 
 package com.beust.jcommander.args;
 
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+
+import org.testng.Assert;
+
+import java.util.EnumSet;
 
 /**
  * Test enums.
@@ -28,8 +33,16 @@ import com.beust.jcommander.Parameter;
 public class ArgsEnum {
 
   public enum ChoiceType { ONE, TWO, THREE };
-  @Parameter(names = "-choice", description = "Choice parameter")
+  @Parameter(names = "-choice")
   public ChoiceType choice = ChoiceType.ONE;
+  
+  public static void main(String[] args1) {
+    ArgsEnum args = new ArgsEnum();
+    String[] argv = { "-choice", "ONE"};
+    JCommander jc = new JCommander(args, argv);
+    jc.usage();
+    Assert.assertEquals(jc.getParameters().get(0).getDescription(), "Options: " + EnumSet.allOf((Class<? extends Enum>) ArgsEnum.ChoiceType.class));
+  }
 
 }
 


### PR DESCRIPTION
Hi Cedric,

I extended my previous patch for enum args to add a default description (list of options) in case the description field is not set (i.e. isEmpty()) in the parameter annotation.

Let me know what do you think,
Thanks,
adrian
