### PR TITLE
Fixed HTML entity escaping in docs.

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -738,14 +738,14 @@ You can download JCommander from the following locations:
 
 <ul>
   <li><a href="http://github.com/cbeust/jcommander">Source on github</a></li>
- <li>If you are using Maven, add the following dependency to your <tt>pom.xml</tt>:
+  <li>If you are using Maven, add the following dependency to your <tt>pom.xml</tt>:
 
   <pre class="brush: xml">
 
 <dependency>
   &lt;groupId&gt;com.beust&lt;/groupId&gt;
   &lt;artifactId&gt;jcommander&lt;/artifactId&gt;
-  <version>1.20</version>
+  &lt;version&gt;1.20&lt;/version&gt;
 </dependency>
   </pre>
 


### PR DESCRIPTION
Hi Cedric,

I fixed the HTML entity escaping of the Maven dependency snippet in the HTML docs.

Best Regards,
Jochen
