### PR TITLE
Allow parameters to be abbreviated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 .project
 .settings
 test-output
+.idea
+*.iml

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -27,6 +27,7 @@ import com.beust.jcommander.internal.DefaultConverterFactory;
 import com.beust.jcommander.internal.JDK6Console;
 import com.beust.jcommander.internal.Lists;
 import com.beust.jcommander.internal.Maps;
+import com.beust.jcommander.internal.AbbreviationMap;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -52,7 +53,6 @@ import java.util.Map;
 import java.util.ResourceBundle;
 
 
-
 /**
  * The main class for JCommander. It's responsible for parsing the object that contains
  * all the annotated fields, parse the command line and assign the fields with the correct
@@ -66,1108 +66,1133 @@ import java.util.ResourceBundle;
  * @author cbeust
  */
 public class JCommander {
-  public static final String DEBUG_PROPERTY = "jcommander.debug";
+   public static final String DEBUG_PROPERTY = "jcommander.debug";
 
-  /**
-   * A map to look up parameter description per option name.
-   */
-  private Map<String, ParameterDescription> m_descriptions;
+   /**
+    * A map to look up parameter description per option name.
+    */
+   private Map<String, ParameterDescription> m_descriptions;
 
-  /**
-   * The objects that contain fields annotated with @Parameter.
-   */
-  private List<Object> m_objects = Lists.newArrayList();
+   /**
+    * Maps abbreviated parameter names to their ful name
+    */
+   private AbbreviationMap<ParameterDescription> m_abbrevMap;
 
-  /**
-   * This field will contain whatever command line parameter is not an option.
-   * It is expected to be a List<String>.
-   */
-  private Field m_mainParameterField = null;
+   /**
+    * The objects that contain fields annotated with @Parameter.
+    */
+   private List<Object> m_objects = Lists.newArrayList();
 
-  /**
-   * The object on which we found the main parameter field.
-   */
-  private Object m_mainParameterObject;
+   /**
+    * This field will contain whatever command line parameter is not an option.
+    * It is expected to be a List<String>.
+    */
+   private Field m_mainParameterField = null;
 
-  /**
-   * The annotation found on the main parameter field.
-   */
-  private Parameter m_mainParameterAnnotation;
+   /**
+    * The object on which we found the main parameter field.
+    */
+   private Object m_mainParameterObject;
 
-  private ParameterDescription m_mainParameterDescription;
+   /**
+    * The annotation found on the main parameter field.
+    */
+   private Parameter m_mainParameterAnnotation;
 
-  /**
-   * A set of all the fields that are required. During the reflection phase,
-   * this field receives all the fields that are annotated with required=true
-   * and during the parsing phase, all the fields that are assigned a value
-   * are removed from it. At the end of the parsing phase, if it's not empty,
-   * then some required fields did not receive a value and an exception is
-   * thrown.
-   */
-  private Map<Field, ParameterDescription> m_requiredFields = Maps.newHashMap();
+   private ParameterDescription m_mainParameterDescription;
 
-  /**
-   * A map of all the annotated fields.
-   */
-  private Map<Field, ParameterDescription> m_fields = Maps.newHashMap();
+   /**
+    * A set of all the fields that are required. During the reflection phase,
+    * this field receives all the fields that are annotated with required=true
+    * and during the parsing phase, all the fields that are assigned a value
+    * are removed from it. At the end of the parsing phase, if it's not empty,
+    * then some required fields did not receive a value and an exception is
+    * thrown.
+    */
+   private Map<Field, ParameterDescription> m_requiredFields = Maps.newHashMap();
 
-  private ResourceBundle m_bundle;
+   /**
+    * A map of all the annotated fields.
+    */
+   private Map<Field, ParameterDescription> m_fields = Maps.newHashMap();
 
-  /**
-   * A default provider returns default values for the parameters.
-   */
-  private IDefaultProvider m_defaultProvider;
+   private ResourceBundle m_bundle;
 
-  /**
-   * List of commands and their instance.
-   */
-  private Map<ProgramName, JCommander> m_commands = Maps.newLinkedHashMap();
-  /**
-   * Alias database for reverse lookup
-   */
-  private Map<String, ProgramName> aliasMap = Maps.newLinkedHashMap();
+   /**
+    * A default provider returns default values for the parameters.
+    */
+   private IDefaultProvider m_defaultProvider;
 
-  /**
-   * The name of the command after the parsing has run.
-   */
-  private String m_parsedCommand;
+   /**
+    * List of commands and their instance.
+    */
+   private Map<ProgramName, JCommander> m_commands = Maps.newLinkedHashMap();
+   /**
+    * Alias database for reverse lookup
+    */
+   private Map<String, ProgramName> aliasMap = Maps.newLinkedHashMap();
 
-  /**
-   * The name of command or alias as it was passed to the
-   * command line
-   */
-  private String m_parsedAlias;
+   /**
+    * The name of the command after the parsing has run.
+    */
+   private String m_parsedCommand;
 
-  private ProgramName m_programName;
+   /**
+    * The name of command or alias as it was passed to the
+    * command line
+    */
+   private String m_parsedAlias;
 
-  private Comparator<? super ParameterDescription> m_parameterDescriptionComparator
-      = new Comparator<ParameterDescription>() {
-        public int compare(ParameterDescription p0, ParameterDescription p1) {
-          return p0.getLongestName().compareTo(p1.getLongestName());
-        }
-      };
+   private ProgramName m_programName;
 
-  private int m_columnSize = 79;
-  
-  private static Console m_console;
-
-  /**
-   * The factories used to look up string converters.
-   */
-  private static LinkedList<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newLinkedList();
-
-  static {
-    CONVERTER_FACTORIES.addFirst(new DefaultConverterFactory());
-  };
-
-  /**
-   * Creates a new un-configured JCommander object.
-   */
-  public JCommander() {
-  }
-
-  /**
-   * @param object The arg object expected to contain {@link Parameter} annotations.
-   */
-  public JCommander(Object object) {
-    addObject(object);
-    createDescriptions();
-  }
-
-  /**
-   * @param object The arg object expected to contain {@link Parameter} annotations.
-   * @param bundle The bundle to use for the descriptions. Can be null.
-   */
-  public JCommander(Object object, ResourceBundle bundle) {
-    addObject(object);
-    setDescriptionsBundle(bundle);
-  }
-
-  /**
-   * @param object The arg object expected to contain {@link Parameter} annotations.
-   * @param bundle The bundle to use for the descriptions. Can be null.
-   * @param args The arguments to parse (optional).
-   */
-  public JCommander(Object object, ResourceBundle bundle, String... args) {
-    addObject(object);
-    setDescriptionsBundle(bundle);
-    parse(args);
-  }
-
-  /**
-   * @param object The arg object expected to contain {@link Parameter} annotations.
-   * @param args The arguments to parse (optional).
-   */
-  public JCommander(Object object, String... args) {
-    addObject(object);
-    parse(args);
-  }
-  
-  public static Console getConsole() {
-    if (m_console == null) {
-      try {
-        Method consoleMethod = System.class.getDeclaredMethod("console", new Class<?>[0]);
-        Object console = consoleMethod.invoke(null, new Object[0]);
-        m_console = new JDK6Console(console);
-      } catch (Throwable t) {
-        m_console = new DefaultConsole();
+   private Comparator<? super ParameterDescription> m_parameterDescriptionComparator
+         = new Comparator<ParameterDescription>() {
+      public int compare(ParameterDescription p0, ParameterDescription p1) {
+         return p0.getLongestName().compareTo(p1.getLongestName());
       }
-    }
-    return m_console;
-  }
+   };
 
-  /**
-   * Adds the provided arg object to the set of objects that this commander
-   * will parse arguments into.
-   *
-   * @param object The arg object expected to contain {@link Parameter}
-   * annotations. If <code>object</code> is an array or is {@link Iterable},
-   * the child objects will be added instead.
-   */
-  // declared final since this is invoked from constructors
-  public final void addObject(Object object) {
-    if (object instanceof Iterable) {
-      // Iterable
-      for (Object o : (Iterable<?>) object) {
-        m_objects.add(o);
+   private int m_columnSize = 79;
+
+   private static Console m_console;
+
+   /**
+    * The factories used to look up string converters.
+    */
+   private static LinkedList<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newLinkedList();
+
+   static {
+      CONVERTER_FACTORIES.addFirst(new DefaultConverterFactory());
+   }
+
+   ;
+
+   /**
+    * Creates a new un-configured JCommander object.
+    */
+   public JCommander() {
+   }
+
+   /**
+    * @param object The arg object expected to contain {@link Parameter} annotations.
+    */
+   public JCommander(Object object) {
+      addObject(object);
+      createDescriptions();
+   }
+
+   /**
+    * @param object The arg object expected to contain {@link Parameter} annotations.
+    * @param bundle The bundle to use for the descriptions. Can be null.
+    */
+   public JCommander(Object object, ResourceBundle bundle) {
+      addObject(object);
+      setDescriptionsBundle(bundle);
+   }
+
+   /**
+    * @param object The arg object expected to contain {@link Parameter} annotations.
+    * @param bundle The bundle to use for the descriptions. Can be null.
+    * @param args   The arguments to parse (optional).
+    */
+   public JCommander(Object object, ResourceBundle bundle, String... args) {
+      addObject(object);
+      setDescriptionsBundle(bundle);
+      parse(args);
+   }
+
+   /**
+    * @param object The arg object expected to contain {@link Parameter} annotations.
+    * @param args   The arguments to parse (optional).
+    */
+   public JCommander(Object object, String... args) {
+      addObject(object);
+      parse(args);
+   }
+
+   public static Console getConsole() {
+      if (m_console == null) {
+         try {
+            Method consoleMethod = System.class.getDeclaredMethod("console", new Class<?>[0]);
+            Object console = consoleMethod.invoke(null, new Object[0]);
+            m_console = new JDK6Console(console);
+         } catch (Throwable t) {
+            m_console = new DefaultConsole();
+         }
       }
-    } else if (object.getClass().isArray()) {
-      // Array
-      for (Object o : (Object[]) object) {
-        m_objects.add(o);
-      }
-    } else {
-      // Single object
-      m_objects.add(object);
-    }
-  }
+      return m_console;
+   }
 
-  /**
-   * Sets the {@link ResourceBundle} to use for looking up descriptions.
-   * Set this to <code>null</code> to use description text directly.
-   */
-  // declared final since this is invoked from constructors
-  public final void setDescriptionsBundle(ResourceBundle bundle) {
-    m_bundle = bundle;
-  }
-
-  /**
-   * Parse and validate the command line parameters.
-   */
-  public void parse(String... args) {
-    parse(true /* validate */, args);
-  }
-
-  /**
-   * Parse the command line parameters without validating them.
-   */
-  public void parseWithoutValidation(String... args) {
-    parse(false /* no validation */, args);
-  }
-
-  private void parse(boolean validate, String... args) {
-    StringBuilder sb = new StringBuilder("Parsing \"");
-    sb.append(join(args).append("\"\n  with:").append(join(m_objects.toArray())));
-    p(sb.toString());
-
-    if (m_descriptions == null) createDescriptions();
-    initializeDefaultValues();
-    parseValues(expandArgs(args));
-    if (validate) validateOptions();
-  }
-
-  private StringBuilder join(Object[] args) {
-    StringBuilder result = new StringBuilder();
-    for (int i = 0; i < args.length; i++) {
-      if (i > 0) result.append(" ");
-      result.append(args[i]);
-    }
-    return result;
-  }
-
-  private void initializeDefaultValues() {
-    if (m_defaultProvider != null) {
-      for (ParameterDescription pd : m_descriptions.values()) {
-        initializeDefaultValue(pd);
-      }
-
-      for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-        entry.getValue().initializeDefaultValues();
-      }
-    }
-  }
-
-  /**
-   * Make sure that all the required parameters have received a value.
-   */
-  private void validateOptions() {
-    if (! m_requiredFields.isEmpty()) {
-      StringBuilder missingFields = new StringBuilder();
-      for (ParameterDescription pd : m_requiredFields.values()) {
-        missingFields.append(pd.getNames()).append(" ");
-      }
-      throw new ParameterException("The following "
-            + pluralize(m_requiredFields.size(), "option is required: ", "options are required: ")
-            + missingFields);
-    }
-
-    if (m_mainParameterDescription != null) {
-      if (m_mainParameterDescription.getParameter().required() &&
-          !m_mainParameterDescription.isAssigned()) {
-        throw new ParameterException("Main parameters are required (\""
-            + m_mainParameterDescription.getDescription() + "\")");
-      }
-    }
-  }
-
-  private static String pluralize(int quantity, String singular, String plural) {
-    return quantity == 1 ? singular : plural;
-  }
-
-  /**
-   * Expand the command line parameters to take @ parameters into account.
-   * When @ is encountered, the content of the file that follows is inserted
-   * in the command line.
-   *
-   * @param originalArgv the original command line parameters
-   * @return the new and enriched command line parameters
-   */
-  private String[] expandArgs(String[] originalArgv) {
-    List<String> vResult1 = Lists.newArrayList();
-
-    //
-    // Expand @
-    //
-    for (String arg : originalArgv) {
-
-      if (arg.startsWith("@")) {
-        String fileName = arg.substring(1);
-        vResult1.addAll(readFile(fileName));
-      }
-      else {
-        List<String> expanded = expandDynamicArg(arg);
-        vResult1.addAll(expanded);
-      }
-    }
-
-    // Expand separators
-    //
-    List<String> vResult2 = Lists.newArrayList();
-    for (int i = 0; i < vResult1.size(); i++) {
-      String arg = vResult1.get(i);
-      String[] v1 = vResult1.toArray(new String[0]);
-      if (isOption(v1, arg)) {
-        String sep = getSeparatorFor(v1, arg);
-        if (! " ".equals(sep)) {
-          String[] sp = arg.split("[" + sep + "]", 2);
-          for (String ssp : sp) {
-            vResult2.add(ssp);
-          }
-        } else {
-          vResult2.add(arg);
-        }
+   /**
+    * Adds the provided arg object to the set of objects that this commander
+    * will parse arguments into.
+    *
+    * @param object The arg object expected to contain {@link Parameter}
+    *               annotations. If <code>object</code> is an array or is {@link Iterable},
+    *               the child objects will be added instead.
+    */
+   // declared final since this is invoked from constructors
+   public final void addObject(Object object) {
+      if (object instanceof Iterable) {
+         // Iterable
+         for (Object o : (Iterable<?>) object) {
+            m_objects.add(o);
+         }
+      } else if (object.getClass().isArray()) {
+         // Array
+         for (Object o : (Object[]) object) {
+            m_objects.add(o);
+         }
       } else {
-        vResult2.add(arg);
+         // Single object
+         m_objects.add(object);
       }
-    }
+   }
 
-    return vResult2.toArray(new String[vResult2.size()]);
-  }
+   /**
+    * Sets the {@link ResourceBundle} to use for looking up descriptions.
+    * Set this to <code>null</code> to use description text directly.
+    */
+   // declared final since this is invoked from constructors
+   public final void setDescriptionsBundle(ResourceBundle bundle) {
+      m_bundle = bundle;
+   }
 
-  private List<String> expandDynamicArg(String arg) {
-    for (ParameterDescription pd : m_descriptions.values()) {
-      if (pd.isDynamicParameter()) {
-        for (String name : pd.getParameter().names()) {
-          if (arg.startsWith(name) && !arg.equals(name)) {
-            return Arrays.asList(name, arg.substring(name.length()));
-          }
-        }
-      }
-    }
+   /**
+    * Parse and validate the command line parameters.
+    */
+   public void parse(String... args) {
+      parse(true /* validate */, false, args);
+   }
 
-    return Arrays.asList(arg);
-  }
+   /**
+    * Parse the command line parameters without validating them.
+    */
+   public void parseWithoutValidation(String... args) {
+      parse(false /* no validation */, false, args);
+   }
 
-  private boolean isOption(String[] args, String arg) {
-    String prefixes = getOptionPrefixes(args, arg);
-    return arg.length() > 0 && prefixes.indexOf(arg.charAt(0)) >= 0;
-  }
+   /**
+    * Parse and validate the command line parameters allowing abbreviated parameters.
+    */
+   public void parseWithAbbreviations(String... args) {
+      parseWithAbbreviations(true, args);
+   }
 
-  private ParameterDescription getPrefixDescriptionFor(String arg) {
-    for (Map.Entry<String, ParameterDescription> es : m_descriptions.entrySet()) {
-      if (arg.startsWith(es.getKey())) return es.getValue();
-    }
+   /**
+    * Parse the command line parameters allowing abbreviated parameters.
+    */
+   public void parseWithAbbreviations(boolean validate, String... args) {
+      parse(validate, true /* allow abbreviations */, args);
+   }
 
-    return null;
-  }
 
-  /**
-   * If arg is an option, we can look it up directly, but if it's a value,
-   * we need to find the description for the option that precedes it.
-   */
-  private ParameterDescription getDescriptionFor(String[] args, String arg) {
-    ParameterDescription result = getPrefixDescriptionFor(arg);
-    if (result != null) return result;
+   private void parse(boolean validate, boolean allowAbbreviations, String... args) {
+      StringBuilder sb = new StringBuilder("Parsing \"");
+      sb.append(join(args).append("\"\n  with:").append(join(m_objects.toArray())));
+      p(sb.toString());
 
-    for (String a : args) {
-      ParameterDescription pd = getPrefixDescriptionFor(arg);
-      if (pd != null) result = pd;
-      if (a.equals(arg)) return result;
-    }
+      if (m_descriptions == null) createDescriptions();
+      initializeDefaultValues();
+      parseValues(allowAbbreviations, expandArgs(args));
+      if (validate) validateOptions();
+   }
 
-    throw new ParameterException("Unknown parameter: " + arg);
-  }
-
-  private String getSeparatorFor(String[] args, String arg) {
-    ParameterDescription pd = getDescriptionFor(args, arg);
-
-    // Could be null if only main parameters were passed
-    if (pd != null) {
-      Parameters p = pd.getObject().getClass().getAnnotation(Parameters.class);
-      if (p != null) return p.separators();
-    }
-
-    return " ";
-  }
-
-  private String getOptionPrefixes(String[] args, String arg) {
-    ParameterDescription pd = getDescriptionFor(args, arg);
-
-    // Could be null if only main parameters were passed
-    if (pd != null) {
-      Parameters p = pd.getObject().getClass()
-          .getAnnotation(Parameters.class);
-      if (p != null) return p.optionPrefixes();
-    }
-    String result = Parameters.DEFAULT_OPTION_PREFIXES;
-
-    // See if any of the objects contains a @Parameters(optionPrefixes)
-    StringBuilder sb = new StringBuilder();
-    for (Object o : m_objects) {
-      Parameters p = o.getClass().getAnnotation(Parameters.class);
-      if (p != null && !Parameters.DEFAULT_OPTION_PREFIXES.equals(p.optionPrefixes())) {
-        sb.append(p.optionPrefixes());
-      }
-    }
-
-    if (! Strings.isStringEmpty(sb.toString())) {
-      result = sb.toString();
-    }
-
-    return result;
-  }
-
-  /**
-   * Reads the file specified by filename and returns the file content as a string.
-   * End of lines are replaced by a space.
-   *
-   * @param fileName the command line filename
-   * @return the file content as a string.
-   */
-  private static List<String> readFile(String fileName) {
-    List<String> result = Lists.newArrayList();
-
-    try {
-      BufferedReader bufRead = new BufferedReader(new FileReader(fileName));
-
-      String line;
-
-      // Read through file one line at time. Print line # and line
-      while ((line = bufRead.readLine()) != null) {
-        // Allow empty lines in these at files
-        if (line.length() > 0) result.add(line);
-      }
-
-      bufRead.close();
-    }
-    catch (IOException e) {
-      throw new ParameterException("Could not read file " + fileName + ": " + e);
-    }
-
-    return result;
-  }
-
-  /**
-   * Remove spaces at both ends and handle double quotes.
-   */
-  private static String trim(String string) {
-    String result = string.trim();
-    if (result.startsWith("\"")) {
-      if (result.endsWith("\"")) {
-          return result.substring(1, result.length() - 1);
-      }
-      return result.substring(1);
-    }
-    return result;
-  }
-
-  /**
-   * Create the ParameterDescriptions for all the \@Parameter found.
-   */
-  private void createDescriptions() {
-    m_descriptions = Maps.newHashMap();
-
-    for (Object object : m_objects) {
-      addDescription(object);
-    }
-  }
-
-  private void addDescription(Object object) {
-    Class<?> cls = object.getClass();
-
-    while (!Object.class.equals(cls)) {
-      for (Field f : cls.getDeclaredFields()) {
-        p("Field:" + cls.getSimpleName() + "." + f.getName());
-        f.setAccessible(true);
-        Annotation annotation = f.getAnnotation(Parameter.class);
-        Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
-        Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
-        if (annotation != null) {
-          //
-          // @Parameter
-          //
-          Parameter p = (Parameter) annotation;
-          if (p.names().length == 0) {
-            p("Found main parameter:" + f);
-            if (m_mainParameterField != null) {
-              throw new ParameterException("Only one @Parameter with no names attribute is"
-                  + " allowed, found:" + m_mainParameterField + " and " + f);
-            }
-            m_mainParameterField = f;
-            m_mainParameterObject = object;
-            m_mainParameterAnnotation = p;
-            m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this);
-          } else {
-            for (String name : p.names()) {
-              if (m_descriptions.containsKey(name)) {
-                throw new ParameterException("Found the option " + name + " multiple times");
-              }
-              p("Adding description for " + name);
-              ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this);
-              m_fields.put(f, pd);
-              m_descriptions.put(name, pd);
-
-              if (p.required()) m_requiredFields.put(f, pd);
-            }
-          }
-        } else if (delegateAnnotation != null) {
-          //
-          // @ParametersDelegate
-          //
-          try {
-            Object delegateObject = f.get(object);
-            if (delegateObject == null){
-              throw new ParameterException("Delegate field '" + f.getName() + "' cannot be null.");
-            }
-            addDescription(delegateObject);
-          } catch (IllegalAccessException e) {
-          }
-        } else if (dynamicParameter != null) {
-          //
-          // @DynamicParameter
-          //
-          DynamicParameter dp = (DynamicParameter) dynamicParameter;
-          for (String name : dp.names()) {
-            if (m_descriptions.containsKey(name)) {
-              throw new ParameterException("Found the option " + name + " multiple times");
-            }
-            p("Adding description for " + name);
-            ParameterDescription pd = new ParameterDescription(object, dp, f, m_bundle, this);
-            m_fields.put(f, pd);
-            m_descriptions.put(name, pd);
-
-            if (dp.required()) m_requiredFields.put(f, pd);
-          }
-        }
-      }
-      // Traverse the super class until we find Object.class
-      cls = cls.getSuperclass();
-    }
-  }
-
-  private void initializeDefaultValue(ParameterDescription pd) {
-    for (String optionName : pd.getParameter().names()) {
-      String def = m_defaultProvider.getDefaultValueFor(optionName);
-      if (def != null) {
-        p("Initializing " + optionName + " with default value:" + def);
-        pd.addValue(def, true /* default */);
-        return;
-      }
-    }
-  }
-
-  /**
-   * Main method that parses the values and initializes the fields accordingly.
-   */
-  private void parseValues(String[] args) {
-    // This boolean becomes true if we encounter a command, which indicates we need
-    // to stop parsing (the parsing of the command will be done in a sub JCommander
-    // object)
-    boolean commandParsed = false;
-    int i = 0;
-    while (i < args.length && ! commandParsed) {
-      String arg = args[i];
-      String a = trim(arg);
-      p("Parsing arg: " + a);
-
-      JCommander jc = findCommandByAlias(arg);
-      int increment = 1;
-      if (isOption(args, a) && jc == null) {
-        //
-        // Option
-        //
-        ParameterDescription pd = m_descriptions.get(a);
-
-        if (pd != null) {
-          if (pd.getParameter().password()) {
-            //
-            // Password option, use the Console to retrieve the password
-            //
-            char[] password = readPassword(pd.getDescription());
-            pd.addValue(new String(password));
-            m_requiredFields.remove(pd.getField());
-          } else {
-            if (pd.getParameter().variableArity()) {
-              //
-              // Variable arity?
-              //
-              increment = processVariableArity(args, i, pd);
-            } else {
-              //
-              // Regular option
-              //
-              Class<?> fieldType = pd.getField().getType();
-
-              // Boolean, set to true as soon as we see it, unless it specified
-              // an arity of 1, in which case we need to read the next value
-              if ((fieldType == boolean.class || fieldType == Boolean.class)
-                  && pd.getParameter().arity() == -1) {
-                pd.addValue("true");
-                m_requiredFields.remove(pd.getField());
-              } else {
-                increment = processFixedArity(args, i, pd, fieldType);
-              }
-            }
-          }
-        } else {
-          throw new ParameterException("Unknown option: " + arg);
-        }
-      }
-      else {
-        //
-        // Main parameter
-        //
-        if (! Strings.isStringEmpty(arg)) {
-          if (m_commands.isEmpty()) {
-            //
-            // Regular (non-command) parsing
-            //
-            List mp = getMainParameter(arg);
-            String value = arg;
-            Object convertedValue = value;
-
-            if (m_mainParameterField.getGenericType() instanceof ParameterizedType) {
-              ParameterizedType p = (ParameterizedType) m_mainParameterField.getGenericType();
-              Type cls = p.getActualTypeArguments()[0];
-              if (cls instanceof Class) {
-                convertedValue = convertValue(m_mainParameterField, (Class) cls, value);
-              }
-            }
-
-            ParameterDescription.validateParameter(m_mainParameterAnnotation.validateWith(),
-                "Default", value);
-
-            m_mainParameterDescription.setAssigned(true);
-            mp.add(convertedValue);
-          }
-          else {
-            //
-            // Command parsing
-            //
-            if (jc == null) throw new MissingCommandException("Expected a command, got " + arg);
-            m_parsedCommand = jc.m_programName.m_name;
-            m_parsedAlias = arg; //preserve the original form
-
-            // Found a valid command, ask it to parse the remainder of the arguments.
-            // Setting the boolean commandParsed to true will force the current
-            // loop to end.
-            jc.parse(subArray(args, i + 1));
-            commandParsed = true;
-          }
-        }
-      }
-      i += increment;
-    }
-
-    // Mark the parameter descriptions held in m_fields as assigned
-    for (ParameterDescription parameterDescription : m_descriptions.values()) {
-      if (parameterDescription.isAssigned()) {
-        m_fields.get(parameterDescription.getField()).setAssigned(true);
-      }
-    }
-
-  }
-
-  /**
-   * @return the generic type of the collection for this field, or null if not applicable.
-   */
-  private Type findFieldGenericType(Field field) {
-    if (field.getGenericType() instanceof ParameterizedType) {
-      ParameterizedType p = (ParameterizedType) field.getGenericType();
-      Type cls = p.getActualTypeArguments()[0];
-      if (cls instanceof Class) {
-        return cls;
-      }
-    }
-
-    return null;
-  }
-
-  private class DefaultVariableArity implements IVariableArity {
-
-    public int processVariableArity(String optionName, String[] options) {
-        int i = 0;
-        while (i < options.length && !isOption(options, options[i])) {
-          i++;
-        }
-        return i;
-    }
-  }
-  private final IVariableArity DEFAULT_VARIABLE_ARITY = new DefaultVariableArity();
-
-  /**
-   * @return the number of options that were processed.
-   */
-  private int processVariableArity(String[] args, int index, ParameterDescription pd) {
-    Object arg = pd.getObject();
-    IVariableArity va;
-    if (! (arg instanceof IVariableArity)) {
-        va = DEFAULT_VARIABLE_ARITY;
-    } else {
-        va = (IVariableArity) arg;
-    }
-
-    List<String> currentArgs = Lists.newArrayList();
-    for (int j = index + 1; j < args.length; j++) {
-      currentArgs.add(args[j]);
-    }
-    int arity = va.processVariableArity(pd.getParameter().names()[0],
-        currentArgs.toArray(new String[0]));
-
-    int result = processFixedArity(args, index, pd, List.class, arity);
-    return result;
-  }
-
-  private int processFixedArity(String[] args, int index, ParameterDescription pd,
-      Class<?> fieldType) {
-    // Regular parameter, use the arity to tell use how many values
-    // we need to consume
-    int arity = pd.getParameter().arity();
-    int n = (arity != -1 ? arity : 1);
-
-    return processFixedArity(args, index, pd, fieldType, n);
-  }
-
-  private int processFixedArity(String[] args, int originalIndex, ParameterDescription pd,
-                                Class<?> fieldType, int arity) {
-    int index = originalIndex;
-    String arg = args[index];
-    // Special case for boolean parameters of arity 0
-    if (arity == 0 &&
-        (Boolean.class.isAssignableFrom(fieldType)
-            || boolean.class.isAssignableFrom(fieldType))) {
-      pd.addValue("true");
-      m_requiredFields.remove(pd.getField());
-    } else if (index < args.length - 1) {
-      int offset = "--".equals(args[index + 1]) ? 1 : 0;
-
-      if (index + arity < args.length) {
-        for (int j = 1; j <= arity; j++) {
-          pd.addValue(trim(args[index + j + offset]));
-          m_requiredFields.remove(pd.getField());
-        }
-        index += arity + offset;
-      } else {
-        throw new ParameterException("Expected " + arity + " values after " + arg);
-      }
-    } else {
-      throw new ParameterException("Expected a value after parameter " + arg);
-    }
-
-    return arity + 1;
-  }
-
-  /**
-   * Invoke Console.readPassword through reflection to avoid depending
-   * on Java 6.
-   */
-  private char[] readPassword(String description) {
-    getConsole().print(description + ": ");
-    return getConsole().readPassword();
-  }
-
-  private String[] subArray(String[] args, int index) {
-    int l = args.length - index;
-    String[] result = new String[l];
-    System.arraycopy(args, index, result, 0, l);
-
-    return result;
-  }
-
-  /**
-   * @return the field that's meant to receive all the parameters that are not options.
-   *
-   * @param arg the arg that we're about to add (only passed here to output a meaningful
-   * error message).
-   */
-  private List<?> getMainParameter(String arg) {
-    if (m_mainParameterField == null) {
-      throw new ParameterException(
-          "Was passed main parameter '" + arg + "' but no main parameter was defined");
-    }
-
-    try {
-      List result = (List) m_mainParameterField.get(m_mainParameterObject);
-      if (result == null) {
-        result = Lists.newArrayList();
-        if (! List.class.isAssignableFrom(m_mainParameterField.getType())) {
-          throw new ParameterException("Main parameter field " + m_mainParameterField
-              + " needs to be of type List, not " + m_mainParameterField.getType());
-        }
-        m_mainParameterField.set(m_mainParameterObject, result);
+   private StringBuilder join(Object[] args) {
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < args.length; i++) {
+         if (i > 0) result.append(" ");
+         result.append(args[i]);
       }
       return result;
-    }
-    catch(IllegalAccessException ex) {
-      throw new ParameterException("Couldn't access main parameter: " + ex.getMessage());
-    }
-  }
+   }
 
-  public String getMainParameterDescription() {
-    if (m_descriptions == null) createDescriptions();
-    return m_mainParameterAnnotation != null ? m_mainParameterAnnotation.description()
-        : null;
-  }
+   private void initializeDefaultValues() {
+      if (m_defaultProvider != null) {
+         for (ParameterDescription pd : m_descriptions.values()) {
+            initializeDefaultValue(pd);
+         }
 
-  private int longestName(Collection<?> objects) {
-    int result = 0;
-    for (Object o : objects) {
-      int l = o.toString().length();
-      if (l > result) result = l;
-    }
+         for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+            entry.getValue().initializeDefaultValues();
+         }
+      }
+   }
 
-    return result;
-  }
-
-  /**
-   * Set the program name (used only in the usage).
-   */
-  public void setProgramName(String name) {
-    setProgramName(name, new String[0]);
-  }
-
-  /**
-   * Set the program name
-   *
-   * @param name    program name
-   * @param aliases aliases to the program name
-   */
-  public void setProgramName(String name, String... aliases) {
-    m_programName = new ProgramName(name, Arrays.asList(aliases));
-  }
-
-  /**
-   * Display the usage for this command.
-   */
-  public void usage(String commandName) {
-    StringBuilder sb = new StringBuilder();
-    usage(commandName, sb);
-    getConsole().println(sb.toString());
-  }
-
-  /**
-   * Store the help for the command in the passed string builder.
-   */
-  public void usage(String commandName, StringBuilder out) {
-    usage(commandName, out, "");
-  }
-
-  /**
-   * Store the help for the command in the passed string builder, indenting
-   * every line with "indent".
-   */
-  public void usage(String commandName, StringBuilder out, String indent) {
-    String description = getCommandDescription(commandName);
-    JCommander jc = findCommandByAlias(commandName);
-    if (description != null) {
-      out.append(indent).append(description);
-      out.append("\n");
-    }
-    jc.usage(out, indent);
-  }
-
-  /**
-   * @return the description of the command.
-   */
-  public String getCommandDescription(String commandName) {
-    JCommander jc = findCommandByAlias(commandName);
-    if (jc == null) {
-      throw new ParameterException("Asking description for unknown command: " + commandName);
-    }
-
-    Object arg = jc.getObjects().get(0);
-    Parameters p = arg.getClass().getAnnotation(Parameters.class);
-    ResourceBundle bundle = null;
-    String result = null;
-    if (p != null) {
-      result = p.commandDescription();
-      String bundleName = p.resourceBundle();
-      if (!"".equals(bundleName)) {
-        bundle = ResourceBundle.getBundle(bundleName, Locale.getDefault());
-      } else {
-        bundle = m_bundle;
+   /**
+    * Make sure that all the required parameters have received a value.
+    */
+   private void validateOptions() {
+      if (!m_requiredFields.isEmpty()) {
+         StringBuilder missingFields = new StringBuilder();
+         for (ParameterDescription pd : m_requiredFields.values()) {
+            missingFields.append(pd.getNames()).append(" ");
+         }
+         throw new ParameterException("The following "
+               + pluralize(m_requiredFields.size(), "option is required: ", "options are required: ")
+               + missingFields);
       }
 
-      if (bundle != null) {
-        result = getI18nString(bundle, p.commandDescriptionKey(), p.commandDescription());
+      if (m_mainParameterDescription != null) {
+         if (m_mainParameterDescription.getParameter().required() &&
+               !m_mainParameterDescription.isAssigned()) {
+            throw new ParameterException("Main parameters are required (\""
+                  + m_mainParameterDescription.getDescription() + "\")");
+         }
       }
-    }
+   }
 
-    return result;
-  }
+   private static String pluralize(int quantity, String singular, String plural) {
+      return quantity == 1 ? singular : plural;
+   }
 
-  /**
-   * @return The internationalized version of the string if available, otherwise
-   * return def.
-   */
-  private String getI18nString(ResourceBundle bundle, String key, String def) {
-    String s = bundle != null ? bundle.getString(key) : null;
-    return s != null ? s : def;
-  }
+   /**
+    * Expand the command line parameters to take @ parameters into account.
+    * When @ is encountered, the content of the file that follows is inserted
+    * in the command line.
+    *
+    * @param originalArgv the original command line parameters
+    * @return the new and enriched command line parameters
+    */
+   private String[] expandArgs(String[] originalArgv) {
+      List<String> vResult1 = Lists.newArrayList();
 
-  /**
-   * Display the help on System.out.
-   */
-  public void usage() {
-    StringBuilder sb = new StringBuilder();
-    usage(sb);
-    getConsole().println(sb.toString());
-  }
+      //
+      // Expand @
+      //
+      for (String arg : originalArgv) {
 
-  /**
-   * Store the help in the passed string builder.
-   */
-  public void usage(StringBuilder out) {
-    usage(out, "");
-  }
-
-  public void usage(StringBuilder out, String indent) {
-    if (m_descriptions == null) createDescriptions();
-    boolean hasCommands = !m_commands.isEmpty();
-
-    //
-    // First line of the usage
-    //
-    String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
-    out.append(indent).append("Usage: " + programName + " [options]");
-    if (hasCommands) out.append(indent).append(" [command] [command options]");
-//    out.append("\n");
-    if (m_mainParameterDescription != null) {
-      out.append(" " + m_mainParameterDescription.getDescription());
-    }
-
-    //
-    // Align the descriptions at the "longestName" column
-    //
-    int longestName = 0;
-    List<ParameterDescription> sorted = Lists.newArrayList();
-    for (ParameterDescription pd : m_fields.values()) {
-      if (! pd.getParameter().hidden()) {
-        sorted.add(pd);
-        // + to have an extra space between the name and the description
-        int length = pd.getNames().length() + 2;
-        if (length > longestName) {
-          longestName = length;
-        }
+         if (arg.startsWith("@")) {
+            String fileName = arg.substring(1);
+            vResult1.addAll(readFile(fileName));
+         } else {
+            List<String> expanded = expandDynamicArg(arg);
+            vResult1.addAll(expanded);
+         }
       }
-    }
 
-    //
-    // Sort the options
-    //
-    Collections.sort(sorted, getParameterDescriptionComparator());
-
-    //
-    // Display all the names and descriptions
-    //
-    if (sorted.size() > 0) out.append(indent).append("\n").append(indent).append("  Options:\n");
-    for (ParameterDescription pd : sorted) {
-      int l = pd.getNames().length();
-      int spaceCount = longestName - l;
-      int start = out.length();
-      WrappedParameter parameter = pd.getParameter();
-      out.append(indent).append("  "
-          + (parameter.required() ? "* " : "  ")
-          + pd.getNames() + s(spaceCount));
-      int indentCount = out.length() - start;
-      wrapDescription(out, indentCount, pd.getDescription());
-      Object def = pd.getDefault();
-      if (pd.isDynamicParameter()) {
-        out.append("\n" + spaces(indentCount + 1))
-            .append("Syntax: " + parameter.names()[0]
-                + "key" + parameter.getAssignment()
-                + "value");
+      // Expand separators
+      //
+      List<String> vResult2 = Lists.newArrayList();
+      for (int i = 0; i < vResult1.size(); i++) {
+         String arg = vResult1.get(i);
+         String[] v1 = vResult1.toArray(new String[0]);
+         if (isOption(v1, arg)) {
+            String sep = getSeparatorFor(v1, arg);
+            if (!" ".equals(sep)) {
+               String[] sp = arg.split("[" + sep + "]", 2);
+               for (String ssp : sp) {
+                  vResult2.add(ssp);
+               }
+            } else {
+               vResult2.add(arg);
+            }
+         } else {
+            vResult2.add(arg);
+         }
       }
-      if (def != null && ! "".equals(def)) {
-        out.append("\n" + spaces(indentCount + 1))
-            .append("Default: " + (parameter.password()?"********":def));
+
+      return vResult2.toArray(new String[vResult2.size()]);
+   }
+
+   private List<String> expandDynamicArg(String arg) {
+      for (ParameterDescription pd : m_descriptions.values()) {
+         if (pd.isDynamicParameter()) {
+            for (String name : pd.getParameter().names()) {
+               if (arg.startsWith(name) && !arg.equals(name)) {
+                  return Arrays.asList(name, arg.substring(name.length()));
+               }
+            }
+         }
       }
-      out.append("\n");
-    }
 
-    //
-    // If commands were specified, show them as well
-    //
-    if (hasCommands) {
-      out.append("  Commands:\n");
-      // The magic value 3 is the number of spaces between the name of the option
-      // and its description
-      for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
-        ProgramName progName = commands.getKey();
-        String dispName = progName.getDisplayName();
-        out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");
+      return Arrays.asList(arg);
+   }
 
-        // Options for this command
-        usage(progName.getName(), out, "      ");
-        out.append("\n");
+   private boolean isOption(String[] args, String arg) {
+      String prefixes = getOptionPrefixes(args, arg);
+      return arg.length() > 0 && prefixes.indexOf(arg.charAt(0)) >= 0;
+   }
+
+   private ParameterDescription getPrefixDescriptionFor(String arg) {
+      for (Map.Entry<String, ParameterDescription> es : m_descriptions.entrySet()) {
+         if (arg.startsWith(es.getKey())) return es.getValue();
       }
-    }
-  }
 
-  private Comparator<? super ParameterDescription> getParameterDescriptionComparator() {
-    return m_parameterDescriptionComparator;
-  }
+      return null;
+   }
 
-  public void setParameterDescriptionComparator(Comparator<? super ParameterDescription> c) {
-    m_parameterDescriptionComparator = c;
-  }
-
-  public void setColumnSize(int columnSize) {
-    m_columnSize = columnSize;
-  }
-
-  public int getColumnSize() {
-    return m_columnSize;
-  }
-
-  private void wrapDescription(StringBuilder out, int indent, String description) {
-    int max = getColumnSize();
-    String[] words = description.split(" ");
-    int current = indent;
-    int i = 0;
-    while (i < words.length) {
-      String word = words[i];
-      if (word.length() > max || current + word.length() <= max) {
-        out.append(" ").append(word);
-        current += word.length() + 1;
-      } else {
-        out.append("\n").append(spaces(indent + 1)).append(word);
-        current = indent;
-      }
-      i++;
-    }
-  }
-
-  private String spaces(int indent) {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < indent; i++) sb.append(" ");
-    return sb.toString();
-  }
-
-  /**
-   * @return a Collection of all the \@Parameter annotations found on the
-   * target class. This can be used to display the usage() in a different
-   * format (e.g. HTML).
-   */
-  public List<ParameterDescription> getParameters() {
-    return new ArrayList<ParameterDescription>(m_fields.values());
-  }
-
-  /**
-   * @return the main parameter description or null if none is defined.
-   */
-  public ParameterDescription getMainParameter() {
-    return m_mainParameterDescription;
-  }
-
-  private void p(String string) {
-    if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
-      getConsole().println("[JCommander] " + string);
-    }
-  }
-
-  /**
-   * Define the default provider for this instance.
-   */
-  public void setDefaultProvider(IDefaultProvider defaultProvider) {
-    m_defaultProvider = defaultProvider;
-
-    for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-      entry.getValue().setDefaultProvider(defaultProvider);
-    }
-  }
-
-  public void addConverterFactory(IStringConverterFactory converterFactory) {
-    CONVERTER_FACTORIES.addFirst(converterFactory);
-  }
-
-  public <T> Class<? extends IStringConverter<T>> findConverter(Class<T> cls) {
-    for (IStringConverterFactory f : CONVERTER_FACTORIES) {
-      Class<? extends IStringConverter<T>> result = f.getConverter(cls);
+   /**
+    * If arg is an option, we can look it up directly, but if it's a value,
+    * we need to find the description for the option that precedes it.
+    */
+   private ParameterDescription getDescriptionFor(String[] args, String arg) {
+      ParameterDescription result = getPrefixDescriptionFor(arg);
       if (result != null) return result;
-    }
 
-    return null;
-  }
-
-  public Object convertValue(ParameterDescription pd, String value) {
-    return convertValue(pd.getField(), pd.getField().getType(), value);
-  }
-
-  /**
-   * @param field The field
-   * @param type The type of the actual parameter
-   * @param value The value to convert
-   */
-  public Object convertValue(Field field, Class type, String value) {
-    Parameter annotation = field.getAnnotation(Parameter.class);
-
-    // Do nothing if it's a @DynamicParameter
-    if (annotation == null) return value;
-
-    Class<? extends IStringConverter<?>> converterClass = annotation.converter();
-    boolean listConverterWasSpecified = annotation.listConverter() != NoConverter.class;
-
-    //
-    // Try to find a converter on the annotation
-    //
-    if (converterClass == null || converterClass == NoConverter.class) {
-      // If no converter specified and type is enum, used enum values to convert
-      if (type.isEnum()){
-        converterClass = type;
-      } else {
-        converterClass = findConverter(type);
+      for (String a : args) {
+         ParameterDescription pd = getPrefixDescriptionFor(arg);
+         if (pd != null) result = pd;
+         if (a.equals(arg)) return result;
       }
-    }
 
-    if (converterClass == null) {
-      Type elementType = findFieldGenericType(field);
-      converterClass = elementType != null
-          ? findConverter((Class<? extends IStringConverter<?>>) elementType)
-          : StringConverter.class;
-    }
+      throw new ParameterException("Unknown parameter: " + arg);
+   }
 
-    //
+   private String getSeparatorFor(String[] args, String arg) {
+      ParameterDescription pd = getDescriptionFor(args, arg);
+
+      // Could be null if only main parameters were passed
+      if (pd != null) {
+         Parameters p = pd.getObject().getClass().getAnnotation(Parameters.class);
+         if (p != null) return p.separators();
+      }
+
+      return " ";
+   }
+
+   private String getOptionPrefixes(String[] args, String arg) {
+      ParameterDescription pd = getDescriptionFor(args, arg);
+
+      // Could be null if only main parameters were passed
+      if (pd != null) {
+         Parameters p = pd.getObject().getClass()
+               .getAnnotation(Parameters.class);
+         if (p != null) return p.optionPrefixes();
+      }
+      String result = Parameters.DEFAULT_OPTION_PREFIXES;
+
+      // See if any of the objects contains a @Parameters(optionPrefixes)
+      StringBuilder sb = new StringBuilder();
+      for (Object o : m_objects) {
+         Parameters p = o.getClass().getAnnotation(Parameters.class);
+         if (p != null && !Parameters.DEFAULT_OPTION_PREFIXES.equals(p.optionPrefixes())) {
+            sb.append(p.optionPrefixes());
+         }
+      }
+
+      if (!Strings.isStringEmpty(sb.toString())) {
+         result = sb.toString();
+      }
+
+      return result;
+   }
+
+   /**
+    * Reads the file specified by filename and returns the file content as a string.
+    * End of lines are replaced by a space.
+    *
+    * @param fileName the command line filename
+    * @return the file content as a string.
+    */
+   private static List<String> readFile(String fileName) {
+      List<String> result = Lists.newArrayList();
+
+      try {
+         BufferedReader bufRead = new BufferedReader(new FileReader(fileName));
+
+         String line;
+
+         // Read through file one line at time. Print line # and line
+         while ((line = bufRead.readLine()) != null) {
+            // Allow empty lines in these at files
+            if (line.length() > 0) result.add(line);
+         }
+
+         bufRead.close();
+      } catch (IOException e) {
+         throw new ParameterException("Could not read file " + fileName + ": " + e);
+      }
+
+      return result;
+   }
+
+   /**
+    * Remove spaces at both ends and handle double quotes.
+    */
+   private static String trim(String string) {
+      String result = string.trim();
+      if (result.startsWith("\"")) {
+         if (result.endsWith("\"")) {
+            return result.substring(1, result.length() - 1);
+         }
+         return result.substring(1);
+      }
+      return result;
+   }
+
+   /**
+    * Create the ParameterDescriptions for all the \@Parameter found.
+    */
+   private void createDescriptions() {
+      m_descriptions = Maps.newHashMap();
+      m_abbrevMap = new AbbreviationMap<ParameterDescription>();
+
+      for (Object object : m_objects) {
+         addDescription(object);
+      }
+   }
+
+   private void addDescription(Object object) {
+      Class<?> cls = object.getClass();
+
+      while (!Object.class.equals(cls)) {
+         for (Field f : cls.getDeclaredFields()) {
+            p("Field:" + cls.getSimpleName() + "." + f.getName());
+            f.setAccessible(true);
+            Annotation annotation = f.getAnnotation(Parameter.class);
+            Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
+            Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
+            if (annotation != null) {
+               //
+               // @Parameter
+               //
+               Parameter p = (Parameter) annotation;
+               if (p.names().length == 0) {
+                  p("Found main parameter:" + f);
+                  if (m_mainParameterField != null) {
+                     throw new ParameterException("Only one @Parameter with no names attribute is"
+                           + " allowed, found:" + m_mainParameterField + " and " + f);
+                  }
+                  m_mainParameterField = f;
+                  m_mainParameterObject = object;
+                  m_mainParameterAnnotation = p;
+                  m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this);
+               } else {
+                  for (String name : p.names()) {
+                     if (m_descriptions.containsKey(name)) {
+                        throw new ParameterException("Found the option " + name + " multiple times");
+                     }
+                     p("Adding description for " + name);
+                     ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this);
+                     m_fields.put(f, pd);
+                     m_descriptions.put(name, pd);
+                     m_abbrevMap.put(name, pd);
+
+                     if (p.required()) m_requiredFields.put(f, pd);
+                  }
+               }
+            } else if (delegateAnnotation != null) {
+               //
+               // @ParametersDelegate
+               //
+               try {
+                  Object delegateObject = f.get(object);
+                  if (delegateObject == null) {
+                     throw new ParameterException("Delegate field '" + f.getName() + "' cannot be null.");
+                  }
+                  addDescription(delegateObject);
+               } catch (IllegalAccessException e) {
+               }
+            } else if (dynamicParameter != null) {
+               //
+               // @DynamicParameter
+               //
+               DynamicParameter dp = (DynamicParameter) dynamicParameter;
+               for (String name : dp.names()) {
+                  if (m_descriptions.containsKey(name)) {
+                     throw new ParameterException("Found the option " + name + " multiple times");
+                  }
+                  p("Adding description for " + name);
+                  ParameterDescription pd = new ParameterDescription(object, dp, f, m_bundle, this);
+                  m_fields.put(f, pd);
+                  m_descriptions.put(name, pd);
+                  m_abbrevMap.put(name, pd);
+
+                  if (dp.required()) m_requiredFields.put(f, pd);
+               }
+            }
+         }
+         // Traverse the super class until we find Object.class
+         cls = cls.getSuperclass();
+      }
+   }
+
+   private void initializeDefaultValue(ParameterDescription pd) {
+      for (String optionName : pd.getParameter().names()) {
+         String def = m_defaultProvider.getDefaultValueFor(optionName);
+         if (def != null) {
+            p("Initializing " + optionName + " with default value:" + def);
+            pd.addValue(def, true /* default */);
+            return;
+         }
+      }
+   }
+
+   /**
+    * Main method that parses the values and initializes the fields accordingly.
+    */
+   private void parseValues(boolean allowAbbreviations, String[] args) {
+      // This boolean becomes true if we encounter a command, which indicates we need
+      // to stop parsing (the parsing of the command will be done in a sub JCommander
+      // object)
+      boolean commandParsed = false;
+      int i = 0;
+      while (i < args.length && !commandParsed) {
+         String arg = args[i];
+         String a = trim(arg);
+         p("Parsing arg: " + a);
+
+         JCommander jc = findCommandByAlias(arg);
+         int increment = 1;
+         if (isOption(args, a) && jc == null) {
+            //
+            // Option
+            //
+            ParameterDescription pd;
+            if (allowAbbreviations) {
+               pd = m_abbrevMap.get(a);
+            } else {
+               pd = m_descriptions.get(a);
+            }
+
+            if (pd != null) {
+               if (pd.getParameter().password()) {
+                  //
+                  // Password option, use the Console to retrieve the password
+                  //
+                  char[] password = readPassword(pd.getDescription());
+                  pd.addValue(new String(password));
+                  m_requiredFields.remove(pd.getField());
+               } else {
+                  if (pd.getParameter().variableArity()) {
+                     //
+                     // Variable arity?
+                     //
+                     increment = processVariableArity(args, i, pd);
+                  } else {
+                     //
+                     // Regular option
+                     //
+                     Class<?> fieldType = pd.getField().getType();
+
+                     // Boolean, set to true as soon as we see it, unless it specified
+                     // an arity of 1, in which case we need to read the next value
+                     if ((fieldType == boolean.class || fieldType == Boolean.class)
+                           && pd.getParameter().arity() == -1) {
+                        pd.addValue("true");
+                        m_requiredFields.remove(pd.getField());
+                     } else {
+                        increment = processFixedArity(args, i, pd, fieldType);
+                     }
+                  }
+               }
+            } else {
+               throw new ParameterException("Unknown option: " + arg);
+            }
+         } else {
+            //
+            // Main parameter
+            //
+            if (!Strings.isStringEmpty(arg)) {
+               if (m_commands.isEmpty()) {
+                  //
+                  // Regular (non-command) parsing
+                  //
+                  List mp = getMainParameter(arg);
+                  String value = arg;
+                  Object convertedValue = value;
+
+                  if (m_mainParameterField.getGenericType() instanceof ParameterizedType) {
+                     ParameterizedType p = (ParameterizedType) m_mainParameterField.getGenericType();
+                     Type cls = p.getActualTypeArguments()[0];
+                     if (cls instanceof Class) {
+                        convertedValue = convertValue(m_mainParameterField, (Class) cls, value);
+                     }
+                  }
+
+                  ParameterDescription.validateParameter(m_mainParameterAnnotation.validateWith(),
+                        "Default", value);
+
+                  m_mainParameterDescription.setAssigned(true);
+                  mp.add(convertedValue);
+               } else {
+                  //
+                  // Command parsing
+                  //
+                  if (jc == null) throw new MissingCommandException("Expected a command, got " + arg);
+                  m_parsedCommand = jc.m_programName.m_name;
+                  m_parsedAlias = arg; //preserve the original form
+
+                  // Found a valid command, ask it to parse the remainder of the arguments.
+                  // Setting the boolean commandParsed to true will force the current
+                  // loop to end.
+                  jc.parse(true, allowAbbreviations, subArray(args, i + 1));
+                  commandParsed = true;
+               }
+            }
+         }
+         i += increment;
+      }
+
+      // Mark the parameter descriptions held in m_fields as assigned
+      for (ParameterDescription parameterDescription : m_descriptions.values()) {
+         if (parameterDescription.isAssigned()) {
+            m_fields.get(parameterDescription.getField()).setAssigned(true);
+         }
+      }
+
+   }
+
+   /**
+    * @return the generic type of the collection for this field, or null if not applicable.
+    */
+   private Type findFieldGenericType(Field field) {
+      if (field.getGenericType() instanceof ParameterizedType) {
+         ParameterizedType p = (ParameterizedType) field.getGenericType();
+         Type cls = p.getActualTypeArguments()[0];
+         if (cls instanceof Class) {
+            return cls;
+         }
+      }
+
+      return null;
+   }
+
+   private class DefaultVariableArity implements IVariableArity {
+
+      public int processVariableArity(String optionName, String[] options) {
+         int i = 0;
+         while (i < options.length && !isOption(options, options[i])) {
+            i++;
+         }
+         return i;
+      }
+   }
+
+   private final IVariableArity DEFAULT_VARIABLE_ARITY = new DefaultVariableArity();
+
+   /**
+    * @return the number of options that were processed.
+    */
+   private int processVariableArity(String[] args, int index, ParameterDescription pd) {
+      Object arg = pd.getObject();
+      IVariableArity va;
+      if (!(arg instanceof IVariableArity)) {
+         va = DEFAULT_VARIABLE_ARITY;
+      } else {
+         va = (IVariableArity) arg;
+      }
+
+      List<String> currentArgs = Lists.newArrayList();
+      for (int j = index + 1; j < args.length; j++) {
+         currentArgs.add(args[j]);
+      }
+      int arity = va.processVariableArity(pd.getParameter().names()[0],
+            currentArgs.toArray(new String[0]));
+
+      int result = processFixedArity(args, index, pd, List.class, arity);
+      return result;
+   }
+
+   private int processFixedArity(String[] args, int index, ParameterDescription pd,
+                                 Class<?> fieldType) {
+      // Regular parameter, use the arity to tell use how many values
+      // we need to consume
+      int arity = pd.getParameter().arity();
+      int n = (arity != -1 ? arity : 1);
+
+      return processFixedArity(args, index, pd, fieldType, n);
+   }
+
+   private int processFixedArity(String[] args, int originalIndex, ParameterDescription pd,
+                                 Class<?> fieldType, int arity) {
+      int index = originalIndex;
+      String arg = args[index];
+      // Special case for boolean parameters of arity 0
+      if (arity == 0 &&
+            (Boolean.class.isAssignableFrom(fieldType)
+                  || boolean.class.isAssignableFrom(fieldType))) {
+         pd.addValue("true");
+         m_requiredFields.remove(pd.getField());
+      } else if (index < args.length - 1) {
+         int offset = "--".equals(args[index + 1]) ? 1 : 0;
+
+         if (index + arity < args.length) {
+            for (int j = 1; j <= arity; j++) {
+               pd.addValue(trim(args[index + j + offset]));
+               m_requiredFields.remove(pd.getField());
+            }
+            index += arity + offset;
+         } else {
+            throw new ParameterException("Expected " + arity + " values after " + arg);
+         }
+      } else {
+         throw new ParameterException("Expected a value after parameter " + arg);
+      }
+
+      return arity + 1;
+   }
+
+   /**
+    * Invoke Console.readPassword through reflection to avoid depending
+    * on Java 6.
+    */
+   private char[] readPassword(String description) {
+      getConsole().print(description + ": ");
+      return getConsole().readPassword();
+   }
+
+   private String[] subArray(String[] args, int index) {
+      int l = args.length - index;
+      String[] result = new String[l];
+      System.arraycopy(args, index, result, 0, l);
+
+      return result;
+   }
+
+   /**
+    * @param arg the arg that we're about to add (only passed here to output a meaningful
+    *            error message).
+    * @return the field that's meant to receive all the parameters that are not options.
+    */
+   private List<?> getMainParameter(String arg) {
+      if (m_mainParameterField == null) {
+         throw new ParameterException(
+               "Was passed main parameter '" + arg + "' but no main parameter was defined");
+      }
+
+      try {
+         List result = (List) m_mainParameterField.get(m_mainParameterObject);
+         if (result == null) {
+            result = Lists.newArrayList();
+            if (!List.class.isAssignableFrom(m_mainParameterField.getType())) {
+               throw new ParameterException("Main parameter field " + m_mainParameterField
+                     + " needs to be of type List, not " + m_mainParameterField.getType());
+            }
+            m_mainParameterField.set(m_mainParameterObject, result);
+         }
+         return result;
+      } catch (IllegalAccessException ex) {
+         throw new ParameterException("Couldn't access main parameter: " + ex.getMessage());
+      }
+   }
+
+   public String getMainParameterDescription() {
+      if (m_descriptions == null) createDescriptions();
+      return m_mainParameterAnnotation != null ? m_mainParameterAnnotation.description()
+            : null;
+   }
+
+   private int longestName(Collection<?> objects) {
+      int result = 0;
+      for (Object o : objects) {
+         int l = o.toString().length();
+         if (l > result) result = l;
+      }
+
+      return result;
+   }
+
+   /**
+    * Set the program name (used only in the usage).
+    */
+   public void setProgramName(String name) {
+      setProgramName(name, new String[0]);
+   }
+
+   /**
+    * Set the program name
+    *
+    * @param name    program name
+    * @param aliases aliases to the program name
+    */
+   public void setProgramName(String name, String... aliases) {
+      m_programName = new ProgramName(name, Arrays.asList(aliases));
+   }
+
+   /**
+    * Display the usage for this command.
+    */
+   public void usage(String commandName) {
+      StringBuilder sb = new StringBuilder();
+      usage(commandName, sb);
+      getConsole().println(sb.toString());
+   }
+
+   /**
+    * Store the help for the command in the passed string builder.
+    */
+   public void usage(String commandName, StringBuilder out) {
+      usage(commandName, out, "");
+   }
+
+   /**
+    * Store the help for the command in the passed string builder, indenting
+    * every line with "indent".
+    */
+   public void usage(String commandName, StringBuilder out, String indent) {
+      String description = getCommandDescription(commandName);
+      JCommander jc = findCommandByAlias(commandName);
+      if (description != null) {
+         out.append(indent).append(description);
+         out.append("\n");
+      }
+      jc.usage(out, indent);
+   }
+
+   /**
+    * @return the description of the command.
+    */
+   public String getCommandDescription(String commandName) {
+      JCommander jc = findCommandByAlias(commandName);
+      if (jc == null) {
+         throw new ParameterException("Asking description for unknown command: " + commandName);
+      }
+
+      Object arg = jc.getObjects().get(0);
+      Parameters p = arg.getClass().getAnnotation(Parameters.class);
+      ResourceBundle bundle = null;
+      String result = null;
+      if (p != null) {
+         result = p.commandDescription();
+         String bundleName = p.resourceBundle();
+         if (!"".equals(bundleName)) {
+            bundle = ResourceBundle.getBundle(bundleName, Locale.getDefault());
+         } else {
+            bundle = m_bundle;
+         }
+
+         if (bundle != null) {
+            result = getI18nString(bundle, p.commandDescriptionKey(), p.commandDescription());
+         }
+      }
+
+      return result;
+   }
+
+   /**
+    * @return The internationalized version of the string if available, otherwise
+    *         return def.
+    */
+   private String getI18nString(ResourceBundle bundle, String key, String def) {
+      String s = bundle != null ? bundle.getString(key) : null;
+      return s != null ? s : def;
+   }
+
+   /**
+    * Display the help on System.out.
+    */
+   public void usage() {
+      StringBuilder sb = new StringBuilder();
+      usage(sb);
+      getConsole().println(sb.toString());
+   }
+
+   /**
+    * Store the help in the passed string builder.
+    */
+   public void usage(StringBuilder out) {
+      usage(out, "");
+   }
+
+   public void usage(StringBuilder out, String indent) {
+      if (m_descriptions == null) createDescriptions();
+      boolean hasCommands = !m_commands.isEmpty();
+
+      //
+      // First line of the usage
+      //
+      String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
+      out.append(indent).append("Usage: " + programName + " [options]");
+      if (hasCommands) out.append(indent).append(" [command] [command options]");
+//    out.append("\n");
+      if (m_mainParameterDescription != null) {
+         out.append(" " + m_mainParameterDescription.getDescription());
+      }
+
+      //
+      // Align the descriptions at the "longestName" column
+      //
+      int longestName = 0;
+      List<ParameterDescription> sorted = Lists.newArrayList();
+      for (ParameterDescription pd : m_fields.values()) {
+         if (!pd.getParameter().hidden()) {
+            sorted.add(pd);
+            // + to have an extra space between the name and the description
+            int length = pd.getNames().length() + 2;
+            if (length > longestName) {
+               longestName = length;
+            }
+         }
+      }
+
+      //
+      // Sort the options
+      //
+      Collections.sort(sorted, getParameterDescriptionComparator());
+
+      //
+      // Display all the names and descriptions
+      //
+      if (sorted.size() > 0) out.append(indent).append("\n").append(indent).append("  Options:\n");
+      for (ParameterDescription pd : sorted) {
+         int l = pd.getNames().length();
+         int spaceCount = longestName - l;
+         int start = out.length();
+         WrappedParameter parameter = pd.getParameter();
+         out.append(indent).append("  "
+               + (parameter.required() ? "* " : "  ")
+               + pd.getNames() + s(spaceCount));
+         int indentCount = out.length() - start;
+         wrapDescription(out, indentCount, pd.getDescription());
+         Object def = pd.getDefault();
+         if (pd.isDynamicParameter()) {
+            out.append("\n" + spaces(indentCount + 1))
+                  .append("Syntax: " + parameter.names()[0]
+                        + "key" + parameter.getAssignment()
+                        + "value");
+         }
+         if (def != null && !"".equals(def)) {
+            out.append("\n" + spaces(indentCount + 1))
+                  .append("Default: " + (parameter.password() ? "********" : def));
+         }
+         out.append("\n");
+      }
+
+      //
+      // If commands were specified, show them as well
+      //
+      if (hasCommands) {
+         out.append("  Commands:\n");
+         // The magic value 3 is the number of spaces between the name of the option
+         // and its description
+         for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
+            ProgramName progName = commands.getKey();
+            String dispName = progName.getDisplayName();
+            out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");
+
+            // Options for this command
+            usage(progName.getName(), out, "      ");
+            out.append("\n");
+         }
+      }
+   }
+
+   private Comparator<? super ParameterDescription> getParameterDescriptionComparator() {
+      return m_parameterDescriptionComparator;
+   }
+
+   public void setParameterDescriptionComparator(Comparator<? super ParameterDescription> c) {
+      m_parameterDescriptionComparator = c;
+   }
+
+   public void setColumnSize(int columnSize) {
+      m_columnSize = columnSize;
+   }
+
+   public int getColumnSize() {
+      return m_columnSize;
+   }
+
+   private void wrapDescription(StringBuilder out, int indent, String description) {
+      int max = getColumnSize();
+      String[] words = description.split(" ");
+      int current = indent;
+      int i = 0;
+      while (i < words.length) {
+         String word = words[i];
+         if (word.length() > max || current + word.length() <= max) {
+            out.append(" ").append(word);
+            current += word.length() + 1;
+         } else {
+            out.append("\n").append(spaces(indent + 1)).append(word);
+            current = indent;
+         }
+         i++;
+      }
+   }
+
+   private String spaces(int indent) {
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < indent; i++) sb.append(" ");
+      return sb.toString();
+   }
+
+   /**
+    * @return a Collection of all the \@Parameter annotations found on the
+    *         target class. This can be used to display the usage() in a different
+    *         format (e.g. HTML).
+    */
+   public List<ParameterDescription> getParameters() {
+      return new ArrayList<ParameterDescription>(m_fields.values());
+   }
+
+   /**
+    * @return the main parameter description or null if none is defined.
+    */
+   public ParameterDescription getMainParameter() {
+      return m_mainParameterDescription;
+   }
+
+   private void p(String string) {
+      if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
+         getConsole().println("[JCommander] " + string);
+      }
+   }
+
+   /**
+    * Define the default provider for this instance.
+    */
+   public void setDefaultProvider(IDefaultProvider defaultProvider) {
+      m_defaultProvider = defaultProvider;
+
+      for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+         entry.getValue().setDefaultProvider(defaultProvider);
+      }
+   }
+
+   public void addConverterFactory(IStringConverterFactory converterFactory) {
+      CONVERTER_FACTORIES.addFirst(converterFactory);
+   }
+
+   public <T> Class<? extends IStringConverter<T>> findConverter(Class<T> cls) {
+      for (IStringConverterFactory f : CONVERTER_FACTORIES) {
+         Class<? extends IStringConverter<T>> result = f.getConverter(cls);
+         if (result != null) return result;
+      }
+
+      return null;
+   }
+
+   public Object convertValue(ParameterDescription pd, String value) {
+      return convertValue(pd.getField(), pd.getField().getType(), value);
+   }
+
+   /**
+    * @param field The field
+    * @param type  The type of the actual parameter
+    * @param value The value to convert
+    */
+   public Object convertValue(Field field, Class type, String value) {
+      Parameter annotation = field.getAnnotation(Parameter.class);
+
+      // Do nothing if it's a @DynamicParameter
+      if (annotation == null) return value;
+
+      Class<? extends IStringConverter<?>> converterClass = annotation.converter();
+      boolean listConverterWasSpecified = annotation.listConverter() != NoConverter.class;
+
+      //
+      // Try to find a converter on the annotation
+      //
+      if (converterClass == null || converterClass == NoConverter.class) {
+         // If no converter specified and type is enum, used enum values to convert
+         if (type.isEnum()) {
+            converterClass = type;
+         } else {
+            converterClass = findConverter(type);
+         }
+      }
+
+      if (converterClass == null) {
+         Type elementType = findFieldGenericType(field);
+         converterClass = elementType != null
+               ? findConverter((Class<? extends IStringConverter<?>>) elementType)
+               : StringConverter.class;
+      }
+
+      //
 //    //
 //    // Try to find a converter in the factory
 //    //
@@ -1182,265 +1207,265 @@ public class JCommander {
 //          + " to type " + type + " (field: " + field.getName() + ")");
 //    }
 
-    IStringConverter<?> converter;
-    Object result = null;
-    try {
-      String[] names = annotation.names();
-      String optionName = names.length > 0 ? names[0] : "[Main class]";
-      if (converterClass.isEnum()) {
-        try {
-          result = Enum.valueOf((Class<? extends Enum>) converterClass, value.toUpperCase());
-        } catch (Exception e) {
-          throw new ParameterException("Invalid value for " + optionName + " parameter. Allowed values:" +
-                                       EnumSet.allOf((Class<? extends Enum>) converterClass));
-        }
-      } else {
-        converter = instantiateConverter(optionName, converterClass);
-        if (type.isAssignableFrom(List.class)
-              && field.getGenericType() instanceof ParameterizedType) {
+      IStringConverter<?> converter;
+      Object result = null;
+      try {
+         String[] names = annotation.names();
+         String optionName = names.length > 0 ? names[0] : "[Main class]";
+         if (converterClass.isEnum()) {
+            try {
+               result = Enum.valueOf((Class<? extends Enum>) converterClass, value.toUpperCase());
+            } catch (Exception e) {
+               throw new ParameterException("Invalid value for " + optionName + " parameter. Allowed values:" +
+                     EnumSet.allOf((Class<? extends Enum>) converterClass));
+            }
+         } else {
+            converter = instantiateConverter(optionName, converterClass);
+            if (type.isAssignableFrom(List.class)
+                  && field.getGenericType() instanceof ParameterizedType) {
 
-          // The field is a List
-          if (listConverterWasSpecified) {
-            // If a list converter was specified, pass the value to it
-            // for direct conversion
-            IStringConverter<?> listConverter =
-                instantiateConverter(optionName, annotation.listConverter());
-            result = listConverter.convert(value);
-          } else {
-            // No list converter: use the single value converter and pass each
-            // parsed value to it individually
-            result = convertToList(value, converter, annotation.splitter());
-          }
-        } else {
-          result = converter.convert(value);
-        }
+               // The field is a List
+               if (listConverterWasSpecified) {
+                  // If a list converter was specified, pass the value to it
+                  // for direct conversion
+                  IStringConverter<?> listConverter =
+                        instantiateConverter(optionName, annotation.listConverter());
+                  result = listConverter.convert(value);
+               } else {
+                  // No list converter: use the single value converter and pass each
+                  // parsed value to it individually
+                  result = convertToList(value, converter, annotation.splitter());
+               }
+            } else {
+               result = converter.convert(value);
+            }
+         }
+      } catch (InstantiationException e) {
+         throw new ParameterException(e);
+      } catch (IllegalAccessException e) {
+         throw new ParameterException(e);
+      } catch (InvocationTargetException e) {
+         throw new ParameterException(e);
       }
-    } catch (InstantiationException e) {
-      throw new ParameterException(e);
-    } catch (IllegalAccessException e) {
-      throw new ParameterException(e);
-    } catch (InvocationTargetException e) {
-      throw new ParameterException(e);
-    }
 
-    return result;
-  }
-
-  /**
-   * Use the splitter to split the value into multiple values and then convert
-   * each of them individually.
-   */
-  private Object convertToList(String value, IStringConverter<?> converter,
-      Class<? extends IParameterSplitter> splitterClass)
-          throws InstantiationException, IllegalAccessException {
-    IParameterSplitter splitter = splitterClass.newInstance();
-    List<Object> result = Lists.newArrayList();
-    for (String param : splitter.split(value)) {
-      result.add(converter.convert(param));
-    }
-    return result;
-  }
-
-  private IStringConverter<?> instantiateConverter(String optionName,
-      Class<? extends IStringConverter<?>> converterClass)
-      throws IllegalArgumentException, InstantiationException, IllegalAccessException,
-      InvocationTargetException {
-    Constructor<IStringConverter<?>> ctor = null;
-    Constructor<IStringConverter<?>> stringCtor = null;
-    Constructor<IStringConverter<?>>[] ctors
-        = (Constructor<IStringConverter<?>>[]) converterClass.getDeclaredConstructors();
-    for (Constructor<IStringConverter<?>> c : ctors) {
-      Class<?>[] types = c.getParameterTypes();
-      if (types.length == 1 && types[0].equals(String.class)) {
-        stringCtor = c;
-      } else if (types.length == 0) {
-        ctor = c;
-      }
-    }
-
-    IStringConverter<?> result = stringCtor != null
-        ? stringCtor.newInstance(optionName)
-        : ctor.newInstance();
-
-        return result;
-  }
-
-  /**
-   * Add a command object.
-   */
-  public void addCommand(String name, Object object) {
-    addCommand(name, object, new String[0]);
-  }
-
-  public void addCommand(Object object) {
-    Parameters p = object.getClass().getAnnotation(Parameters.class);
-    if (p != null && p.commandNames().length > 0) {
-      for (String commandName : p.commandNames()) {
-        addCommand(commandName, object);
-      }
-    } else {
-      throw new ParameterException("Trying to add command " + object.getClass().getName()
-          + " without specifying its names in @Parameters");
-    }
-  }
-
-  /**
-   * Add a command object and its aliases.
-   */
-  public void addCommand(String name, Object object, String... aliases) {
-    JCommander jc = new JCommander(object);
-    jc.setProgramName(name, aliases);
-    jc.setDefaultProvider(m_defaultProvider);
-    ProgramName progName = jc.m_programName;
-    m_commands.put(progName, jc);
-
-    /*
-    * Register aliases
-    */
-    //register command name as an alias of itself for reverse lookup
-    //Note: Name clash check is intentionally omitted to resemble the
-    //     original behaviour of clashing commands.
-    //     Aliases are, however, are strictly checked for name clashes.
-    aliasMap.put(name, progName);
-    for (String alias : aliases) {
-      //omit pointless aliases to avoid name clash exception
-      if (!alias.equals(name)) {
-        ProgramName mappedName = aliasMap.get(alias);
-        if (mappedName != null && !mappedName.equals(progName)) {
-          throw new ParameterException("Cannot set alias " + alias
-                  + " for " + name
-                  + " command because it has already been defined for "
-                  + mappedName.m_name + " command");
-        }
-        aliasMap.put(alias, progName);
-      }
-    }
-  }
-
-  public Map<String, JCommander> getCommands() {
-    Map<String, JCommander> res = Maps.newLinkedHashMap();
-    for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-      res.put(entry.getKey().m_name, entry.getValue());
-    }
-    return res;
-  }
-
-  public String getParsedCommand() {
-    return m_parsedCommand;
-  }
-
-  /**
-   * The name of the command or the alias in the form it was
-   * passed to the command line. <code>null</code> if no
-   * command or alias was specified.
-   *
-   * @return Name of command or alias passed to command line. If none passed: <code>null</code>.
-   */
-  public String getParsedAlias() {
-    return m_parsedAlias;
-  }
-
-  /**
-   * @return n spaces
-   */
-  private String s(int count) {
-    StringBuilder result = new StringBuilder();
-    for (int i = 0; i < count; i++) {
-      result.append(" ");
-    }
-
-    return result.toString();
-  }
-
-  /**
-   * @return the objects that JCommander will fill with the result of
-   * parsing the command line.
-   */
-  public List<Object> getObjects() {
-    return m_objects;
-  }
-
-  /*
-  * Reverse lookup JCommand object by command's name or its alias
-  */
-  private JCommander findCommandByAlias(String commandOrAlias) {
-    ProgramName progName = aliasMap.get(commandOrAlias);
-    if (progName == null) {
-      return null;
-    }
-    JCommander jc = m_commands.get(progName);
-    if (jc == null) {
-      throw new IllegalStateException(
-              "There appears to be inconsistency in the internal command database. " +
-                      " This is likely a bug. Please report.");
-    }
-    return jc;
-  }
-
-  private static final class ProgramName {
-    private final String m_name;
-    private final List<String> m_aliases;
-
-    ProgramName(String name, List<String> aliases) {
-      m_name = name;
-      m_aliases = aliases;
-    }
-
-    public String getName() {
-      return m_name;
-    }
-
-    private String getDisplayName() {
-      StringBuilder sb = new StringBuilder();
-      sb.append(m_name);
-      if (!m_aliases.isEmpty()) {
-        sb.append("(");
-        Iterator<String> aliasesIt = m_aliases.iterator();
-        while (aliasesIt.hasNext()) {
-          sb.append(aliasesIt.next());
-          if (aliasesIt.hasNext()) {
-            sb.append(",");
-          }
-        }
-        sb.append(")");
-      }
-      return sb.toString();
-    }
-    
-    @Override
-    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((m_name == null) ? 0 : m_name.hashCode());
       return result;
-    }
+   }
 
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj)
-        return true;
-      if (obj == null)
-        return false;
-      if (getClass() != obj.getClass())
-        return false;
-      ProgramName other = (ProgramName) obj;
-      if (m_name == null) {
-        if (other.m_name != null)
-          return false;
-      } else if (!m_name.equals(other.m_name))
-        return false;
-      return true;
-    }
+   /**
+    * Use the splitter to split the value into multiple values and then convert
+    * each of them individually.
+    */
+   private Object convertToList(String value, IStringConverter<?> converter,
+                                Class<? extends IParameterSplitter> splitterClass)
+         throws InstantiationException, IllegalAccessException {
+      IParameterSplitter splitter = splitterClass.newInstance();
+      List<Object> result = Lists.newArrayList();
+      for (String param : splitter.split(value)) {
+         result.add(converter.convert(param));
+      }
+      return result;
+   }
 
-    /*
-     * Important: ProgramName#toString() is used by longestName(Collection) function
-     * to format usage output.
-     */
-    @Override
-    public String toString() {
-      return getDisplayName();
-      
-    }
-  }
+   private IStringConverter<?> instantiateConverter(String optionName,
+                                                    Class<? extends IStringConverter<?>> converterClass)
+         throws IllegalArgumentException, InstantiationException, IllegalAccessException,
+         InvocationTargetException {
+      Constructor<IStringConverter<?>> ctor = null;
+      Constructor<IStringConverter<?>> stringCtor = null;
+      Constructor<IStringConverter<?>>[] ctors
+            = (Constructor<IStringConverter<?>>[]) converterClass.getDeclaredConstructors();
+      for (Constructor<IStringConverter<?>> c : ctors) {
+         Class<?>[] types = c.getParameterTypes();
+         if (types.length == 1 && types[0].equals(String.class)) {
+            stringCtor = c;
+         } else if (types.length == 0) {
+            ctor = c;
+         }
+      }
+
+      IStringConverter<?> result = stringCtor != null
+            ? stringCtor.newInstance(optionName)
+            : ctor.newInstance();
+
+      return result;
+   }
+
+   /**
+    * Add a command object.
+    */
+   public void addCommand(String name, Object object) {
+      addCommand(name, object, new String[0]);
+   }
+
+   public void addCommand(Object object) {
+      Parameters p = object.getClass().getAnnotation(Parameters.class);
+      if (p != null && p.commandNames().length > 0) {
+         for (String commandName : p.commandNames()) {
+            addCommand(commandName, object);
+         }
+      } else {
+         throw new ParameterException("Trying to add command " + object.getClass().getName()
+               + " without specifying its names in @Parameters");
+      }
+   }
+
+   /**
+    * Add a command object and its aliases.
+    */
+   public void addCommand(String name, Object object, String... aliases) {
+      JCommander jc = new JCommander(object);
+      jc.setProgramName(name, aliases);
+      jc.setDefaultProvider(m_defaultProvider);
+      ProgramName progName = jc.m_programName;
+      m_commands.put(progName, jc);
+
+      /*
+      * Register aliases
+      */
+      //register command name as an alias of itself for reverse lookup
+      //Note: Name clash check is intentionally omitted to resemble the
+      //     original behaviour of clashing commands.
+      //     Aliases are, however, are strictly checked for name clashes.
+      aliasMap.put(name, progName);
+      for (String alias : aliases) {
+         //omit pointless aliases to avoid name clash exception
+         if (!alias.equals(name)) {
+            ProgramName mappedName = aliasMap.get(alias);
+            if (mappedName != null && !mappedName.equals(progName)) {
+               throw new ParameterException("Cannot set alias " + alias
+                     + " for " + name
+                     + " command because it has already been defined for "
+                     + mappedName.m_name + " command");
+            }
+            aliasMap.put(alias, progName);
+         }
+      }
+   }
+
+   public Map<String, JCommander> getCommands() {
+      Map<String, JCommander> res = Maps.newLinkedHashMap();
+      for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+         res.put(entry.getKey().m_name, entry.getValue());
+      }
+      return res;
+   }
+
+   public String getParsedCommand() {
+      return m_parsedCommand;
+   }
+
+   /**
+    * The name of the command or the alias in the form it was
+    * passed to the command line. <code>null</code> if no
+    * command or alias was specified.
+    *
+    * @return Name of command or alias passed to command line. If none passed: <code>null</code>.
+    */
+   public String getParsedAlias() {
+      return m_parsedAlias;
+   }
+
+   /**
+    * @return n spaces
+    */
+   private String s(int count) {
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < count; i++) {
+         result.append(" ");
+      }
+
+      return result.toString();
+   }
+
+   /**
+    * @return the objects that JCommander will fill with the result of
+    *         parsing the command line.
+    */
+   public List<Object> getObjects() {
+      return m_objects;
+   }
+
+   /*
+   * Reverse lookup JCommand object by command's name or its alias
+   */
+   private JCommander findCommandByAlias(String commandOrAlias) {
+      ProgramName progName = aliasMap.get(commandOrAlias);
+      if (progName == null) {
+         return null;
+      }
+      JCommander jc = m_commands.get(progName);
+      if (jc == null) {
+         throw new IllegalStateException(
+               "There appears to be inconsistency in the internal command database. " +
+                     " This is likely a bug. Please report.");
+      }
+      return jc;
+   }
+
+   private static final class ProgramName {
+      private final String m_name;
+      private final List<String> m_aliases;
+
+      ProgramName(String name, List<String> aliases) {
+         m_name = name;
+         m_aliases = aliases;
+      }
+
+      public String getName() {
+         return m_name;
+      }
+
+      private String getDisplayName() {
+         StringBuilder sb = new StringBuilder();
+         sb.append(m_name);
+         if (!m_aliases.isEmpty()) {
+            sb.append("(");
+            Iterator<String> aliasesIt = m_aliases.iterator();
+            while (aliasesIt.hasNext()) {
+               sb.append(aliasesIt.next());
+               if (aliasesIt.hasNext()) {
+                  sb.append(",");
+               }
+            }
+            sb.append(")");
+         }
+         return sb.toString();
+      }
+
+      @Override
+      public int hashCode() {
+         final int prime = 31;
+         int result = 1;
+         result = prime * result + ((m_name == null) ? 0 : m_name.hashCode());
+         return result;
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+         if (this == obj)
+            return true;
+         if (obj == null)
+            return false;
+         if (getClass() != obj.getClass())
+            return false;
+         ProgramName other = (ProgramName) obj;
+         if (m_name == null) {
+            if (other.m_name != null)
+               return false;
+         } else if (!m_name.equals(other.m_name))
+            return false;
+         return true;
+      }
+
+      /*
+      * Important: ProgramName#toString() is used by longestName(Collection) function
+      * to format usage output.
+      */
+      @Override
+      public String toString() {
+         return getDisplayName();
+
+      }
+   }
 }
 

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -66,1133 +66,1133 @@ import java.util.ResourceBundle;
  * @author cbeust
  */
 public class JCommander {
-   public static final String DEBUG_PROPERTY = "jcommander.debug";
+    public static final String DEBUG_PROPERTY = "jcommander.debug";
 
-   /**
-    * A map to look up parameter description per option name.
-    */
-   private Map<String, ParameterDescription> m_descriptions;
+    /**
+     * A map to look up parameter description per option name.
+     */
+    private Map<String, ParameterDescription> m_descriptions;
 
-   /**
-    * Maps abbreviated parameter names to their ful name
-    */
-   private AbbreviationMap<ParameterDescription> m_abbrevMap;
+    /**
+     * Maps abbreviated parameter names to their ful name
+     */
+    private AbbreviationMap<ParameterDescription> m_abbrevMap;
 
-   /**
-    * The objects that contain fields annotated with @Parameter.
-    */
-   private List<Object> m_objects = Lists.newArrayList();
+    /**
+     * The objects that contain fields annotated with @Parameter.
+     */
+    private List<Object> m_objects = Lists.newArrayList();
 
-   /**
-    * This field will contain whatever command line parameter is not an option.
-    * It is expected to be a List<String>.
-    */
-   private Field m_mainParameterField = null;
+    /**
+     * This field will contain whatever command line parameter is not an option.
+     * It is expected to be a List<String>.
+     */
+    private Field m_mainParameterField = null;
 
-   /**
-    * The object on which we found the main parameter field.
-    */
-   private Object m_mainParameterObject;
+    /**
+     * The object on which we found the main parameter field.
+     */
+    private Object m_mainParameterObject;
 
-   /**
-    * The annotation found on the main parameter field.
-    */
-   private Parameter m_mainParameterAnnotation;
+    /**
+     * The annotation found on the main parameter field.
+     */
+    private Parameter m_mainParameterAnnotation;
 
-   private ParameterDescription m_mainParameterDescription;
+    private ParameterDescription m_mainParameterDescription;
 
-   /**
-    * A set of all the fields that are required. During the reflection phase,
-    * this field receives all the fields that are annotated with required=true
-    * and during the parsing phase, all the fields that are assigned a value
-    * are removed from it. At the end of the parsing phase, if it's not empty,
-    * then some required fields did not receive a value and an exception is
-    * thrown.
-    */
-   private Map<Field, ParameterDescription> m_requiredFields = Maps.newHashMap();
+    /**
+     * A set of all the fields that are required. During the reflection phase,
+     * this field receives all the fields that are annotated with required=true
+     * and during the parsing phase, all the fields that are assigned a value
+     * are removed from it. At the end of the parsing phase, if it's not empty,
+     * then some required fields did not receive a value and an exception is
+     * thrown.
+     */
+    private Map<Field, ParameterDescription> m_requiredFields = Maps.newHashMap();
 
-   /**
-    * A map of all the annotated fields.
-    */
-   private Map<Field, ParameterDescription> m_fields = Maps.newHashMap();
+    /**
+     * A map of all the annotated fields.
+     */
+    private Map<Field, ParameterDescription> m_fields = Maps.newHashMap();
 
-   private ResourceBundle m_bundle;
+    private ResourceBundle m_bundle;
 
-   /**
-    * A default provider returns default values for the parameters.
-    */
-   private IDefaultProvider m_defaultProvider;
+    /**
+     * A default provider returns default values for the parameters.
+     */
+    private IDefaultProvider m_defaultProvider;
 
-   /**
-    * List of commands and their instance.
-    */
-   private Map<ProgramName, JCommander> m_commands = Maps.newLinkedHashMap();
-   /**
-    * Alias database for reverse lookup
-    */
-   private Map<String, ProgramName> aliasMap = Maps.newLinkedHashMap();
+    /**
+     * List of commands and their instance.
+     */
+    private Map<ProgramName, JCommander> m_commands = Maps.newLinkedHashMap();
+    /**
+     * Alias database for reverse lookup
+     */
+    private Map<String, ProgramName> aliasMap = Maps.newLinkedHashMap();
 
-   /**
-    * The name of the command after the parsing has run.
-    */
-   private String m_parsedCommand;
+    /**
+     * The name of the command after the parsing has run.
+     */
+    private String m_parsedCommand;
 
-   /**
-    * The name of command or alias as it was passed to the
-    * command line
-    */
-   private String m_parsedAlias;
+    /**
+     * The name of command or alias as it was passed to the
+     * command line
+     */
+    private String m_parsedAlias;
 
-   private ProgramName m_programName;
+    private ProgramName m_programName;
 
-   private Comparator<? super ParameterDescription> m_parameterDescriptionComparator
-         = new Comparator<ParameterDescription>() {
-      public int compare(ParameterDescription p0, ParameterDescription p1) {
-         return p0.getLongestName().compareTo(p1.getLongestName());
-      }
-   };
+    private Comparator<? super ParameterDescription> m_parameterDescriptionComparator
+          = new Comparator<ParameterDescription>() {
+        public int compare(ParameterDescription p0, ParameterDescription p1) {
+            return p0.getLongestName().compareTo(p1.getLongestName());
+        }
+    };
 
-   private int m_columnSize = 79;
+    private int m_columnSize = 79;
 
-   private static Console m_console;
+    private static Console m_console;
 
-   /**
-    * The factories used to look up string converters.
-    */
-   private static LinkedList<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newLinkedList();
+    /**
+     * The factories used to look up string converters.
+     */
+    private static LinkedList<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newLinkedList();
 
-   static {
-      CONVERTER_FACTORIES.addFirst(new DefaultConverterFactory());
-   }
+    static {
+        CONVERTER_FACTORIES.addFirst(new DefaultConverterFactory());
+    }
 
-   ;
+    ;
 
-   /**
-    * Creates a new un-configured JCommander object.
-    */
-   public JCommander() {
-   }
+    /**
+     * Creates a new un-configured JCommander object.
+     */
+    public JCommander() {
+    }
 
-   /**
-    * @param object The arg object expected to contain {@link Parameter} annotations.
-    */
-   public JCommander(Object object) {
-      addObject(object);
-      createDescriptions();
-   }
+    /**
+     * @param object The arg object expected to contain {@link Parameter} annotations.
+     */
+    public JCommander(Object object) {
+        addObject(object);
+        createDescriptions();
+    }
 
-   /**
-    * @param object The arg object expected to contain {@link Parameter} annotations.
-    * @param bundle The bundle to use for the descriptions. Can be null.
-    */
-   public JCommander(Object object, ResourceBundle bundle) {
-      addObject(object);
-      setDescriptionsBundle(bundle);
-   }
+    /**
+     * @param object The arg object expected to contain {@link Parameter} annotations.
+     * @param bundle The bundle to use for the descriptions. Can be null.
+     */
+    public JCommander(Object object, ResourceBundle bundle) {
+        addObject(object);
+        setDescriptionsBundle(bundle);
+    }
 
-   /**
-    * @param object The arg object expected to contain {@link Parameter} annotations.
-    * @param bundle The bundle to use for the descriptions. Can be null.
-    * @param args   The arguments to parse (optional).
-    */
-   public JCommander(Object object, ResourceBundle bundle, String... args) {
-      addObject(object);
-      setDescriptionsBundle(bundle);
-      parse(args);
-   }
+    /**
+     * @param object The arg object expected to contain {@link Parameter} annotations.
+     * @param bundle The bundle to use for the descriptions. Can be null.
+     * @param args   The arguments to parse (optional).
+     */
+    public JCommander(Object object, ResourceBundle bundle, String... args) {
+        addObject(object);
+        setDescriptionsBundle(bundle);
+        parse(args);
+    }
 
-   /**
-    * @param object The arg object expected to contain {@link Parameter} annotations.
-    * @param args   The arguments to parse (optional).
-    */
-   public JCommander(Object object, String... args) {
-      addObject(object);
-      parse(args);
-   }
+    /**
+     * @param object The arg object expected to contain {@link Parameter} annotations.
+     * @param args   The arguments to parse (optional).
+     */
+    public JCommander(Object object, String... args) {
+        addObject(object);
+        parse(args);
+    }
 
-   public static Console getConsole() {
-      if (m_console == null) {
-         try {
-            Method consoleMethod = System.class.getDeclaredMethod("console", new Class<?>[0]);
-            Object console = consoleMethod.invoke(null, new Object[0]);
-            m_console = new JDK6Console(console);
-         } catch (Throwable t) {
-            m_console = new DefaultConsole();
-         }
-      }
-      return m_console;
-   }
+    public static Console getConsole() {
+        if (m_console == null) {
+            try {
+                Method consoleMethod = System.class.getDeclaredMethod("console", new Class<?>[0]);
+                Object console = consoleMethod.invoke(null, new Object[0]);
+                m_console = new JDK6Console(console);
+            } catch (Throwable t) {
+                m_console = new DefaultConsole();
+            }
+        }
+        return m_console;
+    }
 
-   /**
-    * Adds the provided arg object to the set of objects that this commander
-    * will parse arguments into.
-    *
-    * @param object The arg object expected to contain {@link Parameter}
-    *               annotations. If <code>object</code> is an array or is {@link Iterable},
-    *               the child objects will be added instead.
-    */
-   // declared final since this is invoked from constructors
-   public final void addObject(Object object) {
-      if (object instanceof Iterable) {
-         // Iterable
-         for (Object o : (Iterable<?>) object) {
-            m_objects.add(o);
-         }
-      } else if (object.getClass().isArray()) {
-         // Array
-         for (Object o : (Object[]) object) {
-            m_objects.add(o);
-         }
-      } else {
-         // Single object
-         m_objects.add(object);
-      }
-   }
+    /**
+     * Adds the provided arg object to the set of objects that this commander
+     * will parse arguments into.
+     *
+     * @param object The arg object expected to contain {@link Parameter}
+     *               annotations. If <code>object</code> is an array or is {@link Iterable},
+     *               the child objects will be added instead.
+     */
+    // declared final since this is invoked from constructors
+    public final void addObject(Object object) {
+        if (object instanceof Iterable) {
+            // Iterable
+            for (Object o : (Iterable<?>) object) {
+                m_objects.add(o);
+            }
+        } else if (object.getClass().isArray()) {
+            // Array
+            for (Object o : (Object[]) object) {
+                m_objects.add(o);
+            }
+        } else {
+            // Single object
+            m_objects.add(object);
+        }
+    }
 
-   /**
-    * Sets the {@link ResourceBundle} to use for looking up descriptions.
-    * Set this to <code>null</code> to use description text directly.
-    */
-   // declared final since this is invoked from constructors
-   public final void setDescriptionsBundle(ResourceBundle bundle) {
-      m_bundle = bundle;
-   }
+    /**
+     * Sets the {@link ResourceBundle} to use for looking up descriptions.
+     * Set this to <code>null</code> to use description text directly.
+     */
+    // declared final since this is invoked from constructors
+    public final void setDescriptionsBundle(ResourceBundle bundle) {
+        m_bundle = bundle;
+    }
 
-   /**
-    * Parse and validate the command line parameters.
-    */
-   public void parse(String... args) {
-      parse(true /* validate */, false, args);
-   }
+    /**
+     * Parse and validate the command line parameters.
+     */
+    public void parse(String... args) {
+        parse(true /* validate */, false, args);
+    }
 
-   /**
-    * Parse the command line parameters without validating them.
-    */
-   public void parseWithoutValidation(String... args) {
-      parse(false /* no validation */, false, args);
-   }
+    /**
+     * Parse the command line parameters without validating them.
+     */
+    public void parseWithoutValidation(String... args) {
+        parse(false /* no validation */, false, args);
+    }
 
-   /**
-    * Parse and validate the command line parameters allowing abbreviated parameters.
-    */
-   public void parseWithAbbreviations(String... args) {
-      parseWithAbbreviations(true, args);
-   }
+    /**
+     * Parse and validate the command line parameters allowing abbreviated parameters.
+     */
+    public void parseWithAbbreviations(String... args) {
+        parseWithAbbreviations(true, args);
+    }
 
-   /**
-    * Parse the command line parameters allowing abbreviated parameters.
-    */
-   public void parseWithAbbreviations(boolean validate, String... args) {
-      parse(validate, true /* allow abbreviations */, args);
-   }
+    /**
+     * Parse the command line parameters allowing abbreviated parameters.
+     */
+    public void parseWithAbbreviations(boolean validate, String... args) {
+        parse(validate, true /* allow abbreviations */, args);
+    }
 
 
-   private void parse(boolean validate, boolean allowAbbreviations, String... args) {
-      StringBuilder sb = new StringBuilder("Parsing \"");
-      sb.append(join(args).append("\"\n  with:").append(join(m_objects.toArray())));
-      p(sb.toString());
+    private void parse(boolean validate, boolean allowAbbreviations, String... args) {
+        StringBuilder sb = new StringBuilder("Parsing \"");
+        sb.append(join(args).append("\"\n  with:").append(join(m_objects.toArray())));
+        p(sb.toString());
 
-      if (m_descriptions == null) createDescriptions();
-      initializeDefaultValues();
-      parseValues(allowAbbreviations, expandArgs(args));
-      if (validate) validateOptions();
-   }
+        if (m_descriptions == null) createDescriptions();
+        initializeDefaultValues();
+        parseValues(allowAbbreviations, expandArgs(args));
+        if (validate) validateOptions();
+    }
 
-   private StringBuilder join(Object[] args) {
-      StringBuilder result = new StringBuilder();
-      for (int i = 0; i < args.length; i++) {
-         if (i > 0) result.append(" ");
-         result.append(args[i]);
-      }
-      return result;
-   }
+    private StringBuilder join(Object[] args) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) result.append(" ");
+            result.append(args[i]);
+        }
+        return result;
+    }
 
-   private void initializeDefaultValues() {
-      if (m_defaultProvider != null) {
-         for (ParameterDescription pd : m_descriptions.values()) {
-            initializeDefaultValue(pd);
-         }
+    private void initializeDefaultValues() {
+        if (m_defaultProvider != null) {
+            for (ParameterDescription pd : m_descriptions.values()) {
+                initializeDefaultValue(pd);
+            }
 
-         for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-            entry.getValue().initializeDefaultValues();
-         }
-      }
-   }
+            for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+                entry.getValue().initializeDefaultValues();
+            }
+        }
+    }
 
-   /**
-    * Make sure that all the required parameters have received a value.
-    */
-   private void validateOptions() {
-      if (!m_requiredFields.isEmpty()) {
-         StringBuilder missingFields = new StringBuilder();
-         for (ParameterDescription pd : m_requiredFields.values()) {
-            missingFields.append(pd.getNames()).append(" ");
-         }
-         throw new ParameterException("The following "
-               + pluralize(m_requiredFields.size(), "option is required: ", "options are required: ")
-               + missingFields);
-      }
+    /**
+     * Make sure that all the required parameters have received a value.
+     */
+    private void validateOptions() {
+        if (!m_requiredFields.isEmpty()) {
+            StringBuilder missingFields = new StringBuilder();
+            for (ParameterDescription pd : m_requiredFields.values()) {
+                missingFields.append(pd.getNames()).append(" ");
+            }
+            throw new ParameterException("The following "
+                  + pluralize(m_requiredFields.size(), "option is required: ", "options are required: ")
+                  + missingFields);
+        }
 
-      if (m_mainParameterDescription != null) {
-         if (m_mainParameterDescription.getParameter().required() &&
-               !m_mainParameterDescription.isAssigned()) {
-            throw new ParameterException("Main parameters are required (\""
-                  + m_mainParameterDescription.getDescription() + "\")");
-         }
-      }
-   }
+        if (m_mainParameterDescription != null) {
+            if (m_mainParameterDescription.getParameter().required() &&
+                  !m_mainParameterDescription.isAssigned()) {
+                throw new ParameterException("Main parameters are required (\""
+                      + m_mainParameterDescription.getDescription() + "\")");
+            }
+        }
+    }
 
-   private static String pluralize(int quantity, String singular, String plural) {
-      return quantity == 1 ? singular : plural;
-   }
+    private static String pluralize(int quantity, String singular, String plural) {
+        return quantity == 1 ? singular : plural;
+    }
 
-   /**
-    * Expand the command line parameters to take @ parameters into account.
-    * When @ is encountered, the content of the file that follows is inserted
-    * in the command line.
-    *
-    * @param originalArgv the original command line parameters
-    * @return the new and enriched command line parameters
-    */
-   private String[] expandArgs(String[] originalArgv) {
-      List<String> vResult1 = Lists.newArrayList();
+    /**
+     * Expand the command line parameters to take @ parameters into account.
+     * When @ is encountered, the content of the file that follows is inserted
+     * in the command line.
+     *
+     * @param originalArgv the original command line parameters
+     * @return the new and enriched command line parameters
+     */
+    private String[] expandArgs(String[] originalArgv) {
+        List<String> vResult1 = Lists.newArrayList();
 
-      //
-      // Expand @
-      //
-      for (String arg : originalArgv) {
+        //
+        // Expand @
+        //
+        for (String arg : originalArgv) {
 
-         if (arg.startsWith("@")) {
-            String fileName = arg.substring(1);
-            vResult1.addAll(readFile(fileName));
-         } else {
-            List<String> expanded = expandDynamicArg(arg);
-            vResult1.addAll(expanded);
-         }
-      }
-
-      // Expand separators
-      //
-      List<String> vResult2 = Lists.newArrayList();
-      for (int i = 0; i < vResult1.size(); i++) {
-         String arg = vResult1.get(i);
-         String[] v1 = vResult1.toArray(new String[0]);
-         if (isOption(v1, arg)) {
-            String sep = getSeparatorFor(v1, arg);
-            if (!" ".equals(sep)) {
-               String[] sp = arg.split("[" + sep + "]", 2);
-               for (String ssp : sp) {
-                  vResult2.add(ssp);
-               }
+            if (arg.startsWith("@")) {
+                String fileName = arg.substring(1);
+                vResult1.addAll(readFile(fileName));
             } else {
-               vResult2.add(arg);
+                List<String> expanded = expandDynamicArg(arg);
+                vResult1.addAll(expanded);
             }
-         } else {
-            vResult2.add(arg);
-         }
-      }
+        }
 
-      return vResult2.toArray(new String[vResult2.size()]);
-   }
-
-   private List<String> expandDynamicArg(String arg) {
-      for (ParameterDescription pd : m_descriptions.values()) {
-         if (pd.isDynamicParameter()) {
-            for (String name : pd.getParameter().names()) {
-               if (arg.startsWith(name) && !arg.equals(name)) {
-                  return Arrays.asList(name, arg.substring(name.length()));
-               }
-            }
-         }
-      }
-
-      return Arrays.asList(arg);
-   }
-
-   private boolean isOption(String[] args, String arg) {
-      String prefixes = getOptionPrefixes(args, arg);
-      return arg.length() > 0 && prefixes.indexOf(arg.charAt(0)) >= 0;
-   }
-
-   private ParameterDescription getPrefixDescriptionFor(String arg) {
-      for (Map.Entry<String, ParameterDescription> es : m_descriptions.entrySet()) {
-         if (arg.startsWith(es.getKey())) return es.getValue();
-      }
-
-      return null;
-   }
-
-   /**
-    * If arg is an option, we can look it up directly, but if it's a value,
-    * we need to find the description for the option that precedes it.
-    */
-   private ParameterDescription getDescriptionFor(String[] args, String arg) {
-      ParameterDescription result = getPrefixDescriptionFor(arg);
-      if (result != null) return result;
-
-      for (String a : args) {
-         ParameterDescription pd = getPrefixDescriptionFor(arg);
-         if (pd != null) result = pd;
-         if (a.equals(arg)) return result;
-      }
-
-      throw new ParameterException("Unknown parameter: " + arg);
-   }
-
-   private String getSeparatorFor(String[] args, String arg) {
-      ParameterDescription pd = getDescriptionFor(args, arg);
-
-      // Could be null if only main parameters were passed
-      if (pd != null) {
-         Parameters p = pd.getObject().getClass().getAnnotation(Parameters.class);
-         if (p != null) return p.separators();
-      }
-
-      return " ";
-   }
-
-   private String getOptionPrefixes(String[] args, String arg) {
-      ParameterDescription pd = getDescriptionFor(args, arg);
-
-      // Could be null if only main parameters were passed
-      if (pd != null) {
-         Parameters p = pd.getObject().getClass()
-               .getAnnotation(Parameters.class);
-         if (p != null) return p.optionPrefixes();
-      }
-      String result = Parameters.DEFAULT_OPTION_PREFIXES;
-
-      // See if any of the objects contains a @Parameters(optionPrefixes)
-      StringBuilder sb = new StringBuilder();
-      for (Object o : m_objects) {
-         Parameters p = o.getClass().getAnnotation(Parameters.class);
-         if (p != null && !Parameters.DEFAULT_OPTION_PREFIXES.equals(p.optionPrefixes())) {
-            sb.append(p.optionPrefixes());
-         }
-      }
-
-      if (!Strings.isStringEmpty(sb.toString())) {
-         result = sb.toString();
-      }
-
-      return result;
-   }
-
-   /**
-    * Reads the file specified by filename and returns the file content as a string.
-    * End of lines are replaced by a space.
-    *
-    * @param fileName the command line filename
-    * @return the file content as a string.
-    */
-   private static List<String> readFile(String fileName) {
-      List<String> result = Lists.newArrayList();
-
-      try {
-         BufferedReader bufRead = new BufferedReader(new FileReader(fileName));
-
-         String line;
-
-         // Read through file one line at time. Print line # and line
-         while ((line = bufRead.readLine()) != null) {
-            // Allow empty lines in these at files
-            if (line.length() > 0) result.add(line);
-         }
-
-         bufRead.close();
-      } catch (IOException e) {
-         throw new ParameterException("Could not read file " + fileName + ": " + e);
-      }
-
-      return result;
-   }
-
-   /**
-    * Remove spaces at both ends and handle double quotes.
-    */
-   private static String trim(String string) {
-      String result = string.trim();
-      if (result.startsWith("\"")) {
-         if (result.endsWith("\"")) {
-            return result.substring(1, result.length() - 1);
-         }
-         return result.substring(1);
-      }
-      return result;
-   }
-
-   /**
-    * Create the ParameterDescriptions for all the \@Parameter found.
-    */
-   private void createDescriptions() {
-      m_descriptions = Maps.newHashMap();
-      m_abbrevMap = new AbbreviationMap<ParameterDescription>();
-
-      for (Object object : m_objects) {
-         addDescription(object);
-      }
-   }
-
-   private void addDescription(Object object) {
-      Class<?> cls = object.getClass();
-
-      while (!Object.class.equals(cls)) {
-         for (Field f : cls.getDeclaredFields()) {
-            p("Field:" + cls.getSimpleName() + "." + f.getName());
-            f.setAccessible(true);
-            Annotation annotation = f.getAnnotation(Parameter.class);
-            Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
-            Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
-            if (annotation != null) {
-               //
-               // @Parameter
-               //
-               Parameter p = (Parameter) annotation;
-               if (p.names().length == 0) {
-                  p("Found main parameter:" + f);
-                  if (m_mainParameterField != null) {
-                     throw new ParameterException("Only one @Parameter with no names attribute is"
-                           + " allowed, found:" + m_mainParameterField + " and " + f);
-                  }
-                  m_mainParameterField = f;
-                  m_mainParameterObject = object;
-                  m_mainParameterAnnotation = p;
-                  m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this);
-               } else {
-                  for (String name : p.names()) {
-                     if (m_descriptions.containsKey(name)) {
-                        throw new ParameterException("Found the option " + name + " multiple times");
-                     }
-                     p("Adding description for " + name);
-                     ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this);
-                     m_fields.put(f, pd);
-                     m_descriptions.put(name, pd);
-                     m_abbrevMap.put(name, pd);
-
-                     if (p.required()) m_requiredFields.put(f, pd);
-                  }
-               }
-            } else if (delegateAnnotation != null) {
-               //
-               // @ParametersDelegate
-               //
-               try {
-                  Object delegateObject = f.get(object);
-                  if (delegateObject == null) {
-                     throw new ParameterException("Delegate field '" + f.getName() + "' cannot be null.");
-                  }
-                  addDescription(delegateObject);
-               } catch (IllegalAccessException e) {
-               }
-            } else if (dynamicParameter != null) {
-               //
-               // @DynamicParameter
-               //
-               DynamicParameter dp = (DynamicParameter) dynamicParameter;
-               for (String name : dp.names()) {
-                  if (m_descriptions.containsKey(name)) {
-                     throw new ParameterException("Found the option " + name + " multiple times");
-                  }
-                  p("Adding description for " + name);
-                  ParameterDescription pd = new ParameterDescription(object, dp, f, m_bundle, this);
-                  m_fields.put(f, pd);
-                  m_descriptions.put(name, pd);
-                  m_abbrevMap.put(name, pd);
-
-                  if (dp.required()) m_requiredFields.put(f, pd);
-               }
-            }
-         }
-         // Traverse the super class until we find Object.class
-         cls = cls.getSuperclass();
-      }
-   }
-
-   private void initializeDefaultValue(ParameterDescription pd) {
-      for (String optionName : pd.getParameter().names()) {
-         String def = m_defaultProvider.getDefaultValueFor(optionName);
-         if (def != null) {
-            p("Initializing " + optionName + " with default value:" + def);
-            pd.addValue(def, true /* default */);
-            return;
-         }
-      }
-   }
-
-   /**
-    * Main method that parses the values and initializes the fields accordingly.
-    */
-   private void parseValues(boolean allowAbbreviations, String[] args) {
-      // This boolean becomes true if we encounter a command, which indicates we need
-      // to stop parsing (the parsing of the command will be done in a sub JCommander
-      // object)
-      boolean commandParsed = false;
-      int i = 0;
-      while (i < args.length && !commandParsed) {
-         String arg = args[i];
-         String a = trim(arg);
-         p("Parsing arg: " + a);
-
-         JCommander jc = findCommandByAlias(arg);
-         int increment = 1;
-         if (isOption(args, a) && jc == null) {
-            //
-            // Option
-            //
-            ParameterDescription pd;
-            if (allowAbbreviations) {
-               pd = m_abbrevMap.get(a);
+        // Expand separators
+        //
+        List<String> vResult2 = Lists.newArrayList();
+        for (int i = 0; i < vResult1.size(); i++) {
+            String arg = vResult1.get(i);
+            String[] v1 = vResult1.toArray(new String[0]);
+            if (isOption(v1, arg)) {
+                String sep = getSeparatorFor(v1, arg);
+                if (!" ".equals(sep)) {
+                    String[] sp = arg.split("[" + sep + "]", 2);
+                    for (String ssp : sp) {
+                        vResult2.add(ssp);
+                    }
+                } else {
+                    vResult2.add(arg);
+                }
             } else {
-               pd = m_descriptions.get(a);
+                vResult2.add(arg);
+            }
+        }
+
+        return vResult2.toArray(new String[vResult2.size()]);
+    }
+
+    private List<String> expandDynamicArg(String arg) {
+        for (ParameterDescription pd : m_descriptions.values()) {
+            if (pd.isDynamicParameter()) {
+                for (String name : pd.getParameter().names()) {
+                    if (arg.startsWith(name) && !arg.equals(name)) {
+                        return Arrays.asList(name, arg.substring(name.length()));
+                    }
+                }
+            }
+        }
+
+        return Arrays.asList(arg);
+    }
+
+    private boolean isOption(String[] args, String arg) {
+        String prefixes = getOptionPrefixes(args, arg);
+        return arg.length() > 0 && prefixes.indexOf(arg.charAt(0)) >= 0;
+    }
+
+    private ParameterDescription getPrefixDescriptionFor(String arg) {
+        for (Map.Entry<String, ParameterDescription> es : m_descriptions.entrySet()) {
+            if (arg.startsWith(es.getKey())) return es.getValue();
+        }
+
+        return null;
+    }
+
+    /**
+     * If arg is an option, we can look it up directly, but if it's a value,
+     * we need to find the description for the option that precedes it.
+     */
+    private ParameterDescription getDescriptionFor(String[] args, String arg) {
+        ParameterDescription result = getPrefixDescriptionFor(arg);
+        if (result != null) return result;
+
+        for (String a : args) {
+            ParameterDescription pd = getPrefixDescriptionFor(arg);
+            if (pd != null) result = pd;
+            if (a.equals(arg)) return result;
+        }
+
+        throw new ParameterException("Unknown parameter: " + arg);
+    }
+
+    private String getSeparatorFor(String[] args, String arg) {
+        ParameterDescription pd = getDescriptionFor(args, arg);
+
+        // Could be null if only main parameters were passed
+        if (pd != null) {
+            Parameters p = pd.getObject().getClass().getAnnotation(Parameters.class);
+            if (p != null) return p.separators();
+        }
+
+        return " ";
+    }
+
+    private String getOptionPrefixes(String[] args, String arg) {
+        ParameterDescription pd = getDescriptionFor(args, arg);
+
+        // Could be null if only main parameters were passed
+        if (pd != null) {
+            Parameters p = pd.getObject().getClass()
+                  .getAnnotation(Parameters.class);
+            if (p != null) return p.optionPrefixes();
+        }
+        String result = Parameters.DEFAULT_OPTION_PREFIXES;
+
+        // See if any of the objects contains a @Parameters(optionPrefixes)
+        StringBuilder sb = new StringBuilder();
+        for (Object o : m_objects) {
+            Parameters p = o.getClass().getAnnotation(Parameters.class);
+            if (p != null && !Parameters.DEFAULT_OPTION_PREFIXES.equals(p.optionPrefixes())) {
+                sb.append(p.optionPrefixes());
+            }
+        }
+
+        if (!Strings.isStringEmpty(sb.toString())) {
+            result = sb.toString();
+        }
+
+        return result;
+    }
+
+    /**
+     * Reads the file specified by filename and returns the file content as a string.
+     * End of lines are replaced by a space.
+     *
+     * @param fileName the command line filename
+     * @return the file content as a string.
+     */
+    private static List<String> readFile(String fileName) {
+        List<String> result = Lists.newArrayList();
+
+        try {
+            BufferedReader bufRead = new BufferedReader(new FileReader(fileName));
+
+            String line;
+
+            // Read through file one line at time. Print line # and line
+            while ((line = bufRead.readLine()) != null) {
+                // Allow empty lines in these at files
+                if (line.length() > 0) result.add(line);
             }
 
-            if (pd != null) {
-               if (pd.getParameter().password()) {
-                  //
-                  // Password option, use the Console to retrieve the password
-                  //
-                  char[] password = readPassword(pd.getDescription());
-                  pd.addValue(new String(password));
-                  m_requiredFields.remove(pd.getField());
-               } else {
-                  if (pd.getParameter().variableArity()) {
-                     //
-                     // Variable arity?
-                     //
-                     increment = processVariableArity(args, i, pd);
-                  } else {
-                     //
-                     // Regular option
-                     //
-                     Class<?> fieldType = pd.getField().getType();
+            bufRead.close();
+        } catch (IOException e) {
+            throw new ParameterException("Could not read file " + fileName + ": " + e);
+        }
 
-                     // Boolean, set to true as soon as we see it, unless it specified
-                     // an arity of 1, in which case we need to read the next value
-                     if ((fieldType == boolean.class || fieldType == Boolean.class)
-                           && pd.getParameter().arity() == -1) {
-                        pd.addValue("true");
+        return result;
+    }
+
+    /**
+     * Remove spaces at both ends and handle double quotes.
+     */
+    private static String trim(String string) {
+        String result = string.trim();
+        if (result.startsWith("\"")) {
+            if (result.endsWith("\"")) {
+                return result.substring(1, result.length() - 1);
+            }
+            return result.substring(1);
+        }
+        return result;
+    }
+
+    /**
+     * Create the ParameterDescriptions for all the \@Parameter found.
+     */
+    private void createDescriptions() {
+        m_descriptions = Maps.newHashMap();
+        m_abbrevMap = new AbbreviationMap<ParameterDescription>();
+
+        for (Object object : m_objects) {
+            addDescription(object);
+        }
+    }
+
+    private void addDescription(Object object) {
+        Class<?> cls = object.getClass();
+
+        while (!Object.class.equals(cls)) {
+            for (Field f : cls.getDeclaredFields()) {
+                p("Field:" + cls.getSimpleName() + "." + f.getName());
+                f.setAccessible(true);
+                Annotation annotation = f.getAnnotation(Parameter.class);
+                Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
+                Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
+                if (annotation != null) {
+                    //
+                    // @Parameter
+                    //
+                    Parameter p = (Parameter) annotation;
+                    if (p.names().length == 0) {
+                        p("Found main parameter:" + f);
+                        if (m_mainParameterField != null) {
+                            throw new ParameterException("Only one @Parameter with no names attribute is"
+                                  + " allowed, found:" + m_mainParameterField + " and " + f);
+                        }
+                        m_mainParameterField = f;
+                        m_mainParameterObject = object;
+                        m_mainParameterAnnotation = p;
+                        m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this);
+                    } else {
+                        for (String name : p.names()) {
+                            if (m_descriptions.containsKey(name)) {
+                                throw new ParameterException("Found the option " + name + " multiple times");
+                            }
+                            p("Adding description for " + name);
+                            ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this);
+                            m_fields.put(f, pd);
+                            m_descriptions.put(name, pd);
+                            m_abbrevMap.put(name, pd);
+
+                            if (p.required()) m_requiredFields.put(f, pd);
+                        }
+                    }
+                } else if (delegateAnnotation != null) {
+                    //
+                    // @ParametersDelegate
+                    //
+                    try {
+                        Object delegateObject = f.get(object);
+                        if (delegateObject == null) {
+                            throw new ParameterException("Delegate field '" + f.getName() + "' cannot be null.");
+                        }
+                        addDescription(delegateObject);
+                    } catch (IllegalAccessException e) {
+                    }
+                } else if (dynamicParameter != null) {
+                    //
+                    // @DynamicParameter
+                    //
+                    DynamicParameter dp = (DynamicParameter) dynamicParameter;
+                    for (String name : dp.names()) {
+                        if (m_descriptions.containsKey(name)) {
+                            throw new ParameterException("Found the option " + name + " multiple times");
+                        }
+                        p("Adding description for " + name);
+                        ParameterDescription pd = new ParameterDescription(object, dp, f, m_bundle, this);
+                        m_fields.put(f, pd);
+                        m_descriptions.put(name, pd);
+                        m_abbrevMap.put(name, pd);
+
+                        if (dp.required()) m_requiredFields.put(f, pd);
+                    }
+                }
+            }
+            // Traverse the super class until we find Object.class
+            cls = cls.getSuperclass();
+        }
+    }
+
+    private void initializeDefaultValue(ParameterDescription pd) {
+        for (String optionName : pd.getParameter().names()) {
+            String def = m_defaultProvider.getDefaultValueFor(optionName);
+            if (def != null) {
+                p("Initializing " + optionName + " with default value:" + def);
+                pd.addValue(def, true /* default */);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Main method that parses the values and initializes the fields accordingly.
+     */
+    private void parseValues(boolean allowAbbreviations, String[] args) {
+        // This boolean becomes true if we encounter a command, which indicates we need
+        // to stop parsing (the parsing of the command will be done in a sub JCommander
+        // object)
+        boolean commandParsed = false;
+        int i = 0;
+        while (i < args.length && !commandParsed) {
+            String arg = args[i];
+            String a = trim(arg);
+            p("Parsing arg: " + a);
+
+            JCommander jc = findCommandByAlias(arg);
+            int increment = 1;
+            if (isOption(args, a) && jc == null) {
+                //
+                // Option
+                //
+                ParameterDescription pd;
+                if (allowAbbreviations) {
+                    pd = m_abbrevMap.get(a);
+                } else {
+                    pd = m_descriptions.get(a);
+                }
+
+                if (pd != null) {
+                    if (pd.getParameter().password()) {
+                        //
+                        // Password option, use the Console to retrieve the password
+                        //
+                        char[] password = readPassword(pd.getDescription());
+                        pd.addValue(new String(password));
                         m_requiredFields.remove(pd.getField());
-                     } else {
-                        increment = processFixedArity(args, i, pd, fieldType);
-                     }
-                  }
-               }
+                    } else {
+                        if (pd.getParameter().variableArity()) {
+                            //
+                            // Variable arity?
+                            //
+                            increment = processVariableArity(args, i, pd);
+                        } else {
+                            //
+                            // Regular option
+                            //
+                            Class<?> fieldType = pd.getField().getType();
+
+                            // Boolean, set to true as soon as we see it, unless it specified
+                            // an arity of 1, in which case we need to read the next value
+                            if ((fieldType == boolean.class || fieldType == Boolean.class)
+                                  && pd.getParameter().arity() == -1) {
+                                pd.addValue("true");
+                                m_requiredFields.remove(pd.getField());
+                            } else {
+                                increment = processFixedArity(args, i, pd, fieldType);
+                            }
+                        }
+                    }
+                } else {
+                    throw new ParameterException("Unknown option: " + arg);
+                }
             } else {
-               throw new ParameterException("Unknown option: " + arg);
+                //
+                // Main parameter
+                //
+                if (!Strings.isStringEmpty(arg)) {
+                    if (m_commands.isEmpty()) {
+                        //
+                        // Regular (non-command) parsing
+                        //
+                        List mp = getMainParameter(arg);
+                        String value = arg;
+                        Object convertedValue = value;
+
+                        if (m_mainParameterField.getGenericType() instanceof ParameterizedType) {
+                            ParameterizedType p = (ParameterizedType) m_mainParameterField.getGenericType();
+                            Type cls = p.getActualTypeArguments()[0];
+                            if (cls instanceof Class) {
+                                convertedValue = convertValue(m_mainParameterField, (Class) cls, value);
+                            }
+                        }
+
+                        ParameterDescription.validateParameter(m_mainParameterAnnotation.validateWith(),
+                              "Default", value);
+
+                        m_mainParameterDescription.setAssigned(true);
+                        mp.add(convertedValue);
+                    } else {
+                        //
+                        // Command parsing
+                        //
+                        if (jc == null) throw new MissingCommandException("Expected a command, got " + arg);
+                        m_parsedCommand = jc.m_programName.m_name;
+                        m_parsedAlias = arg; //preserve the original form
+
+                        // Found a valid command, ask it to parse the remainder of the arguments.
+                        // Setting the boolean commandParsed to true will force the current
+                        // loop to end.
+                        jc.parse(true, allowAbbreviations, subArray(args, i + 1));
+                        commandParsed = true;
+                    }
+                }
             }
-         } else {
-            //
-            // Main parameter
-            //
-            if (!Strings.isStringEmpty(arg)) {
-               if (m_commands.isEmpty()) {
-                  //
-                  // Regular (non-command) parsing
-                  //
-                  List mp = getMainParameter(arg);
-                  String value = arg;
-                  Object convertedValue = value;
+            i += increment;
+        }
 
-                  if (m_mainParameterField.getGenericType() instanceof ParameterizedType) {
-                     ParameterizedType p = (ParameterizedType) m_mainParameterField.getGenericType();
-                     Type cls = p.getActualTypeArguments()[0];
-                     if (cls instanceof Class) {
-                        convertedValue = convertValue(m_mainParameterField, (Class) cls, value);
-                     }
-                  }
-
-                  ParameterDescription.validateParameter(m_mainParameterAnnotation.validateWith(),
-                        "Default", value);
-
-                  m_mainParameterDescription.setAssigned(true);
-                  mp.add(convertedValue);
-               } else {
-                  //
-                  // Command parsing
-                  //
-                  if (jc == null) throw new MissingCommandException("Expected a command, got " + arg);
-                  m_parsedCommand = jc.m_programName.m_name;
-                  m_parsedAlias = arg; //preserve the original form
-
-                  // Found a valid command, ask it to parse the remainder of the arguments.
-                  // Setting the boolean commandParsed to true will force the current
-                  // loop to end.
-                  jc.parse(true, allowAbbreviations, subArray(args, i + 1));
-                  commandParsed = true;
-               }
+        // Mark the parameter descriptions held in m_fields as assigned
+        for (ParameterDescription parameterDescription : m_descriptions.values()) {
+            if (parameterDescription.isAssigned()) {
+                m_fields.get(parameterDescription.getField()).setAssigned(true);
             }
-         }
-         i += increment;
-      }
+        }
 
-      // Mark the parameter descriptions held in m_fields as assigned
-      for (ParameterDescription parameterDescription : m_descriptions.values()) {
-         if (parameterDescription.isAssigned()) {
-            m_fields.get(parameterDescription.getField()).setAssigned(true);
-         }
-      }
+    }
 
-   }
-
-   /**
-    * @return the generic type of the collection for this field, or null if not applicable.
-    */
-   private Type findFieldGenericType(Field field) {
-      if (field.getGenericType() instanceof ParameterizedType) {
-         ParameterizedType p = (ParameterizedType) field.getGenericType();
-         Type cls = p.getActualTypeArguments()[0];
-         if (cls instanceof Class) {
-            return cls;
-         }
-      }
-
-      return null;
-   }
-
-   private class DefaultVariableArity implements IVariableArity {
-
-      public int processVariableArity(String optionName, String[] options) {
-         int i = 0;
-         while (i < options.length && !isOption(options, options[i])) {
-            i++;
-         }
-         return i;
-      }
-   }
-
-   private final IVariableArity DEFAULT_VARIABLE_ARITY = new DefaultVariableArity();
-
-   /**
-    * @return the number of options that were processed.
-    */
-   private int processVariableArity(String[] args, int index, ParameterDescription pd) {
-      Object arg = pd.getObject();
-      IVariableArity va;
-      if (!(arg instanceof IVariableArity)) {
-         va = DEFAULT_VARIABLE_ARITY;
-      } else {
-         va = (IVariableArity) arg;
-      }
-
-      List<String> currentArgs = Lists.newArrayList();
-      for (int j = index + 1; j < args.length; j++) {
-         currentArgs.add(args[j]);
-      }
-      int arity = va.processVariableArity(pd.getParameter().names()[0],
-            currentArgs.toArray(new String[0]));
-
-      int result = processFixedArity(args, index, pd, List.class, arity);
-      return result;
-   }
-
-   private int processFixedArity(String[] args, int index, ParameterDescription pd,
-                                 Class<?> fieldType) {
-      // Regular parameter, use the arity to tell use how many values
-      // we need to consume
-      int arity = pd.getParameter().arity();
-      int n = (arity != -1 ? arity : 1);
-
-      return processFixedArity(args, index, pd, fieldType, n);
-   }
-
-   private int processFixedArity(String[] args, int originalIndex, ParameterDescription pd,
-                                 Class<?> fieldType, int arity) {
-      int index = originalIndex;
-      String arg = args[index];
-      // Special case for boolean parameters of arity 0
-      if (arity == 0 &&
-            (Boolean.class.isAssignableFrom(fieldType)
-                  || boolean.class.isAssignableFrom(fieldType))) {
-         pd.addValue("true");
-         m_requiredFields.remove(pd.getField());
-      } else if (index < args.length - 1) {
-         int offset = "--".equals(args[index + 1]) ? 1 : 0;
-
-         if (index + arity < args.length) {
-            for (int j = 1; j <= arity; j++) {
-               pd.addValue(trim(args[index + j + offset]));
-               m_requiredFields.remove(pd.getField());
+    /**
+     * @return the generic type of the collection for this field, or null if not applicable.
+     */
+    private Type findFieldGenericType(Field field) {
+        if (field.getGenericType() instanceof ParameterizedType) {
+            ParameterizedType p = (ParameterizedType) field.getGenericType();
+            Type cls = p.getActualTypeArguments()[0];
+            if (cls instanceof Class) {
+                return cls;
             }
-            index += arity + offset;
-         } else {
-            throw new ParameterException("Expected " + arity + " values after " + arg);
-         }
-      } else {
-         throw new ParameterException("Expected a value after parameter " + arg);
-      }
+        }
 
-      return arity + 1;
-   }
+        return null;
+    }
 
-   /**
-    * Invoke Console.readPassword through reflection to avoid depending
-    * on Java 6.
-    */
-   private char[] readPassword(String description) {
-      getConsole().print(description + ": ");
-      return getConsole().readPassword();
-   }
+    private class DefaultVariableArity implements IVariableArity {
 
-   private String[] subArray(String[] args, int index) {
-      int l = args.length - index;
-      String[] result = new String[l];
-      System.arraycopy(args, index, result, 0, l);
-
-      return result;
-   }
-
-   /**
-    * @param arg the arg that we're about to add (only passed here to output a meaningful
-    *            error message).
-    * @return the field that's meant to receive all the parameters that are not options.
-    */
-   private List<?> getMainParameter(String arg) {
-      if (m_mainParameterField == null) {
-         throw new ParameterException(
-               "Was passed main parameter '" + arg + "' but no main parameter was defined");
-      }
-
-      try {
-         List result = (List) m_mainParameterField.get(m_mainParameterObject);
-         if (result == null) {
-            result = Lists.newArrayList();
-            if (!List.class.isAssignableFrom(m_mainParameterField.getType())) {
-               throw new ParameterException("Main parameter field " + m_mainParameterField
-                     + " needs to be of type List, not " + m_mainParameterField.getType());
+        public int processVariableArity(String optionName, String[] options) {
+            int i = 0;
+            while (i < options.length && !isOption(options, options[i])) {
+                i++;
             }
-            m_mainParameterField.set(m_mainParameterObject, result);
-         }
-         return result;
-      } catch (IllegalAccessException ex) {
-         throw new ParameterException("Couldn't access main parameter: " + ex.getMessage());
-      }
-   }
+            return i;
+        }
+    }
 
-   public String getMainParameterDescription() {
-      if (m_descriptions == null) createDescriptions();
-      return m_mainParameterAnnotation != null ? m_mainParameterAnnotation.description()
-            : null;
-   }
+    private final IVariableArity DEFAULT_VARIABLE_ARITY = new DefaultVariableArity();
 
-   private int longestName(Collection<?> objects) {
-      int result = 0;
-      for (Object o : objects) {
-         int l = o.toString().length();
-         if (l > result) result = l;
-      }
+    /**
+     * @return the number of options that were processed.
+     */
+    private int processVariableArity(String[] args, int index, ParameterDescription pd) {
+        Object arg = pd.getObject();
+        IVariableArity va;
+        if (!(arg instanceof IVariableArity)) {
+            va = DEFAULT_VARIABLE_ARITY;
+        } else {
+            va = (IVariableArity) arg;
+        }
 
-      return result;
-   }
+        List<String> currentArgs = Lists.newArrayList();
+        for (int j = index + 1; j < args.length; j++) {
+            currentArgs.add(args[j]);
+        }
+        int arity = va.processVariableArity(pd.getParameter().names()[0],
+              currentArgs.toArray(new String[0]));
 
-   /**
-    * Set the program name (used only in the usage).
-    */
-   public void setProgramName(String name) {
-      setProgramName(name, new String[0]);
-   }
+        int result = processFixedArity(args, index, pd, List.class, arity);
+        return result;
+    }
 
-   /**
-    * Set the program name
-    *
-    * @param name    program name
-    * @param aliases aliases to the program name
-    */
-   public void setProgramName(String name, String... aliases) {
-      m_programName = new ProgramName(name, Arrays.asList(aliases));
-   }
+    private int processFixedArity(String[] args, int index, ParameterDescription pd,
+                                  Class<?> fieldType) {
+        // Regular parameter, use the arity to tell use how many values
+        // we need to consume
+        int arity = pd.getParameter().arity();
+        int n = (arity != -1 ? arity : 1);
 
-   /**
-    * Display the usage for this command.
-    */
-   public void usage(String commandName) {
-      StringBuilder sb = new StringBuilder();
-      usage(commandName, sb);
-      getConsole().println(sb.toString());
-   }
+        return processFixedArity(args, index, pd, fieldType, n);
+    }
 
-   /**
-    * Store the help for the command in the passed string builder.
-    */
-   public void usage(String commandName, StringBuilder out) {
-      usage(commandName, out, "");
-   }
+    private int processFixedArity(String[] args, int originalIndex, ParameterDescription pd,
+                                  Class<?> fieldType, int arity) {
+        int index = originalIndex;
+        String arg = args[index];
+        // Special case for boolean parameters of arity 0
+        if (arity == 0 &&
+              (Boolean.class.isAssignableFrom(fieldType)
+                    || boolean.class.isAssignableFrom(fieldType))) {
+            pd.addValue("true");
+            m_requiredFields.remove(pd.getField());
+        } else if (index < args.length - 1) {
+            int offset = "--".equals(args[index + 1]) ? 1 : 0;
 
-   /**
-    * Store the help for the command in the passed string builder, indenting
-    * every line with "indent".
-    */
-   public void usage(String commandName, StringBuilder out, String indent) {
-      String description = getCommandDescription(commandName);
-      JCommander jc = findCommandByAlias(commandName);
-      if (description != null) {
-         out.append(indent).append(description);
-         out.append("\n");
-      }
-      jc.usage(out, indent);
-   }
-
-   /**
-    * @return the description of the command.
-    */
-   public String getCommandDescription(String commandName) {
-      JCommander jc = findCommandByAlias(commandName);
-      if (jc == null) {
-         throw new ParameterException("Asking description for unknown command: " + commandName);
-      }
-
-      Object arg = jc.getObjects().get(0);
-      Parameters p = arg.getClass().getAnnotation(Parameters.class);
-      ResourceBundle bundle = null;
-      String result = null;
-      if (p != null) {
-         result = p.commandDescription();
-         String bundleName = p.resourceBundle();
-         if (!"".equals(bundleName)) {
-            bundle = ResourceBundle.getBundle(bundleName, Locale.getDefault());
-         } else {
-            bundle = m_bundle;
-         }
-
-         if (bundle != null) {
-            result = getI18nString(bundle, p.commandDescriptionKey(), p.commandDescription());
-         }
-      }
-
-      return result;
-   }
-
-   /**
-    * @return The internationalized version of the string if available, otherwise
-    *         return def.
-    */
-   private String getI18nString(ResourceBundle bundle, String key, String def) {
-      String s = bundle != null ? bundle.getString(key) : null;
-      return s != null ? s : def;
-   }
-
-   /**
-    * Display the help on System.out.
-    */
-   public void usage() {
-      StringBuilder sb = new StringBuilder();
-      usage(sb);
-      getConsole().println(sb.toString());
-   }
-
-   /**
-    * Store the help in the passed string builder.
-    */
-   public void usage(StringBuilder out) {
-      usage(out, "");
-   }
-
-   public void usage(StringBuilder out, String indent) {
-      if (m_descriptions == null) createDescriptions();
-      boolean hasCommands = !m_commands.isEmpty();
-
-      //
-      // First line of the usage
-      //
-      String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
-      out.append(indent).append("Usage: " + programName + " [options]");
-      if (hasCommands) out.append(indent).append(" [command] [command options]");
-//    out.append("\n");
-      if (m_mainParameterDescription != null) {
-         out.append(" " + m_mainParameterDescription.getDescription());
-      }
-
-      //
-      // Align the descriptions at the "longestName" column
-      //
-      int longestName = 0;
-      List<ParameterDescription> sorted = Lists.newArrayList();
-      for (ParameterDescription pd : m_fields.values()) {
-         if (!pd.getParameter().hidden()) {
-            sorted.add(pd);
-            // + to have an extra space between the name and the description
-            int length = pd.getNames().length() + 2;
-            if (length > longestName) {
-               longestName = length;
+            if (index + arity < args.length) {
+                for (int j = 1; j <= arity; j++) {
+                    pd.addValue(trim(args[index + j + offset]));
+                    m_requiredFields.remove(pd.getField());
+                }
+                index += arity + offset;
+            } else {
+                throw new ParameterException("Expected " + arity + " values after " + arg);
             }
-         }
-      }
+        } else {
+            throw new ParameterException("Expected a value after parameter " + arg);
+        }
 
-      //
-      // Sort the options
-      //
-      Collections.sort(sorted, getParameterDescriptionComparator());
+        return arity + 1;
+    }
 
-      //
-      // Display all the names and descriptions
-      //
-      if (sorted.size() > 0) out.append(indent).append("\n").append(indent).append("  Options:\n");
-      for (ParameterDescription pd : sorted) {
-         int l = pd.getNames().length();
-         int spaceCount = longestName - l;
-         int start = out.length();
-         WrappedParameter parameter = pd.getParameter();
-         out.append(indent).append("  "
-               + (parameter.required() ? "* " : "  ")
-               + pd.getNames() + s(spaceCount));
-         int indentCount = out.length() - start;
-         wrapDescription(out, indentCount, pd.getDescription());
-         Object def = pd.getDefault();
-         if (pd.isDynamicParameter()) {
-            out.append("\n" + spaces(indentCount + 1))
-                  .append("Syntax: " + parameter.names()[0]
-                        + "key" + parameter.getAssignment()
-                        + "value");
-         }
-         if (def != null && !"".equals(def)) {
-            out.append("\n" + spaces(indentCount + 1))
-                  .append("Default: " + (parameter.password() ? "********" : def));
-         }
-         out.append("\n");
-      }
+    /**
+     * Invoke Console.readPassword through reflection to avoid depending
+     * on Java 6.
+     */
+    private char[] readPassword(String description) {
+        getConsole().print(description + ": ");
+        return getConsole().readPassword();
+    }
 
-      //
-      // If commands were specified, show them as well
-      //
-      if (hasCommands) {
-         out.append("  Commands:\n");
-         // The magic value 3 is the number of spaces between the name of the option
-         // and its description
-         for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
-            ProgramName progName = commands.getKey();
-            String dispName = progName.getDisplayName();
-            out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");
+    private String[] subArray(String[] args, int index) {
+        int l = args.length - index;
+        String[] result = new String[l];
+        System.arraycopy(args, index, result, 0, l);
 
-            // Options for this command
-            usage(progName.getName(), out, "      ");
+        return result;
+    }
+
+    /**
+     * @param arg the arg that we're about to add (only passed here to output a meaningful
+     *            error message).
+     * @return the field that's meant to receive all the parameters that are not options.
+     */
+    private List<?> getMainParameter(String arg) {
+        if (m_mainParameterField == null) {
+            throw new ParameterException(
+                  "Was passed main parameter '" + arg + "' but no main parameter was defined");
+        }
+
+        try {
+            List result = (List) m_mainParameterField.get(m_mainParameterObject);
+            if (result == null) {
+                result = Lists.newArrayList();
+                if (!List.class.isAssignableFrom(m_mainParameterField.getType())) {
+                    throw new ParameterException("Main parameter field " + m_mainParameterField
+                          + " needs to be of type List, not " + m_mainParameterField.getType());
+                }
+                m_mainParameterField.set(m_mainParameterObject, result);
+            }
+            return result;
+        } catch (IllegalAccessException ex) {
+            throw new ParameterException("Couldn't access main parameter: " + ex.getMessage());
+        }
+    }
+
+    public String getMainParameterDescription() {
+        if (m_descriptions == null) createDescriptions();
+        return m_mainParameterAnnotation != null ? m_mainParameterAnnotation.description()
+              : null;
+    }
+
+    private int longestName(Collection<?> objects) {
+        int result = 0;
+        for (Object o : objects) {
+            int l = o.toString().length();
+            if (l > result) result = l;
+        }
+
+        return result;
+    }
+
+    /**
+     * Set the program name (used only in the usage).
+     */
+    public void setProgramName(String name) {
+        setProgramName(name, new String[0]);
+    }
+
+    /**
+     * Set the program name
+     *
+     * @param name    program name
+     * @param aliases aliases to the program name
+     */
+    public void setProgramName(String name, String... aliases) {
+        m_programName = new ProgramName(name, Arrays.asList(aliases));
+    }
+
+    /**
+     * Display the usage for this command.
+     */
+    public void usage(String commandName) {
+        StringBuilder sb = new StringBuilder();
+        usage(commandName, sb);
+        getConsole().println(sb.toString());
+    }
+
+    /**
+     * Store the help for the command in the passed string builder.
+     */
+    public void usage(String commandName, StringBuilder out) {
+        usage(commandName, out, "");
+    }
+
+    /**
+     * Store the help for the command in the passed string builder, indenting
+     * every line with "indent".
+     */
+    public void usage(String commandName, StringBuilder out, String indent) {
+        String description = getCommandDescription(commandName);
+        JCommander jc = findCommandByAlias(commandName);
+        if (description != null) {
+            out.append(indent).append(description);
             out.append("\n");
-         }
-      }
-   }
+        }
+        jc.usage(out, indent);
+    }
 
-   private Comparator<? super ParameterDescription> getParameterDescriptionComparator() {
-      return m_parameterDescriptionComparator;
-   }
+    /**
+     * @return the description of the command.
+     */
+    public String getCommandDescription(String commandName) {
+        JCommander jc = findCommandByAlias(commandName);
+        if (jc == null) {
+            throw new ParameterException("Asking description for unknown command: " + commandName);
+        }
 
-   public void setParameterDescriptionComparator(Comparator<? super ParameterDescription> c) {
-      m_parameterDescriptionComparator = c;
-   }
+        Object arg = jc.getObjects().get(0);
+        Parameters p = arg.getClass().getAnnotation(Parameters.class);
+        ResourceBundle bundle = null;
+        String result = null;
+        if (p != null) {
+            result = p.commandDescription();
+            String bundleName = p.resourceBundle();
+            if (!"".equals(bundleName)) {
+                bundle = ResourceBundle.getBundle(bundleName, Locale.getDefault());
+            } else {
+                bundle = m_bundle;
+            }
 
-   public void setColumnSize(int columnSize) {
-      m_columnSize = columnSize;
-   }
+            if (bundle != null) {
+                result = getI18nString(bundle, p.commandDescriptionKey(), p.commandDescription());
+            }
+        }
 
-   public int getColumnSize() {
-      return m_columnSize;
-   }
+        return result;
+    }
 
-   private void wrapDescription(StringBuilder out, int indent, String description) {
-      int max = getColumnSize();
-      String[] words = description.split(" ");
-      int current = indent;
-      int i = 0;
-      while (i < words.length) {
-         String word = words[i];
-         if (word.length() > max || current + word.length() <= max) {
-            out.append(" ").append(word);
-            current += word.length() + 1;
-         } else {
-            out.append("\n").append(spaces(indent + 1)).append(word);
-            current = indent;
-         }
-         i++;
-      }
-   }
+    /**
+     * @return The internationalized version of the string if available, otherwise
+     *         return def.
+     */
+    private String getI18nString(ResourceBundle bundle, String key, String def) {
+        String s = bundle != null ? bundle.getString(key) : null;
+        return s != null ? s : def;
+    }
 
-   private String spaces(int indent) {
-      StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < indent; i++) sb.append(" ");
-      return sb.toString();
-   }
+    /**
+     * Display the help on System.out.
+     */
+    public void usage() {
+        StringBuilder sb = new StringBuilder();
+        usage(sb);
+        getConsole().println(sb.toString());
+    }
 
-   /**
-    * @return a Collection of all the \@Parameter annotations found on the
-    *         target class. This can be used to display the usage() in a different
-    *         format (e.g. HTML).
-    */
-   public List<ParameterDescription> getParameters() {
-      return new ArrayList<ParameterDescription>(m_fields.values());
-   }
+    /**
+     * Store the help in the passed string builder.
+     */
+    public void usage(StringBuilder out) {
+        usage(out, "");
+    }
 
-   /**
-    * @return the main parameter description or null if none is defined.
-    */
-   public ParameterDescription getMainParameter() {
-      return m_mainParameterDescription;
-   }
+    public void usage(StringBuilder out, String indent) {
+        if (m_descriptions == null) createDescriptions();
+        boolean hasCommands = !m_commands.isEmpty();
 
-   private void p(String string) {
-      if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
-         getConsole().println("[JCommander] " + string);
-      }
-   }
+        //
+        // First line of the usage
+        //
+        String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
+        out.append(indent).append("Usage: " + programName + " [options]");
+        if (hasCommands) out.append(indent).append(" [command] [command options]");
+//    out.append("\n");
+        if (m_mainParameterDescription != null) {
+            out.append(" " + m_mainParameterDescription.getDescription());
+        }
 
-   /**
-    * Define the default provider for this instance.
-    */
-   public void setDefaultProvider(IDefaultProvider defaultProvider) {
-      m_defaultProvider = defaultProvider;
+        //
+        // Align the descriptions at the "longestName" column
+        //
+        int longestName = 0;
+        List<ParameterDescription> sorted = Lists.newArrayList();
+        for (ParameterDescription pd : m_fields.values()) {
+            if (!pd.getParameter().hidden()) {
+                sorted.add(pd);
+                // + to have an extra space between the name and the description
+                int length = pd.getNames().length() + 2;
+                if (length > longestName) {
+                    longestName = length;
+                }
+            }
+        }
 
-      for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-         entry.getValue().setDefaultProvider(defaultProvider);
-      }
-   }
+        //
+        // Sort the options
+        //
+        Collections.sort(sorted, getParameterDescriptionComparator());
 
-   public void addConverterFactory(IStringConverterFactory converterFactory) {
-      CONVERTER_FACTORIES.addFirst(converterFactory);
-   }
+        //
+        // Display all the names and descriptions
+        //
+        if (sorted.size() > 0) out.append(indent).append("\n").append(indent).append("  Options:\n");
+        for (ParameterDescription pd : sorted) {
+            int l = pd.getNames().length();
+            int spaceCount = longestName - l;
+            int start = out.length();
+            WrappedParameter parameter = pd.getParameter();
+            out.append(indent).append("  "
+                  + (parameter.required() ? "* " : "  ")
+                  + pd.getNames() + s(spaceCount));
+            int indentCount = out.length() - start;
+            wrapDescription(out, indentCount, pd.getDescription());
+            Object def = pd.getDefault();
+            if (pd.isDynamicParameter()) {
+                out.append("\n" + spaces(indentCount + 1))
+                      .append("Syntax: " + parameter.names()[0]
+                            + "key" + parameter.getAssignment()
+                            + "value");
+            }
+            if (def != null && !"".equals(def)) {
+                out.append("\n" + spaces(indentCount + 1))
+                      .append("Default: " + (parameter.password() ? "********" : def));
+            }
+            out.append("\n");
+        }
 
-   public <T> Class<? extends IStringConverter<T>> findConverter(Class<T> cls) {
-      for (IStringConverterFactory f : CONVERTER_FACTORIES) {
-         Class<? extends IStringConverter<T>> result = f.getConverter(cls);
-         if (result != null) return result;
-      }
+        //
+        // If commands were specified, show them as well
+        //
+        if (hasCommands) {
+            out.append("  Commands:\n");
+            // The magic value 3 is the number of spaces between the name of the option
+            // and its description
+            for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
+                ProgramName progName = commands.getKey();
+                String dispName = progName.getDisplayName();
+                out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");
 
-      return null;
-   }
+                // Options for this command
+                usage(progName.getName(), out, "      ");
+                out.append("\n");
+            }
+        }
+    }
 
-   public Object convertValue(ParameterDescription pd, String value) {
-      return convertValue(pd.getField(), pd.getField().getType(), value);
-   }
+    private Comparator<? super ParameterDescription> getParameterDescriptionComparator() {
+        return m_parameterDescriptionComparator;
+    }
 
-   /**
-    * @param field The field
-    * @param type  The type of the actual parameter
-    * @param value The value to convert
-    */
-   public Object convertValue(Field field, Class type, String value) {
-      Parameter annotation = field.getAnnotation(Parameter.class);
+    public void setParameterDescriptionComparator(Comparator<? super ParameterDescription> c) {
+        m_parameterDescriptionComparator = c;
+    }
 
-      // Do nothing if it's a @DynamicParameter
-      if (annotation == null) return value;
+    public void setColumnSize(int columnSize) {
+        m_columnSize = columnSize;
+    }
 
-      Class<? extends IStringConverter<?>> converterClass = annotation.converter();
-      boolean listConverterWasSpecified = annotation.listConverter() != NoConverter.class;
+    public int getColumnSize() {
+        return m_columnSize;
+    }
 
-      //
-      // Try to find a converter on the annotation
-      //
-      if (converterClass == null || converterClass == NoConverter.class) {
-         // If no converter specified and type is enum, used enum values to convert
-         if (type.isEnum()) {
-            converterClass = type;
-         } else {
-            converterClass = findConverter(type);
-         }
-      }
+    private void wrapDescription(StringBuilder out, int indent, String description) {
+        int max = getColumnSize();
+        String[] words = description.split(" ");
+        int current = indent;
+        int i = 0;
+        while (i < words.length) {
+            String word = words[i];
+            if (word.length() > max || current + word.length() <= max) {
+                out.append(" ").append(word);
+                current += word.length() + 1;
+            } else {
+                out.append("\n").append(spaces(indent + 1)).append(word);
+                current = indent;
+            }
+            i++;
+        }
+    }
 
-      if (converterClass == null) {
-         Type elementType = findFieldGenericType(field);
-         converterClass = elementType != null
-               ? findConverter((Class<? extends IStringConverter<?>>) elementType)
-               : StringConverter.class;
-      }
+    private String spaces(int indent) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < indent; i++) sb.append(" ");
+        return sb.toString();
+    }
 
-      //
+    /**
+     * @return a Collection of all the \@Parameter annotations found on the
+     *         target class. This can be used to display the usage() in a different
+     *         format (e.g. HTML).
+     */
+    public List<ParameterDescription> getParameters() {
+        return new ArrayList<ParameterDescription>(m_fields.values());
+    }
+
+    /**
+     * @return the main parameter description or null if none is defined.
+     */
+    public ParameterDescription getMainParameter() {
+        return m_mainParameterDescription;
+    }
+
+    private void p(String string) {
+        if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
+            getConsole().println("[JCommander] " + string);
+        }
+    }
+
+    /**
+     * Define the default provider for this instance.
+     */
+    public void setDefaultProvider(IDefaultProvider defaultProvider) {
+        m_defaultProvider = defaultProvider;
+
+        for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+            entry.getValue().setDefaultProvider(defaultProvider);
+        }
+    }
+
+    public void addConverterFactory(IStringConverterFactory converterFactory) {
+        CONVERTER_FACTORIES.addFirst(converterFactory);
+    }
+
+    public <T> Class<? extends IStringConverter<T>> findConverter(Class<T> cls) {
+        for (IStringConverterFactory f : CONVERTER_FACTORIES) {
+            Class<? extends IStringConverter<T>> result = f.getConverter(cls);
+            if (result != null) return result;
+        }
+
+        return null;
+    }
+
+    public Object convertValue(ParameterDescription pd, String value) {
+        return convertValue(pd.getField(), pd.getField().getType(), value);
+    }
+
+    /**
+     * @param field The field
+     * @param type  The type of the actual parameter
+     * @param value The value to convert
+     */
+    public Object convertValue(Field field, Class type, String value) {
+        Parameter annotation = field.getAnnotation(Parameter.class);
+
+        // Do nothing if it's a @DynamicParameter
+        if (annotation == null) return value;
+
+        Class<? extends IStringConverter<?>> converterClass = annotation.converter();
+        boolean listConverterWasSpecified = annotation.listConverter() != NoConverter.class;
+
+        //
+        // Try to find a converter on the annotation
+        //
+        if (converterClass == null || converterClass == NoConverter.class) {
+            // If no converter specified and type is enum, used enum values to convert
+            if (type.isEnum()) {
+                converterClass = type;
+            } else {
+                converterClass = findConverter(type);
+            }
+        }
+
+        if (converterClass == null) {
+            Type elementType = findFieldGenericType(field);
+            converterClass = elementType != null
+                  ? findConverter((Class<? extends IStringConverter<?>>) elementType)
+                  : StringConverter.class;
+        }
+
+        //
 //    //
 //    // Try to find a converter in the factory
 //    //
@@ -1207,265 +1207,265 @@ public class JCommander {
 //          + " to type " + type + " (field: " + field.getName() + ")");
 //    }
 
-      IStringConverter<?> converter;
-      Object result = null;
-      try {
-         String[] names = annotation.names();
-         String optionName = names.length > 0 ? names[0] : "[Main class]";
-         if (converterClass.isEnum()) {
-            try {
-               result = Enum.valueOf((Class<? extends Enum>) converterClass, value.toUpperCase());
-            } catch (Exception e) {
-               throw new ParameterException("Invalid value for " + optionName + " parameter. Allowed values:" +
-                     EnumSet.allOf((Class<? extends Enum>) converterClass));
-            }
-         } else {
-            converter = instantiateConverter(optionName, converterClass);
-            if (type.isAssignableFrom(List.class)
-                  && field.getGenericType() instanceof ParameterizedType) {
-
-               // The field is a List
-               if (listConverterWasSpecified) {
-                  // If a list converter was specified, pass the value to it
-                  // for direct conversion
-                  IStringConverter<?> listConverter =
-                        instantiateConverter(optionName, annotation.listConverter());
-                  result = listConverter.convert(value);
-               } else {
-                  // No list converter: use the single value converter and pass each
-                  // parsed value to it individually
-                  result = convertToList(value, converter, annotation.splitter());
-               }
+        IStringConverter<?> converter;
+        Object result = null;
+        try {
+            String[] names = annotation.names();
+            String optionName = names.length > 0 ? names[0] : "[Main class]";
+            if (converterClass.isEnum()) {
+                try {
+                    result = Enum.valueOf((Class<? extends Enum>) converterClass, value.toUpperCase());
+                } catch (Exception e) {
+                    throw new ParameterException("Invalid value for " + optionName + " parameter. Allowed values:" +
+                          EnumSet.allOf((Class<? extends Enum>) converterClass));
+                }
             } else {
-               result = converter.convert(value);
+                converter = instantiateConverter(optionName, converterClass);
+                if (type.isAssignableFrom(List.class)
+                      && field.getGenericType() instanceof ParameterizedType) {
+
+                    // The field is a List
+                    if (listConverterWasSpecified) {
+                        // If a list converter was specified, pass the value to it
+                        // for direct conversion
+                        IStringConverter<?> listConverter =
+                              instantiateConverter(optionName, annotation.listConverter());
+                        result = listConverter.convert(value);
+                    } else {
+                        // No list converter: use the single value converter and pass each
+                        // parsed value to it individually
+                        result = convertToList(value, converter, annotation.splitter());
+                    }
+                } else {
+                    result = converter.convert(value);
+                }
             }
-         }
-      } catch (InstantiationException e) {
-         throw new ParameterException(e);
-      } catch (IllegalAccessException e) {
-         throw new ParameterException(e);
-      } catch (InvocationTargetException e) {
-         throw new ParameterException(e);
-      }
+        } catch (InstantiationException e) {
+            throw new ParameterException(e);
+        } catch (IllegalAccessException e) {
+            throw new ParameterException(e);
+        } catch (InvocationTargetException e) {
+            throw new ParameterException(e);
+        }
 
-      return result;
-   }
+        return result;
+    }
 
-   /**
-    * Use the splitter to split the value into multiple values and then convert
-    * each of them individually.
-    */
-   private Object convertToList(String value, IStringConverter<?> converter,
-                                Class<? extends IParameterSplitter> splitterClass)
-         throws InstantiationException, IllegalAccessException {
-      IParameterSplitter splitter = splitterClass.newInstance();
-      List<Object> result = Lists.newArrayList();
-      for (String param : splitter.split(value)) {
-         result.add(converter.convert(param));
-      }
-      return result;
-   }
+    /**
+     * Use the splitter to split the value into multiple values and then convert
+     * each of them individually.
+     */
+    private Object convertToList(String value, IStringConverter<?> converter,
+                                 Class<? extends IParameterSplitter> splitterClass)
+          throws InstantiationException, IllegalAccessException {
+        IParameterSplitter splitter = splitterClass.newInstance();
+        List<Object> result = Lists.newArrayList();
+        for (String param : splitter.split(value)) {
+            result.add(converter.convert(param));
+        }
+        return result;
+    }
 
-   private IStringConverter<?> instantiateConverter(String optionName,
-                                                    Class<? extends IStringConverter<?>> converterClass)
-         throws IllegalArgumentException, InstantiationException, IllegalAccessException,
-         InvocationTargetException {
-      Constructor<IStringConverter<?>> ctor = null;
-      Constructor<IStringConverter<?>> stringCtor = null;
-      Constructor<IStringConverter<?>>[] ctors
-            = (Constructor<IStringConverter<?>>[]) converterClass.getDeclaredConstructors();
-      for (Constructor<IStringConverter<?>> c : ctors) {
-         Class<?>[] types = c.getParameterTypes();
-         if (types.length == 1 && types[0].equals(String.class)) {
-            stringCtor = c;
-         } else if (types.length == 0) {
-            ctor = c;
-         }
-      }
-
-      IStringConverter<?> result = stringCtor != null
-            ? stringCtor.newInstance(optionName)
-            : ctor.newInstance();
-
-      return result;
-   }
-
-   /**
-    * Add a command object.
-    */
-   public void addCommand(String name, Object object) {
-      addCommand(name, object, new String[0]);
-   }
-
-   public void addCommand(Object object) {
-      Parameters p = object.getClass().getAnnotation(Parameters.class);
-      if (p != null && p.commandNames().length > 0) {
-         for (String commandName : p.commandNames()) {
-            addCommand(commandName, object);
-         }
-      } else {
-         throw new ParameterException("Trying to add command " + object.getClass().getName()
-               + " without specifying its names in @Parameters");
-      }
-   }
-
-   /**
-    * Add a command object and its aliases.
-    */
-   public void addCommand(String name, Object object, String... aliases) {
-      JCommander jc = new JCommander(object);
-      jc.setProgramName(name, aliases);
-      jc.setDefaultProvider(m_defaultProvider);
-      ProgramName progName = jc.m_programName;
-      m_commands.put(progName, jc);
-
-      /*
-      * Register aliases
-      */
-      //register command name as an alias of itself for reverse lookup
-      //Note: Name clash check is intentionally omitted to resemble the
-      //     original behaviour of clashing commands.
-      //     Aliases are, however, are strictly checked for name clashes.
-      aliasMap.put(name, progName);
-      for (String alias : aliases) {
-         //omit pointless aliases to avoid name clash exception
-         if (!alias.equals(name)) {
-            ProgramName mappedName = aliasMap.get(alias);
-            if (mappedName != null && !mappedName.equals(progName)) {
-               throw new ParameterException("Cannot set alias " + alias
-                     + " for " + name
-                     + " command because it has already been defined for "
-                     + mappedName.m_name + " command");
+    private IStringConverter<?> instantiateConverter(String optionName,
+                                                     Class<? extends IStringConverter<?>> converterClass)
+          throws IllegalArgumentException, InstantiationException, IllegalAccessException,
+          InvocationTargetException {
+        Constructor<IStringConverter<?>> ctor = null;
+        Constructor<IStringConverter<?>> stringCtor = null;
+        Constructor<IStringConverter<?>>[] ctors
+              = (Constructor<IStringConverter<?>>[]) converterClass.getDeclaredConstructors();
+        for (Constructor<IStringConverter<?>> c : ctors) {
+            Class<?>[] types = c.getParameterTypes();
+            if (types.length == 1 && types[0].equals(String.class)) {
+                stringCtor = c;
+            } else if (types.length == 0) {
+                ctor = c;
             }
-            aliasMap.put(alias, progName);
-         }
-      }
-   }
+        }
 
-   public Map<String, JCommander> getCommands() {
-      Map<String, JCommander> res = Maps.newLinkedHashMap();
-      for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-         res.put(entry.getKey().m_name, entry.getValue());
-      }
-      return res;
-   }
+        IStringConverter<?> result = stringCtor != null
+              ? stringCtor.newInstance(optionName)
+              : ctor.newInstance();
 
-   public String getParsedCommand() {
-      return m_parsedCommand;
-   }
+        return result;
+    }
 
-   /**
-    * The name of the command or the alias in the form it was
-    * passed to the command line. <code>null</code> if no
-    * command or alias was specified.
-    *
-    * @return Name of command or alias passed to command line. If none passed: <code>null</code>.
-    */
-   public String getParsedAlias() {
-      return m_parsedAlias;
-   }
+    /**
+     * Add a command object.
+     */
+    public void addCommand(String name, Object object) {
+        addCommand(name, object, new String[0]);
+    }
 
-   /**
-    * @return n spaces
-    */
-   private String s(int count) {
-      StringBuilder result = new StringBuilder();
-      for (int i = 0; i < count; i++) {
-         result.append(" ");
-      }
-
-      return result.toString();
-   }
-
-   /**
-    * @return the objects that JCommander will fill with the result of
-    *         parsing the command line.
-    */
-   public List<Object> getObjects() {
-      return m_objects;
-   }
-
-   /*
-   * Reverse lookup JCommand object by command's name or its alias
-   */
-   private JCommander findCommandByAlias(String commandOrAlias) {
-      ProgramName progName = aliasMap.get(commandOrAlias);
-      if (progName == null) {
-         return null;
-      }
-      JCommander jc = m_commands.get(progName);
-      if (jc == null) {
-         throw new IllegalStateException(
-               "There appears to be inconsistency in the internal command database. " +
-                     " This is likely a bug. Please report.");
-      }
-      return jc;
-   }
-
-   private static final class ProgramName {
-      private final String m_name;
-      private final List<String> m_aliases;
-
-      ProgramName(String name, List<String> aliases) {
-         m_name = name;
-         m_aliases = aliases;
-      }
-
-      public String getName() {
-         return m_name;
-      }
-
-      private String getDisplayName() {
-         StringBuilder sb = new StringBuilder();
-         sb.append(m_name);
-         if (!m_aliases.isEmpty()) {
-            sb.append("(");
-            Iterator<String> aliasesIt = m_aliases.iterator();
-            while (aliasesIt.hasNext()) {
-               sb.append(aliasesIt.next());
-               if (aliasesIt.hasNext()) {
-                  sb.append(",");
-               }
+    public void addCommand(Object object) {
+        Parameters p = object.getClass().getAnnotation(Parameters.class);
+        if (p != null && p.commandNames().length > 0) {
+            for (String commandName : p.commandNames()) {
+                addCommand(commandName, object);
             }
-            sb.append(")");
-         }
-         return sb.toString();
-      }
+        } else {
+            throw new ParameterException("Trying to add command " + object.getClass().getName()
+                  + " without specifying its names in @Parameters");
+        }
+    }
 
-      @Override
-      public int hashCode() {
-         final int prime = 31;
-         int result = 1;
-         result = prime * result + ((m_name == null) ? 0 : m_name.hashCode());
-         return result;
-      }
+    /**
+     * Add a command object and its aliases.
+     */
+    public void addCommand(String name, Object object, String... aliases) {
+        JCommander jc = new JCommander(object);
+        jc.setProgramName(name, aliases);
+        jc.setDefaultProvider(m_defaultProvider);
+        ProgramName progName = jc.m_programName;
+        m_commands.put(progName, jc);
 
-      @Override
-      public boolean equals(Object obj) {
-         if (this == obj)
+        /*
+        * Register aliases
+        */
+        //register command name as an alias of itself for reverse lookup
+        //Note: Name clash check is intentionally omitted to resemble the
+        //     original behaviour of clashing commands.
+        //     Aliases are, however, are strictly checked for name clashes.
+        aliasMap.put(name, progName);
+        for (String alias : aliases) {
+            //omit pointless aliases to avoid name clash exception
+            if (!alias.equals(name)) {
+                ProgramName mappedName = aliasMap.get(alias);
+                if (mappedName != null && !mappedName.equals(progName)) {
+                    throw new ParameterException("Cannot set alias " + alias
+                          + " for " + name
+                          + " command because it has already been defined for "
+                          + mappedName.m_name + " command");
+                }
+                aliasMap.put(alias, progName);
+            }
+        }
+    }
+
+    public Map<String, JCommander> getCommands() {
+        Map<String, JCommander> res = Maps.newLinkedHashMap();
+        for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+            res.put(entry.getKey().m_name, entry.getValue());
+        }
+        return res;
+    }
+
+    public String getParsedCommand() {
+        return m_parsedCommand;
+    }
+
+    /**
+     * The name of the command or the alias in the form it was
+     * passed to the command line. <code>null</code> if no
+     * command or alias was specified.
+     *
+     * @return Name of command or alias passed to command line. If none passed: <code>null</code>.
+     */
+    public String getParsedAlias() {
+        return m_parsedAlias;
+    }
+
+    /**
+     * @return n spaces
+     */
+    private String s(int count) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            result.append(" ");
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * @return the objects that JCommander will fill with the result of
+     *         parsing the command line.
+     */
+    public List<Object> getObjects() {
+        return m_objects;
+    }
+
+    /*
+    * Reverse lookup JCommand object by command's name or its alias
+    */
+    private JCommander findCommandByAlias(String commandOrAlias) {
+        ProgramName progName = aliasMap.get(commandOrAlias);
+        if (progName == null) {
+            return null;
+        }
+        JCommander jc = m_commands.get(progName);
+        if (jc == null) {
+            throw new IllegalStateException(
+                  "There appears to be inconsistency in the internal command database. " +
+                        " This is likely a bug. Please report.");
+        }
+        return jc;
+    }
+
+    private static final class ProgramName {
+        private final String m_name;
+        private final List<String> m_aliases;
+
+        ProgramName(String name, List<String> aliases) {
+            m_name = name;
+            m_aliases = aliases;
+        }
+
+        public String getName() {
+            return m_name;
+        }
+
+        private String getDisplayName() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(m_name);
+            if (!m_aliases.isEmpty()) {
+                sb.append("(");
+                Iterator<String> aliasesIt = m_aliases.iterator();
+                while (aliasesIt.hasNext()) {
+                    sb.append(aliasesIt.next());
+                    if (aliasesIt.hasNext()) {
+                        sb.append(",");
+                    }
+                }
+                sb.append(")");
+            }
+            return sb.toString();
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((m_name == null) ? 0 : m_name.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            ProgramName other = (ProgramName) obj;
+            if (m_name == null) {
+                if (other.m_name != null)
+                    return false;
+            } else if (!m_name.equals(other.m_name))
+                return false;
             return true;
-         if (obj == null)
-            return false;
-         if (getClass() != obj.getClass())
-            return false;
-         ProgramName other = (ProgramName) obj;
-         if (m_name == null) {
-            if (other.m_name != null)
-               return false;
-         } else if (!m_name.equals(other.m_name))
-            return false;
-         return true;
-      }
+        }
 
-      /*
-      * Important: ProgramName#toString() is used by longestName(Collection) function
-      * to format usage output.
-      */
-      @Override
-      public String toString() {
-         return getDisplayName();
+        /*
+        * Important: ProgramName#toString() is used by longestName(Collection) function
+        * to format usage output.
+        */
+        @Override
+        public String toString() {
+            return getDisplayName();
 
-      }
-   }
+        }
+    }
 }
 

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -57,7 +57,7 @@ import java.util.ResourceBundle;
  * The main class for JCommander. It's responsible for parsing the object that contains
  * all the annotated fields, parse the command line and assign the fields with the correct
  * values and a few other helper methods, such as usage().
- *
+ * <p/>
  * The object(s) you pass in the constructor are expected to have one or more
  * \@Parameter annotations on them. You can pass either a single object, an array of objects
  * or an instance of Iterable. In the case of an array or Iterable, JCommander will collect
@@ -66,1133 +66,1133 @@ import java.util.ResourceBundle;
  * @author cbeust
  */
 public class JCommander {
-    public static final String DEBUG_PROPERTY = "jcommander.debug";
+  public static final String DEBUG_PROPERTY = "jcommander.debug";
 
-    /**
-     * A map to look up parameter description per option name.
-     */
-    private Map<String, ParameterDescription> m_descriptions;
+  /**
+   * A map to look up parameter description per option name.
+   */
+  private Map<String, ParameterDescription> m_descriptions;
 
-    /**
-     * Maps abbreviated parameter names to their ful name
-     */
-    private AbbreviationMap<ParameterDescription> m_abbrevMap;
+  /**
+   * Maps abbreviated parameter names to their ful name
+   */
+  private AbbreviationMap<ParameterDescription> m_abbrevMap;
 
-    /**
-     * The objects that contain fields annotated with @Parameter.
-     */
-    private List<Object> m_objects = Lists.newArrayList();
+  /**
+   * The objects that contain fields annotated with @Parameter.
+   */
+  private List<Object> m_objects = Lists.newArrayList();
 
-    /**
-     * This field will contain whatever command line parameter is not an option.
-     * It is expected to be a List<String>.
-     */
-    private Field m_mainParameterField = null;
+  /**
+   * This field will contain whatever command line parameter is not an option.
+   * It is expected to be a List<String>.
+   */
+  private Field m_mainParameterField = null;
 
-    /**
-     * The object on which we found the main parameter field.
-     */
-    private Object m_mainParameterObject;
+  /**
+   * The object on which we found the main parameter field.
+   */
+  private Object m_mainParameterObject;
 
-    /**
-     * The annotation found on the main parameter field.
-     */
-    private Parameter m_mainParameterAnnotation;
+  /**
+   * The annotation found on the main parameter field.
+   */
+  private Parameter m_mainParameterAnnotation;
 
-    private ParameterDescription m_mainParameterDescription;
+  private ParameterDescription m_mainParameterDescription;
 
-    /**
-     * A set of all the fields that are required. During the reflection phase,
-     * this field receives all the fields that are annotated with required=true
-     * and during the parsing phase, all the fields that are assigned a value
-     * are removed from it. At the end of the parsing phase, if it's not empty,
-     * then some required fields did not receive a value and an exception is
-     * thrown.
-     */
-    private Map<Field, ParameterDescription> m_requiredFields = Maps.newHashMap();
+  /**
+   * A set of all the fields that are required. During the reflection phase,
+   * this field receives all the fields that are annotated with required=true
+   * and during the parsing phase, all the fields that are assigned a value
+   * are removed from it. At the end of the parsing phase, if it's not empty,
+   * then some required fields did not receive a value and an exception is
+   * thrown.
+   */
+  private Map<Field, ParameterDescription> m_requiredFields = Maps.newHashMap();
 
-    /**
-     * A map of all the annotated fields.
-     */
-    private Map<Field, ParameterDescription> m_fields = Maps.newHashMap();
+  /**
+   * A map of all the annotated fields.
+   */
+  private Map<Field, ParameterDescription> m_fields = Maps.newHashMap();
 
-    private ResourceBundle m_bundle;
+  private ResourceBundle m_bundle;
 
-    /**
-     * A default provider returns default values for the parameters.
-     */
-    private IDefaultProvider m_defaultProvider;
+  /**
+   * A default provider returns default values for the parameters.
+   */
+  private IDefaultProvider m_defaultProvider;
 
-    /**
-     * List of commands and their instance.
-     */
-    private Map<ProgramName, JCommander> m_commands = Maps.newLinkedHashMap();
-    /**
-     * Alias database for reverse lookup
-     */
-    private Map<String, ProgramName> aliasMap = Maps.newLinkedHashMap();
+  /**
+   * List of commands and their instance.
+   */
+  private Map<ProgramName, JCommander> m_commands = Maps.newLinkedHashMap();
+  /**
+   * Alias database for reverse lookup
+   */
+  private Map<String, ProgramName> aliasMap = Maps.newLinkedHashMap();
 
-    /**
-     * The name of the command after the parsing has run.
-     */
-    private String m_parsedCommand;
+  /**
+   * The name of the command after the parsing has run.
+   */
+  private String m_parsedCommand;
 
-    /**
-     * The name of command or alias as it was passed to the
-     * command line
-     */
-    private String m_parsedAlias;
+  /**
+   * The name of command or alias as it was passed to the
+   * command line
+   */
+  private String m_parsedAlias;
 
-    private ProgramName m_programName;
+  private ProgramName m_programName;
 
-    private Comparator<? super ParameterDescription> m_parameterDescriptionComparator
+  private Comparator<? super ParameterDescription> m_parameterDescriptionComparator
           = new Comparator<ParameterDescription>() {
-        public int compare(ParameterDescription p0, ParameterDescription p1) {
-            return p0.getLongestName().compareTo(p1.getLongestName());
-        }
-    };
+    public int compare(ParameterDescription p0, ParameterDescription p1) {
+      return p0.getLongestName().compareTo(p1.getLongestName());
+    }
+  };
 
-    private int m_columnSize = 79;
+  private int m_columnSize = 79;
 
-    private static Console m_console;
+  private static Console m_console;
 
-    /**
-     * The factories used to look up string converters.
-     */
-    private static LinkedList<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newLinkedList();
+  /**
+   * The factories used to look up string converters.
+   */
+  private static LinkedList<IStringConverterFactory> CONVERTER_FACTORIES = Lists.newLinkedList();
 
-    static {
-        CONVERTER_FACTORIES.addFirst(new DefaultConverterFactory());
+  static {
+    CONVERTER_FACTORIES.addFirst(new DefaultConverterFactory());
+  }
+
+  ;
+
+  /**
+   * Creates a new un-configured JCommander object.
+   */
+  public JCommander() {
+  }
+
+  /**
+   * @param object The arg object expected to contain {@link Parameter} annotations.
+   */
+  public JCommander(Object object) {
+    addObject(object);
+    createDescriptions();
+  }
+
+  /**
+   * @param object The arg object expected to contain {@link Parameter} annotations.
+   * @param bundle The bundle to use for the descriptions. Can be null.
+   */
+  public JCommander(Object object, ResourceBundle bundle) {
+    addObject(object);
+    setDescriptionsBundle(bundle);
+  }
+
+  /**
+   * @param object The arg object expected to contain {@link Parameter} annotations.
+   * @param bundle The bundle to use for the descriptions. Can be null.
+   * @param args   The arguments to parse (optional).
+   */
+  public JCommander(Object object, ResourceBundle bundle, String... args) {
+    addObject(object);
+    setDescriptionsBundle(bundle);
+    parse(args);
+  }
+
+  /**
+   * @param object The arg object expected to contain {@link Parameter} annotations.
+   * @param args   The arguments to parse (optional).
+   */
+  public JCommander(Object object, String... args) {
+    addObject(object);
+    parse(args);
+  }
+
+  public static Console getConsole() {
+    if (m_console == null) {
+      try {
+        Method consoleMethod = System.class.getDeclaredMethod("console", new Class<?>[0]);
+        Object console = consoleMethod.invoke(null, new Object[0]);
+        m_console = new JDK6Console(console);
+      } catch (Throwable t) {
+        m_console = new DefaultConsole();
+      }
+    }
+    return m_console;
+  }
+
+  /**
+   * Adds the provided arg object to the set of objects that this commander
+   * will parse arguments into.
+   *
+   * @param object The arg object expected to contain {@link Parameter}
+   *               annotations. If <code>object</code> is an array or is {@link Iterable},
+   *               the child objects will be added instead.
+   */
+  // declared final since this is invoked from constructors
+  public final void addObject(Object object) {
+    if (object instanceof Iterable) {
+      // Iterable
+      for (Object o : (Iterable<?>) object) {
+        m_objects.add(o);
+      }
+    } else if (object.getClass().isArray()) {
+      // Array
+      for (Object o : (Object[]) object) {
+        m_objects.add(o);
+      }
+    } else {
+      // Single object
+      m_objects.add(object);
+    }
+  }
+
+  /**
+   * Sets the {@link ResourceBundle} to use for looking up descriptions.
+   * Set this to <code>null</code> to use description text directly.
+   */
+  // declared final since this is invoked from constructors
+  public final void setDescriptionsBundle(ResourceBundle bundle) {
+    m_bundle = bundle;
+  }
+
+  /**
+   * Parse and validate the command line parameters.
+   */
+  public void parse(String... args) {
+    parse(true /* validate */, false, args);
+  }
+
+  /**
+   * Parse the command line parameters without validating them.
+   */
+  public void parseWithoutValidation(String... args) {
+    parse(false /* no validation */, false, args);
+  }
+
+  /**
+   * Parse and validate the command line parameters allowing abbreviated parameters.
+   */
+  public void parseWithAbbreviations(String... args) {
+    parseWithAbbreviations(true, args);
+  }
+
+  /**
+   * Parse the command line parameters allowing abbreviated parameters.
+   */
+  public void parseWithAbbreviations(boolean validate, String... args) {
+    parse(validate, true /* allow abbreviations */, args);
+  }
+
+
+  private void parse(boolean validate, boolean allowAbbreviations, String... args) {
+    StringBuilder sb = new StringBuilder("Parsing \"");
+    sb.append(join(args).append("\"\n  with:").append(join(m_objects.toArray())));
+    p(sb.toString());
+
+    if (m_descriptions == null) createDescriptions();
+    initializeDefaultValues();
+    parseValues(allowAbbreviations, expandArgs(args));
+    if (validate) validateOptions();
+  }
+
+  private StringBuilder join(Object[] args) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < args.length; i++) {
+      if (i > 0) result.append(" ");
+      result.append(args[i]);
+    }
+    return result;
+  }
+
+  private void initializeDefaultValues() {
+    if (m_defaultProvider != null) {
+      for (ParameterDescription pd : m_descriptions.values()) {
+        initializeDefaultValue(pd);
+      }
+
+      for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+        entry.getValue().initializeDefaultValues();
+      }
+    }
+  }
+
+  /**
+   * Make sure that all the required parameters have received a value.
+   */
+  private void validateOptions() {
+    if (!m_requiredFields.isEmpty()) {
+      StringBuilder missingFields = new StringBuilder();
+      for (ParameterDescription pd : m_requiredFields.values()) {
+        missingFields.append(pd.getNames()).append(" ");
+      }
+      throw new ParameterException("The following "
+              + pluralize(m_requiredFields.size(), "option is required: ", "options are required: ")
+              + missingFields);
     }
 
-    ;
+    if (m_mainParameterDescription != null) {
+      if (m_mainParameterDescription.getParameter().required() &&
+              !m_mainParameterDescription.isAssigned()) {
+        throw new ParameterException("Main parameters are required (\""
+                + m_mainParameterDescription.getDescription() + "\")");
+      }
+    }
+  }
 
-    /**
-     * Creates a new un-configured JCommander object.
-     */
-    public JCommander() {
+  private static String pluralize(int quantity, String singular, String plural) {
+    return quantity == 1 ? singular : plural;
+  }
+
+  /**
+   * Expand the command line parameters to take @ parameters into account.
+   * When @ is encountered, the content of the file that follows is inserted
+   * in the command line.
+   *
+   * @param originalArgv the original command line parameters
+   * @return the new and enriched command line parameters
+   */
+  private String[] expandArgs(String[] originalArgv) {
+    List<String> vResult1 = Lists.newArrayList();
+
+    //
+    // Expand @
+    //
+    for (String arg : originalArgv) {
+
+      if (arg.startsWith("@")) {
+        String fileName = arg.substring(1);
+        vResult1.addAll(readFile(fileName));
+      } else {
+        List<String> expanded = expandDynamicArg(arg);
+        vResult1.addAll(expanded);
+      }
     }
 
-    /**
-     * @param object The arg object expected to contain {@link Parameter} annotations.
-     */
-    public JCommander(Object object) {
-        addObject(object);
-        createDescriptions();
-    }
-
-    /**
-     * @param object The arg object expected to contain {@link Parameter} annotations.
-     * @param bundle The bundle to use for the descriptions. Can be null.
-     */
-    public JCommander(Object object, ResourceBundle bundle) {
-        addObject(object);
-        setDescriptionsBundle(bundle);
-    }
-
-    /**
-     * @param object The arg object expected to contain {@link Parameter} annotations.
-     * @param bundle The bundle to use for the descriptions. Can be null.
-     * @param args   The arguments to parse (optional).
-     */
-    public JCommander(Object object, ResourceBundle bundle, String... args) {
-        addObject(object);
-        setDescriptionsBundle(bundle);
-        parse(args);
-    }
-
-    /**
-     * @param object The arg object expected to contain {@link Parameter} annotations.
-     * @param args   The arguments to parse (optional).
-     */
-    public JCommander(Object object, String... args) {
-        addObject(object);
-        parse(args);
-    }
-
-    public static Console getConsole() {
-        if (m_console == null) {
-            try {
-                Method consoleMethod = System.class.getDeclaredMethod("console", new Class<?>[0]);
-                Object console = consoleMethod.invoke(null, new Object[0]);
-                m_console = new JDK6Console(console);
-            } catch (Throwable t) {
-                m_console = new DefaultConsole();
-            }
-        }
-        return m_console;
-    }
-
-    /**
-     * Adds the provided arg object to the set of objects that this commander
-     * will parse arguments into.
-     *
-     * @param object The arg object expected to contain {@link Parameter}
-     *               annotations. If <code>object</code> is an array or is {@link Iterable},
-     *               the child objects will be added instead.
-     */
-    // declared final since this is invoked from constructors
-    public final void addObject(Object object) {
-        if (object instanceof Iterable) {
-            // Iterable
-            for (Object o : (Iterable<?>) object) {
-                m_objects.add(o);
-            }
-        } else if (object.getClass().isArray()) {
-            // Array
-            for (Object o : (Object[]) object) {
-                m_objects.add(o);
-            }
+    // Expand separators
+    //
+    List<String> vResult2 = Lists.newArrayList();
+    for (int i = 0; i < vResult1.size(); i++) {
+      String arg = vResult1.get(i);
+      String[] v1 = vResult1.toArray(new String[0]);
+      if (isOption(v1, arg)) {
+        String sep = getSeparatorFor(v1, arg);
+        if (!" ".equals(sep)) {
+          String[] sp = arg.split("[" + sep + "]", 2);
+          for (String ssp : sp) {
+            vResult2.add(ssp);
+          }
         } else {
-            // Single object
-            m_objects.add(object);
+          vResult2.add(arg);
         }
+      } else {
+        vResult2.add(arg);
+      }
     }
 
-    /**
-     * Sets the {@link ResourceBundle} to use for looking up descriptions.
-     * Set this to <code>null</code> to use description text directly.
-     */
-    // declared final since this is invoked from constructors
-    public final void setDescriptionsBundle(ResourceBundle bundle) {
-        m_bundle = bundle;
-    }
+    return vResult2.toArray(new String[vResult2.size()]);
+  }
 
-    /**
-     * Parse and validate the command line parameters.
-     */
-    public void parse(String... args) {
-        parse(true /* validate */, false, args);
-    }
-
-    /**
-     * Parse the command line parameters without validating them.
-     */
-    public void parseWithoutValidation(String... args) {
-        parse(false /* no validation */, false, args);
-    }
-
-    /**
-     * Parse and validate the command line parameters allowing abbreviated parameters.
-     */
-    public void parseWithAbbreviations(String... args) {
-        parseWithAbbreviations(true, args);
-    }
-
-    /**
-     * Parse the command line parameters allowing abbreviated parameters.
-     */
-    public void parseWithAbbreviations(boolean validate, String... args) {
-        parse(validate, true /* allow abbreviations */, args);
-    }
-
-
-    private void parse(boolean validate, boolean allowAbbreviations, String... args) {
-        StringBuilder sb = new StringBuilder("Parsing \"");
-        sb.append(join(args).append("\"\n  with:").append(join(m_objects.toArray())));
-        p(sb.toString());
-
-        if (m_descriptions == null) createDescriptions();
-        initializeDefaultValues();
-        parseValues(allowAbbreviations, expandArgs(args));
-        if (validate) validateOptions();
-    }
-
-    private StringBuilder join(Object[] args) {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < args.length; i++) {
-            if (i > 0) result.append(" ");
-            result.append(args[i]);
+  private List<String> expandDynamicArg(String arg) {
+    for (ParameterDescription pd : m_descriptions.values()) {
+      if (pd.isDynamicParameter()) {
+        for (String name : pd.getParameter().names()) {
+          if (arg.startsWith(name) && !arg.equals(name)) {
+            return Arrays.asList(name, arg.substring(name.length()));
+          }
         }
-        return result;
+      }
     }
 
-    private void initializeDefaultValues() {
-        if (m_defaultProvider != null) {
-            for (ParameterDescription pd : m_descriptions.values()) {
-                initializeDefaultValue(pd);
+    return Arrays.asList(arg);
+  }
+
+  private boolean isOption(String[] args, String arg) {
+    String prefixes = getOptionPrefixes(args, arg);
+    return arg.length() > 0 && prefixes.indexOf(arg.charAt(0)) >= 0;
+  }
+
+  private ParameterDescription getPrefixDescriptionFor(String arg) {
+    for (Map.Entry<String, ParameterDescription> es : m_descriptions.entrySet()) {
+      if (arg.startsWith(es.getKey())) return es.getValue();
+    }
+
+    return null;
+  }
+
+  /**
+   * If arg is an option, we can look it up directly, but if it's a value,
+   * we need to find the description for the option that precedes it.
+   */
+  private ParameterDescription getDescriptionFor(String[] args, String arg) {
+    ParameterDescription result = getPrefixDescriptionFor(arg);
+    if (result != null) return result;
+
+    for (String a : args) {
+      ParameterDescription pd = getPrefixDescriptionFor(arg);
+      if (pd != null) result = pd;
+      if (a.equals(arg)) return result;
+    }
+
+    throw new ParameterException("Unknown parameter: " + arg);
+  }
+
+  private String getSeparatorFor(String[] args, String arg) {
+    ParameterDescription pd = getDescriptionFor(args, arg);
+
+    // Could be null if only main parameters were passed
+    if (pd != null) {
+      Parameters p = pd.getObject().getClass().getAnnotation(Parameters.class);
+      if (p != null) return p.separators();
+    }
+
+    return " ";
+  }
+
+  private String getOptionPrefixes(String[] args, String arg) {
+    ParameterDescription pd = getDescriptionFor(args, arg);
+
+    // Could be null if only main parameters were passed
+    if (pd != null) {
+      Parameters p = pd.getObject().getClass()
+              .getAnnotation(Parameters.class);
+      if (p != null) return p.optionPrefixes();
+    }
+    String result = Parameters.DEFAULT_OPTION_PREFIXES;
+
+    // See if any of the objects contains a @Parameters(optionPrefixes)
+    StringBuilder sb = new StringBuilder();
+    for (Object o : m_objects) {
+      Parameters p = o.getClass().getAnnotation(Parameters.class);
+      if (p != null && !Parameters.DEFAULT_OPTION_PREFIXES.equals(p.optionPrefixes())) {
+        sb.append(p.optionPrefixes());
+      }
+    }
+
+    if (!Strings.isStringEmpty(sb.toString())) {
+      result = sb.toString();
+    }
+
+    return result;
+  }
+
+  /**
+   * Reads the file specified by filename and returns the file content as a string.
+   * End of lines are replaced by a space.
+   *
+   * @param fileName the command line filename
+   * @return the file content as a string.
+   */
+  private static List<String> readFile(String fileName) {
+    List<String> result = Lists.newArrayList();
+
+    try {
+      BufferedReader bufRead = new BufferedReader(new FileReader(fileName));
+
+      String line;
+
+      // Read through file one line at time. Print line # and line
+      while ((line = bufRead.readLine()) != null) {
+        // Allow empty lines in these at files
+        if (line.length() > 0) result.add(line);
+      }
+
+      bufRead.close();
+    } catch (IOException e) {
+      throw new ParameterException("Could not read file " + fileName + ": " + e);
+    }
+
+    return result;
+  }
+
+  /**
+   * Remove spaces at both ends and handle double quotes.
+   */
+  private static String trim(String string) {
+    String result = string.trim();
+    if (result.startsWith("\"")) {
+      if (result.endsWith("\"")) {
+        return result.substring(1, result.length() - 1);
+      }
+      return result.substring(1);
+    }
+    return result;
+  }
+
+  /**
+   * Create the ParameterDescriptions for all the \@Parameter found.
+   */
+  private void createDescriptions() {
+    m_descriptions = Maps.newHashMap();
+    m_abbrevMap = new AbbreviationMap<ParameterDescription>();
+
+    for (Object object : m_objects) {
+      addDescription(object);
+    }
+  }
+
+  private void addDescription(Object object) {
+    Class<?> cls = object.getClass();
+
+    while (!Object.class.equals(cls)) {
+      for (Field f : cls.getDeclaredFields()) {
+        p("Field:" + cls.getSimpleName() + "." + f.getName());
+        f.setAccessible(true);
+        Annotation annotation = f.getAnnotation(Parameter.class);
+        Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
+        Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
+        if (annotation != null) {
+          //
+          // @Parameter
+          //
+          Parameter p = (Parameter) annotation;
+          if (p.names().length == 0) {
+            p("Found main parameter:" + f);
+            if (m_mainParameterField != null) {
+              throw new ParameterException("Only one @Parameter with no names attribute is"
+                      + " allowed, found:" + m_mainParameterField + " and " + f);
             }
+            m_mainParameterField = f;
+            m_mainParameterObject = object;
+            m_mainParameterAnnotation = p;
+            m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this);
+          } else {
+            for (String name : p.names()) {
+              if (m_descriptions.containsKey(name)) {
+                throw new ParameterException("Found the option " + name + " multiple times");
+              }
+              p("Adding description for " + name);
+              ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this);
+              m_fields.put(f, pd);
+              m_descriptions.put(name, pd);
+              m_abbrevMap.put(name, pd);
 
-            for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-                entry.getValue().initializeDefaultValues();
+              if (p.required()) m_requiredFields.put(f, pd);
             }
-        }
-    }
-
-    /**
-     * Make sure that all the required parameters have received a value.
-     */
-    private void validateOptions() {
-        if (!m_requiredFields.isEmpty()) {
-            StringBuilder missingFields = new StringBuilder();
-            for (ParameterDescription pd : m_requiredFields.values()) {
-                missingFields.append(pd.getNames()).append(" ");
+          }
+        } else if (delegateAnnotation != null) {
+          //
+          // @ParametersDelegate
+          //
+          try {
+            Object delegateObject = f.get(object);
+            if (delegateObject == null) {
+              throw new ParameterException("Delegate field '" + f.getName() + "' cannot be null.");
             }
-            throw new ParameterException("The following "
-                  + pluralize(m_requiredFields.size(), "option is required: ", "options are required: ")
-                  + missingFields);
-        }
-
-        if (m_mainParameterDescription != null) {
-            if (m_mainParameterDescription.getParameter().required() &&
-                  !m_mainParameterDescription.isAssigned()) {
-                throw new ParameterException("Main parameters are required (\""
-                      + m_mainParameterDescription.getDescription() + "\")");
+            addDescription(delegateObject);
+          } catch (IllegalAccessException e) {
+          }
+        } else if (dynamicParameter != null) {
+          //
+          // @DynamicParameter
+          //
+          DynamicParameter dp = (DynamicParameter) dynamicParameter;
+          for (String name : dp.names()) {
+            if (m_descriptions.containsKey(name)) {
+              throw new ParameterException("Found the option " + name + " multiple times");
             }
+            p("Adding description for " + name);
+            ParameterDescription pd = new ParameterDescription(object, dp, f, m_bundle, this);
+            m_fields.put(f, pd);
+            m_descriptions.put(name, pd);
+            m_abbrevMap.put(name, pd);
+
+            if (dp.required()) m_requiredFields.put(f, pd);
+          }
         }
+      }
+      // Traverse the super class until we find Object.class
+      cls = cls.getSuperclass();
     }
+  }
 
-    private static String pluralize(int quantity, String singular, String plural) {
-        return quantity == 1 ? singular : plural;
+  private void initializeDefaultValue(ParameterDescription pd) {
+    for (String optionName : pd.getParameter().names()) {
+      String def = m_defaultProvider.getDefaultValueFor(optionName);
+      if (def != null) {
+        p("Initializing " + optionName + " with default value:" + def);
+        pd.addValue(def, true /* default */);
+        return;
+      }
     }
+  }
 
-    /**
-     * Expand the command line parameters to take @ parameters into account.
-     * When @ is encountered, the content of the file that follows is inserted
-     * in the command line.
-     *
-     * @param originalArgv the original command line parameters
-     * @return the new and enriched command line parameters
-     */
-    private String[] expandArgs(String[] originalArgv) {
-        List<String> vResult1 = Lists.newArrayList();
+  /**
+   * Main method that parses the values and initializes the fields accordingly.
+   */
+  private void parseValues(boolean allowAbbreviations, String[] args) {
+    // This boolean becomes true if we encounter a command, which indicates we need
+    // to stop parsing (the parsing of the command will be done in a sub JCommander
+    // object)
+    boolean commandParsed = false;
+    int i = 0;
+    while (i < args.length && !commandParsed) {
+      String arg = args[i];
+      String a = trim(arg);
+      p("Parsing arg: " + a);
 
+      JCommander jc = findCommandByAlias(arg);
+      int increment = 1;
+      if (isOption(args, a) && jc == null) {
         //
-        // Expand @
+        // Option
         //
-        for (String arg : originalArgv) {
-
-            if (arg.startsWith("@")) {
-                String fileName = arg.substring(1);
-                vResult1.addAll(readFile(fileName));
-            } else {
-                List<String> expanded = expandDynamicArg(arg);
-                vResult1.addAll(expanded);
-            }
-        }
-
-        // Expand separators
-        //
-        List<String> vResult2 = Lists.newArrayList();
-        for (int i = 0; i < vResult1.size(); i++) {
-            String arg = vResult1.get(i);
-            String[] v1 = vResult1.toArray(new String[0]);
-            if (isOption(v1, arg)) {
-                String sep = getSeparatorFor(v1, arg);
-                if (!" ".equals(sep)) {
-                    String[] sp = arg.split("[" + sep + "]", 2);
-                    for (String ssp : sp) {
-                        vResult2.add(ssp);
-                    }
-                } else {
-                    vResult2.add(arg);
-                }
-            } else {
-                vResult2.add(arg);
-            }
-        }
-
-        return vResult2.toArray(new String[vResult2.size()]);
-    }
-
-    private List<String> expandDynamicArg(String arg) {
-        for (ParameterDescription pd : m_descriptions.values()) {
-            if (pd.isDynamicParameter()) {
-                for (String name : pd.getParameter().names()) {
-                    if (arg.startsWith(name) && !arg.equals(name)) {
-                        return Arrays.asList(name, arg.substring(name.length()));
-                    }
-                }
-            }
-        }
-
-        return Arrays.asList(arg);
-    }
-
-    private boolean isOption(String[] args, String arg) {
-        String prefixes = getOptionPrefixes(args, arg);
-        return arg.length() > 0 && prefixes.indexOf(arg.charAt(0)) >= 0;
-    }
-
-    private ParameterDescription getPrefixDescriptionFor(String arg) {
-        for (Map.Entry<String, ParameterDescription> es : m_descriptions.entrySet()) {
-            if (arg.startsWith(es.getKey())) return es.getValue();
-        }
-
-        return null;
-    }
-
-    /**
-     * If arg is an option, we can look it up directly, but if it's a value,
-     * we need to find the description for the option that precedes it.
-     */
-    private ParameterDescription getDescriptionFor(String[] args, String arg) {
-        ParameterDescription result = getPrefixDescriptionFor(arg);
-        if (result != null) return result;
-
-        for (String a : args) {
-            ParameterDescription pd = getPrefixDescriptionFor(arg);
-            if (pd != null) result = pd;
-            if (a.equals(arg)) return result;
-        }
-
-        throw new ParameterException("Unknown parameter: " + arg);
-    }
-
-    private String getSeparatorFor(String[] args, String arg) {
-        ParameterDescription pd = getDescriptionFor(args, arg);
-
-        // Could be null if only main parameters were passed
-        if (pd != null) {
-            Parameters p = pd.getObject().getClass().getAnnotation(Parameters.class);
-            if (p != null) return p.separators();
-        }
-
-        return " ";
-    }
-
-    private String getOptionPrefixes(String[] args, String arg) {
-        ParameterDescription pd = getDescriptionFor(args, arg);
-
-        // Could be null if only main parameters were passed
-        if (pd != null) {
-            Parameters p = pd.getObject().getClass()
-                  .getAnnotation(Parameters.class);
-            if (p != null) return p.optionPrefixes();
-        }
-        String result = Parameters.DEFAULT_OPTION_PREFIXES;
-
-        // See if any of the objects contains a @Parameters(optionPrefixes)
-        StringBuilder sb = new StringBuilder();
-        for (Object o : m_objects) {
-            Parameters p = o.getClass().getAnnotation(Parameters.class);
-            if (p != null && !Parameters.DEFAULT_OPTION_PREFIXES.equals(p.optionPrefixes())) {
-                sb.append(p.optionPrefixes());
-            }
-        }
-
-        if (!Strings.isStringEmpty(sb.toString())) {
-            result = sb.toString();
-        }
-
-        return result;
-    }
-
-    /**
-     * Reads the file specified by filename and returns the file content as a string.
-     * End of lines are replaced by a space.
-     *
-     * @param fileName the command line filename
-     * @return the file content as a string.
-     */
-    private static List<String> readFile(String fileName) {
-        List<String> result = Lists.newArrayList();
-
-        try {
-            BufferedReader bufRead = new BufferedReader(new FileReader(fileName));
-
-            String line;
-
-            // Read through file one line at time. Print line # and line
-            while ((line = bufRead.readLine()) != null) {
-                // Allow empty lines in these at files
-                if (line.length() > 0) result.add(line);
-            }
-
-            bufRead.close();
-        } catch (IOException e) {
-            throw new ParameterException("Could not read file " + fileName + ": " + e);
-        }
-
-        return result;
-    }
-
-    /**
-     * Remove spaces at both ends and handle double quotes.
-     */
-    private static String trim(String string) {
-        String result = string.trim();
-        if (result.startsWith("\"")) {
-            if (result.endsWith("\"")) {
-                return result.substring(1, result.length() - 1);
-            }
-            return result.substring(1);
-        }
-        return result;
-    }
-
-    /**
-     * Create the ParameterDescriptions for all the \@Parameter found.
-     */
-    private void createDescriptions() {
-        m_descriptions = Maps.newHashMap();
-        m_abbrevMap = new AbbreviationMap<ParameterDescription>();
-
-        for (Object object : m_objects) {
-            addDescription(object);
-        }
-    }
-
-    private void addDescription(Object object) {
-        Class<?> cls = object.getClass();
-
-        while (!Object.class.equals(cls)) {
-            for (Field f : cls.getDeclaredFields()) {
-                p("Field:" + cls.getSimpleName() + "." + f.getName());
-                f.setAccessible(true);
-                Annotation annotation = f.getAnnotation(Parameter.class);
-                Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
-                Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
-                if (annotation != null) {
-                    //
-                    // @Parameter
-                    //
-                    Parameter p = (Parameter) annotation;
-                    if (p.names().length == 0) {
-                        p("Found main parameter:" + f);
-                        if (m_mainParameterField != null) {
-                            throw new ParameterException("Only one @Parameter with no names attribute is"
-                                  + " allowed, found:" + m_mainParameterField + " and " + f);
-                        }
-                        m_mainParameterField = f;
-                        m_mainParameterObject = object;
-                        m_mainParameterAnnotation = p;
-                        m_mainParameterDescription = new ParameterDescription(object, p, f, m_bundle, this);
-                    } else {
-                        for (String name : p.names()) {
-                            if (m_descriptions.containsKey(name)) {
-                                throw new ParameterException("Found the option " + name + " multiple times");
-                            }
-                            p("Adding description for " + name);
-                            ParameterDescription pd = new ParameterDescription(object, p, f, m_bundle, this);
-                            m_fields.put(f, pd);
-                            m_descriptions.put(name, pd);
-                            m_abbrevMap.put(name, pd);
-
-                            if (p.required()) m_requiredFields.put(f, pd);
-                        }
-                    }
-                } else if (delegateAnnotation != null) {
-                    //
-                    // @ParametersDelegate
-                    //
-                    try {
-                        Object delegateObject = f.get(object);
-                        if (delegateObject == null) {
-                            throw new ParameterException("Delegate field '" + f.getName() + "' cannot be null.");
-                        }
-                        addDescription(delegateObject);
-                    } catch (IllegalAccessException e) {
-                    }
-                } else if (dynamicParameter != null) {
-                    //
-                    // @DynamicParameter
-                    //
-                    DynamicParameter dp = (DynamicParameter) dynamicParameter;
-                    for (String name : dp.names()) {
-                        if (m_descriptions.containsKey(name)) {
-                            throw new ParameterException("Found the option " + name + " multiple times");
-                        }
-                        p("Adding description for " + name);
-                        ParameterDescription pd = new ParameterDescription(object, dp, f, m_bundle, this);
-                        m_fields.put(f, pd);
-                        m_descriptions.put(name, pd);
-                        m_abbrevMap.put(name, pd);
-
-                        if (dp.required()) m_requiredFields.put(f, pd);
-                    }
-                }
-            }
-            // Traverse the super class until we find Object.class
-            cls = cls.getSuperclass();
-        }
-    }
-
-    private void initializeDefaultValue(ParameterDescription pd) {
-        for (String optionName : pd.getParameter().names()) {
-            String def = m_defaultProvider.getDefaultValueFor(optionName);
-            if (def != null) {
-                p("Initializing " + optionName + " with default value:" + def);
-                pd.addValue(def, true /* default */);
-                return;
-            }
-        }
-    }
-
-    /**
-     * Main method that parses the values and initializes the fields accordingly.
-     */
-    private void parseValues(boolean allowAbbreviations, String[] args) {
-        // This boolean becomes true if we encounter a command, which indicates we need
-        // to stop parsing (the parsing of the command will be done in a sub JCommander
-        // object)
-        boolean commandParsed = false;
-        int i = 0;
-        while (i < args.length && !commandParsed) {
-            String arg = args[i];
-            String a = trim(arg);
-            p("Parsing arg: " + a);
-
-            JCommander jc = findCommandByAlias(arg);
-            int increment = 1;
-            if (isOption(args, a) && jc == null) {
-                //
-                // Option
-                //
-                ParameterDescription pd;
-                if (allowAbbreviations) {
-                    pd = m_abbrevMap.get(a);
-                } else {
-                    pd = m_descriptions.get(a);
-                }
-
-                if (pd != null) {
-                    if (pd.getParameter().password()) {
-                        //
-                        // Password option, use the Console to retrieve the password
-                        //
-                        char[] password = readPassword(pd.getDescription());
-                        pd.addValue(new String(password));
-                        m_requiredFields.remove(pd.getField());
-                    } else {
-                        if (pd.getParameter().variableArity()) {
-                            //
-                            // Variable arity?
-                            //
-                            increment = processVariableArity(args, i, pd);
-                        } else {
-                            //
-                            // Regular option
-                            //
-                            Class<?> fieldType = pd.getField().getType();
-
-                            // Boolean, set to true as soon as we see it, unless it specified
-                            // an arity of 1, in which case we need to read the next value
-                            if ((fieldType == boolean.class || fieldType == Boolean.class)
-                                  && pd.getParameter().arity() == -1) {
-                                pd.addValue("true");
-                                m_requiredFields.remove(pd.getField());
-                            } else {
-                                increment = processFixedArity(args, i, pd, fieldType);
-                            }
-                        }
-                    }
-                } else {
-                    throw new ParameterException("Unknown option: " + arg);
-                }
-            } else {
-                //
-                // Main parameter
-                //
-                if (!Strings.isStringEmpty(arg)) {
-                    if (m_commands.isEmpty()) {
-                        //
-                        // Regular (non-command) parsing
-                        //
-                        List mp = getMainParameter(arg);
-                        String value = arg;
-                        Object convertedValue = value;
-
-                        if (m_mainParameterField.getGenericType() instanceof ParameterizedType) {
-                            ParameterizedType p = (ParameterizedType) m_mainParameterField.getGenericType();
-                            Type cls = p.getActualTypeArguments()[0];
-                            if (cls instanceof Class) {
-                                convertedValue = convertValue(m_mainParameterField, (Class) cls, value);
-                            }
-                        }
-
-                        ParameterDescription.validateParameter(m_mainParameterAnnotation.validateWith(),
-                              "Default", value);
-
-                        m_mainParameterDescription.setAssigned(true);
-                        mp.add(convertedValue);
-                    } else {
-                        //
-                        // Command parsing
-                        //
-                        if (jc == null) throw new MissingCommandException("Expected a command, got " + arg);
-                        m_parsedCommand = jc.m_programName.m_name;
-                        m_parsedAlias = arg; //preserve the original form
-
-                        // Found a valid command, ask it to parse the remainder of the arguments.
-                        // Setting the boolean commandParsed to true will force the current
-                        // loop to end.
-                        jc.parse(true, allowAbbreviations, subArray(args, i + 1));
-                        commandParsed = true;
-                    }
-                }
-            }
-            i += increment;
-        }
-
-        // Mark the parameter descriptions held in m_fields as assigned
-        for (ParameterDescription parameterDescription : m_descriptions.values()) {
-            if (parameterDescription.isAssigned()) {
-                m_fields.get(parameterDescription.getField()).setAssigned(true);
-            }
-        }
-
-    }
-
-    /**
-     * @return the generic type of the collection for this field, or null if not applicable.
-     */
-    private Type findFieldGenericType(Field field) {
-        if (field.getGenericType() instanceof ParameterizedType) {
-            ParameterizedType p = (ParameterizedType) field.getGenericType();
-            Type cls = p.getActualTypeArguments()[0];
-            if (cls instanceof Class) {
-                return cls;
-            }
-        }
-
-        return null;
-    }
-
-    private class DefaultVariableArity implements IVariableArity {
-
-        public int processVariableArity(String optionName, String[] options) {
-            int i = 0;
-            while (i < options.length && !isOption(options, options[i])) {
-                i++;
-            }
-            return i;
-        }
-    }
-
-    private final IVariableArity DEFAULT_VARIABLE_ARITY = new DefaultVariableArity();
-
-    /**
-     * @return the number of options that were processed.
-     */
-    private int processVariableArity(String[] args, int index, ParameterDescription pd) {
-        Object arg = pd.getObject();
-        IVariableArity va;
-        if (!(arg instanceof IVariableArity)) {
-            va = DEFAULT_VARIABLE_ARITY;
+        ParameterDescription pd;
+        if (allowAbbreviations) {
+          pd = m_abbrevMap.get(a);
         } else {
-            va = (IVariableArity) arg;
+          pd = m_descriptions.get(a);
         }
 
-        List<String> currentArgs = Lists.newArrayList();
-        for (int j = index + 1; j < args.length; j++) {
-            currentArgs.add(args[j]);
-        }
-        int arity = va.processVariableArity(pd.getParameter().names()[0],
-              currentArgs.toArray(new String[0]));
-
-        int result = processFixedArity(args, index, pd, List.class, arity);
-        return result;
-    }
-
-    private int processFixedArity(String[] args, int index, ParameterDescription pd,
-                                  Class<?> fieldType) {
-        // Regular parameter, use the arity to tell use how many values
-        // we need to consume
-        int arity = pd.getParameter().arity();
-        int n = (arity != -1 ? arity : 1);
-
-        return processFixedArity(args, index, pd, fieldType, n);
-    }
-
-    private int processFixedArity(String[] args, int originalIndex, ParameterDescription pd,
-                                  Class<?> fieldType, int arity) {
-        int index = originalIndex;
-        String arg = args[index];
-        // Special case for boolean parameters of arity 0
-        if (arity == 0 &&
-              (Boolean.class.isAssignableFrom(fieldType)
-                    || boolean.class.isAssignableFrom(fieldType))) {
-            pd.addValue("true");
+        if (pd != null) {
+          if (pd.getParameter().password()) {
+            //
+            // Password option, use the Console to retrieve the password
+            //
+            char[] password = readPassword(pd.getDescription());
+            pd.addValue(new String(password));
             m_requiredFields.remove(pd.getField());
-        } else if (index < args.length - 1) {
-            int offset = "--".equals(args[index + 1]) ? 1 : 0;
-
-            if (index + arity < args.length) {
-                for (int j = 1; j <= arity; j++) {
-                    pd.addValue(trim(args[index + j + offset]));
-                    m_requiredFields.remove(pd.getField());
-                }
-                index += arity + offset;
+          } else {
+            if (pd.getParameter().variableArity()) {
+              //
+              // Variable arity?
+              //
+              increment = processVariableArity(args, i, pd);
             } else {
-                throw new ParameterException("Expected " + arity + " values after " + arg);
+              //
+              // Regular option
+              //
+              Class<?> fieldType = pd.getField().getType();
+
+              // Boolean, set to true as soon as we see it, unless it specified
+              // an arity of 1, in which case we need to read the next value
+              if ((fieldType == boolean.class || fieldType == Boolean.class)
+                      && pd.getParameter().arity() == -1) {
+                pd.addValue("true");
+                m_requiredFields.remove(pd.getField());
+              } else {
+                increment = processFixedArity(args, i, pd, fieldType);
+              }
             }
+          }
         } else {
-            throw new ParameterException("Expected a value after parameter " + arg);
+          throw new ParameterException("Unknown option: " + arg);
         }
-
-        return arity + 1;
-    }
-
-    /**
-     * Invoke Console.readPassword through reflection to avoid depending
-     * on Java 6.
-     */
-    private char[] readPassword(String description) {
-        getConsole().print(description + ": ");
-        return getConsole().readPassword();
-    }
-
-    private String[] subArray(String[] args, int index) {
-        int l = args.length - index;
-        String[] result = new String[l];
-        System.arraycopy(args, index, result, 0, l);
-
-        return result;
-    }
-
-    /**
-     * @param arg the arg that we're about to add (only passed here to output a meaningful
-     *            error message).
-     * @return the field that's meant to receive all the parameters that are not options.
-     */
-    private List<?> getMainParameter(String arg) {
-        if (m_mainParameterField == null) {
-            throw new ParameterException(
-                  "Was passed main parameter '" + arg + "' but no main parameter was defined");
-        }
-
-        try {
-            List result = (List) m_mainParameterField.get(m_mainParameterObject);
-            if (result == null) {
-                result = Lists.newArrayList();
-                if (!List.class.isAssignableFrom(m_mainParameterField.getType())) {
-                    throw new ParameterException("Main parameter field " + m_mainParameterField
-                          + " needs to be of type List, not " + m_mainParameterField.getType());
-                }
-                m_mainParameterField.set(m_mainParameterObject, result);
-            }
-            return result;
-        } catch (IllegalAccessException ex) {
-            throw new ParameterException("Couldn't access main parameter: " + ex.getMessage());
-        }
-    }
-
-    public String getMainParameterDescription() {
-        if (m_descriptions == null) createDescriptions();
-        return m_mainParameterAnnotation != null ? m_mainParameterAnnotation.description()
-              : null;
-    }
-
-    private int longestName(Collection<?> objects) {
-        int result = 0;
-        for (Object o : objects) {
-            int l = o.toString().length();
-            if (l > result) result = l;
-        }
-
-        return result;
-    }
-
-    /**
-     * Set the program name (used only in the usage).
-     */
-    public void setProgramName(String name) {
-        setProgramName(name, new String[0]);
-    }
-
-    /**
-     * Set the program name
-     *
-     * @param name    program name
-     * @param aliases aliases to the program name
-     */
-    public void setProgramName(String name, String... aliases) {
-        m_programName = new ProgramName(name, Arrays.asList(aliases));
-    }
-
-    /**
-     * Display the usage for this command.
-     */
-    public void usage(String commandName) {
-        StringBuilder sb = new StringBuilder();
-        usage(commandName, sb);
-        getConsole().println(sb.toString());
-    }
-
-    /**
-     * Store the help for the command in the passed string builder.
-     */
-    public void usage(String commandName, StringBuilder out) {
-        usage(commandName, out, "");
-    }
-
-    /**
-     * Store the help for the command in the passed string builder, indenting
-     * every line with "indent".
-     */
-    public void usage(String commandName, StringBuilder out, String indent) {
-        String description = getCommandDescription(commandName);
-        JCommander jc = findCommandByAlias(commandName);
-        if (description != null) {
-            out.append(indent).append(description);
-            out.append("\n");
-        }
-        jc.usage(out, indent);
-    }
-
-    /**
-     * @return the description of the command.
-     */
-    public String getCommandDescription(String commandName) {
-        JCommander jc = findCommandByAlias(commandName);
-        if (jc == null) {
-            throw new ParameterException("Asking description for unknown command: " + commandName);
-        }
-
-        Object arg = jc.getObjects().get(0);
-        Parameters p = arg.getClass().getAnnotation(Parameters.class);
-        ResourceBundle bundle = null;
-        String result = null;
-        if (p != null) {
-            result = p.commandDescription();
-            String bundleName = p.resourceBundle();
-            if (!"".equals(bundleName)) {
-                bundle = ResourceBundle.getBundle(bundleName, Locale.getDefault());
-            } else {
-                bundle = m_bundle;
-            }
-
-            if (bundle != null) {
-                result = getI18nString(bundle, p.commandDescriptionKey(), p.commandDescription());
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * @return The internationalized version of the string if available, otherwise
-     *         return def.
-     */
-    private String getI18nString(ResourceBundle bundle, String key, String def) {
-        String s = bundle != null ? bundle.getString(key) : null;
-        return s != null ? s : def;
-    }
-
-    /**
-     * Display the help on System.out.
-     */
-    public void usage() {
-        StringBuilder sb = new StringBuilder();
-        usage(sb);
-        getConsole().println(sb.toString());
-    }
-
-    /**
-     * Store the help in the passed string builder.
-     */
-    public void usage(StringBuilder out) {
-        usage(out, "");
-    }
-
-    public void usage(StringBuilder out, String indent) {
-        if (m_descriptions == null) createDescriptions();
-        boolean hasCommands = !m_commands.isEmpty();
-
+      } else {
         //
-        // First line of the usage
+        // Main parameter
         //
-        String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
-        out.append(indent).append("Usage: " + programName + " [options]");
-        if (hasCommands) out.append(indent).append(" [command] [command options]");
+        if (!Strings.isStringEmpty(arg)) {
+          if (m_commands.isEmpty()) {
+            //
+            // Regular (non-command) parsing
+            //
+            List mp = getMainParameter(arg);
+            String value = arg;
+            Object convertedValue = value;
+
+            if (m_mainParameterField.getGenericType() instanceof ParameterizedType) {
+              ParameterizedType p = (ParameterizedType) m_mainParameterField.getGenericType();
+              Type cls = p.getActualTypeArguments()[0];
+              if (cls instanceof Class) {
+                convertedValue = convertValue(m_mainParameterField, (Class) cls, value);
+              }
+            }
+
+            ParameterDescription.validateParameter(m_mainParameterAnnotation.validateWith(),
+                    "Default", value);
+
+            m_mainParameterDescription.setAssigned(true);
+            mp.add(convertedValue);
+          } else {
+            //
+            // Command parsing
+            //
+            if (jc == null) throw new MissingCommandException("Expected a command, got " + arg);
+            m_parsedCommand = jc.m_programName.m_name;
+            m_parsedAlias = arg; //preserve the original form
+
+            // Found a valid command, ask it to parse the remainder of the arguments.
+            // Setting the boolean commandParsed to true will force the current
+            // loop to end.
+            jc.parse(true, allowAbbreviations, subArray(args, i + 1));
+            commandParsed = true;
+          }
+        }
+      }
+      i += increment;
+    }
+
+    // Mark the parameter descriptions held in m_fields as assigned
+    for (ParameterDescription parameterDescription : m_descriptions.values()) {
+      if (parameterDescription.isAssigned()) {
+        m_fields.get(parameterDescription.getField()).setAssigned(true);
+      }
+    }
+
+  }
+
+  /**
+   * @return the generic type of the collection for this field, or null if not applicable.
+   */
+  private Type findFieldGenericType(Field field) {
+    if (field.getGenericType() instanceof ParameterizedType) {
+      ParameterizedType p = (ParameterizedType) field.getGenericType();
+      Type cls = p.getActualTypeArguments()[0];
+      if (cls instanceof Class) {
+        return cls;
+      }
+    }
+
+    return null;
+  }
+
+  private class DefaultVariableArity implements IVariableArity {
+
+    public int processVariableArity(String optionName, String[] options) {
+      int i = 0;
+      while (i < options.length && !isOption(options, options[i])) {
+        i++;
+      }
+      return i;
+    }
+  }
+
+  private final IVariableArity DEFAULT_VARIABLE_ARITY = new DefaultVariableArity();
+
+  /**
+   * @return the number of options that were processed.
+   */
+  private int processVariableArity(String[] args, int index, ParameterDescription pd) {
+    Object arg = pd.getObject();
+    IVariableArity va;
+    if (!(arg instanceof IVariableArity)) {
+      va = DEFAULT_VARIABLE_ARITY;
+    } else {
+      va = (IVariableArity) arg;
+    }
+
+    List<String> currentArgs = Lists.newArrayList();
+    for (int j = index + 1; j < args.length; j++) {
+      currentArgs.add(args[j]);
+    }
+    int arity = va.processVariableArity(pd.getParameter().names()[0],
+            currentArgs.toArray(new String[0]));
+
+    int result = processFixedArity(args, index, pd, List.class, arity);
+    return result;
+  }
+
+  private int processFixedArity(String[] args, int index, ParameterDescription pd,
+                                Class<?> fieldType) {
+    // Regular parameter, use the arity to tell use how many values
+    // we need to consume
+    int arity = pd.getParameter().arity();
+    int n = (arity != -1 ? arity : 1);
+
+    return processFixedArity(args, index, pd, fieldType, n);
+  }
+
+  private int processFixedArity(String[] args, int originalIndex, ParameterDescription pd,
+                                Class<?> fieldType, int arity) {
+    int index = originalIndex;
+    String arg = args[index];
+    // Special case for boolean parameters of arity 0
+    if (arity == 0 &&
+            (Boolean.class.isAssignableFrom(fieldType)
+                    || boolean.class.isAssignableFrom(fieldType))) {
+      pd.addValue("true");
+      m_requiredFields.remove(pd.getField());
+    } else if (index < args.length - 1) {
+      int offset = "--".equals(args[index + 1]) ? 1 : 0;
+
+      if (index + arity < args.length) {
+        for (int j = 1; j <= arity; j++) {
+          pd.addValue(trim(args[index + j + offset]));
+          m_requiredFields.remove(pd.getField());
+        }
+        index += arity + offset;
+      } else {
+        throw new ParameterException("Expected " + arity + " values after " + arg);
+      }
+    } else {
+      throw new ParameterException("Expected a value after parameter " + arg);
+    }
+
+    return arity + 1;
+  }
+
+  /**
+   * Invoke Console.readPassword through reflection to avoid depending
+   * on Java 6.
+   */
+  private char[] readPassword(String description) {
+    getConsole().print(description + ": ");
+    return getConsole().readPassword();
+  }
+
+  private String[] subArray(String[] args, int index) {
+    int l = args.length - index;
+    String[] result = new String[l];
+    System.arraycopy(args, index, result, 0, l);
+
+    return result;
+  }
+
+  /**
+   * @param arg the arg that we're about to add (only passed here to output a meaningful
+   *            error message).
+   * @return the field that's meant to receive all the parameters that are not options.
+   */
+  private List<?> getMainParameter(String arg) {
+    if (m_mainParameterField == null) {
+      throw new ParameterException(
+              "Was passed main parameter '" + arg + "' but no main parameter was defined");
+    }
+
+    try {
+      List result = (List) m_mainParameterField.get(m_mainParameterObject);
+      if (result == null) {
+        result = Lists.newArrayList();
+        if (!List.class.isAssignableFrom(m_mainParameterField.getType())) {
+          throw new ParameterException("Main parameter field " + m_mainParameterField
+                  + " needs to be of type List, not " + m_mainParameterField.getType());
+        }
+        m_mainParameterField.set(m_mainParameterObject, result);
+      }
+      return result;
+    } catch (IllegalAccessException ex) {
+      throw new ParameterException("Couldn't access main parameter: " + ex.getMessage());
+    }
+  }
+
+  public String getMainParameterDescription() {
+    if (m_descriptions == null) createDescriptions();
+    return m_mainParameterAnnotation != null ? m_mainParameterAnnotation.description()
+            : null;
+  }
+
+  private int longestName(Collection<?> objects) {
+    int result = 0;
+    for (Object o : objects) {
+      int l = o.toString().length();
+      if (l > result) result = l;
+    }
+
+    return result;
+  }
+
+  /**
+   * Set the program name (used only in the usage).
+   */
+  public void setProgramName(String name) {
+    setProgramName(name, new String[0]);
+  }
+
+  /**
+   * Set the program name
+   *
+   * @param name    program name
+   * @param aliases aliases to the program name
+   */
+  public void setProgramName(String name, String... aliases) {
+    m_programName = new ProgramName(name, Arrays.asList(aliases));
+  }
+
+  /**
+   * Display the usage for this command.
+   */
+  public void usage(String commandName) {
+    StringBuilder sb = new StringBuilder();
+    usage(commandName, sb);
+    getConsole().println(sb.toString());
+  }
+
+  /**
+   * Store the help for the command in the passed string builder.
+   */
+  public void usage(String commandName, StringBuilder out) {
+    usage(commandName, out, "");
+  }
+
+  /**
+   * Store the help for the command in the passed string builder, indenting
+   * every line with "indent".
+   */
+  public void usage(String commandName, StringBuilder out, String indent) {
+    String description = getCommandDescription(commandName);
+    JCommander jc = findCommandByAlias(commandName);
+    if (description != null) {
+      out.append(indent).append(description);
+      out.append("\n");
+    }
+    jc.usage(out, indent);
+  }
+
+  /**
+   * @return the description of the command.
+   */
+  public String getCommandDescription(String commandName) {
+    JCommander jc = findCommandByAlias(commandName);
+    if (jc == null) {
+      throw new ParameterException("Asking description for unknown command: " + commandName);
+    }
+
+    Object arg = jc.getObjects().get(0);
+    Parameters p = arg.getClass().getAnnotation(Parameters.class);
+    ResourceBundle bundle = null;
+    String result = null;
+    if (p != null) {
+      result = p.commandDescription();
+      String bundleName = p.resourceBundle();
+      if (!"".equals(bundleName)) {
+        bundle = ResourceBundle.getBundle(bundleName, Locale.getDefault());
+      } else {
+        bundle = m_bundle;
+      }
+
+      if (bundle != null) {
+        result = getI18nString(bundle, p.commandDescriptionKey(), p.commandDescription());
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * @return The internationalized version of the string if available, otherwise
+   *         return def.
+   */
+  private String getI18nString(ResourceBundle bundle, String key, String def) {
+    String s = bundle != null ? bundle.getString(key) : null;
+    return s != null ? s : def;
+  }
+
+  /**
+   * Display the help on System.out.
+   */
+  public void usage() {
+    StringBuilder sb = new StringBuilder();
+    usage(sb);
+    getConsole().println(sb.toString());
+  }
+
+  /**
+   * Store the help in the passed string builder.
+   */
+  public void usage(StringBuilder out) {
+    usage(out, "");
+  }
+
+  public void usage(StringBuilder out, String indent) {
+    if (m_descriptions == null) createDescriptions();
+    boolean hasCommands = !m_commands.isEmpty();
+
+    //
+    // First line of the usage
+    //
+    String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
+    out.append(indent).append("Usage: " + programName + " [options]");
+    if (hasCommands) out.append(indent).append(" [command] [command options]");
 //    out.append("\n");
-        if (m_mainParameterDescription != null) {
-            out.append(" " + m_mainParameterDescription.getDescription());
+    if (m_mainParameterDescription != null) {
+      out.append(" " + m_mainParameterDescription.getDescription());
+    }
+
+    //
+    // Align the descriptions at the "longestName" column
+    //
+    int longestName = 0;
+    List<ParameterDescription> sorted = Lists.newArrayList();
+    for (ParameterDescription pd : m_fields.values()) {
+      if (!pd.getParameter().hidden()) {
+        sorted.add(pd);
+        // + to have an extra space between the name and the description
+        int length = pd.getNames().length() + 2;
+        if (length > longestName) {
+          longestName = length;
         }
-
-        //
-        // Align the descriptions at the "longestName" column
-        //
-        int longestName = 0;
-        List<ParameterDescription> sorted = Lists.newArrayList();
-        for (ParameterDescription pd : m_fields.values()) {
-            if (!pd.getParameter().hidden()) {
-                sorted.add(pd);
-                // + to have an extra space between the name and the description
-                int length = pd.getNames().length() + 2;
-                if (length > longestName) {
-                    longestName = length;
-                }
-            }
-        }
-
-        //
-        // Sort the options
-        //
-        Collections.sort(sorted, getParameterDescriptionComparator());
-
-        //
-        // Display all the names and descriptions
-        //
-        if (sorted.size() > 0) out.append(indent).append("\n").append(indent).append("  Options:\n");
-        for (ParameterDescription pd : sorted) {
-            int l = pd.getNames().length();
-            int spaceCount = longestName - l;
-            int start = out.length();
-            WrappedParameter parameter = pd.getParameter();
-            out.append(indent).append("  "
-                  + (parameter.required() ? "* " : "  ")
-                  + pd.getNames() + s(spaceCount));
-            int indentCount = out.length() - start;
-            wrapDescription(out, indentCount, pd.getDescription());
-            Object def = pd.getDefault();
-            if (pd.isDynamicParameter()) {
-                out.append("\n" + spaces(indentCount + 1))
-                      .append("Syntax: " + parameter.names()[0]
-                            + "key" + parameter.getAssignment()
-                            + "value");
-            }
-            if (def != null && !"".equals(def)) {
-                out.append("\n" + spaces(indentCount + 1))
-                      .append("Default: " + (parameter.password() ? "********" : def));
-            }
-            out.append("\n");
-        }
-
-        //
-        // If commands were specified, show them as well
-        //
-        if (hasCommands) {
-            out.append("  Commands:\n");
-            // The magic value 3 is the number of spaces between the name of the option
-            // and its description
-            for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
-                ProgramName progName = commands.getKey();
-                String dispName = progName.getDisplayName();
-                out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");
-
-                // Options for this command
-                usage(progName.getName(), out, "      ");
-                out.append("\n");
-            }
-        }
+      }
     }
 
-    private Comparator<? super ParameterDescription> getParameterDescriptionComparator() {
-        return m_parameterDescriptionComparator;
+    //
+    // Sort the options
+    //
+    Collections.sort(sorted, getParameterDescriptionComparator());
+
+    //
+    // Display all the names and descriptions
+    //
+    if (sorted.size() > 0) out.append(indent).append("\n").append(indent).append("  Options:\n");
+    for (ParameterDescription pd : sorted) {
+      int l = pd.getNames().length();
+      int spaceCount = longestName - l;
+      int start = out.length();
+      WrappedParameter parameter = pd.getParameter();
+      out.append(indent).append("  "
+              + (parameter.required() ? "* " : "  ")
+              + pd.getNames() + s(spaceCount));
+      int indentCount = out.length() - start;
+      wrapDescription(out, indentCount, pd.getDescription());
+      Object def = pd.getDefault();
+      if (pd.isDynamicParameter()) {
+        out.append("\n" + spaces(indentCount + 1))
+                .append("Syntax: " + parameter.names()[0]
+                        + "key" + parameter.getAssignment()
+                        + "value");
+      }
+      if (def != null && !"".equals(def)) {
+        out.append("\n" + spaces(indentCount + 1))
+                .append("Default: " + (parameter.password() ? "********" : def));
+      }
+      out.append("\n");
     }
 
-    public void setParameterDescriptionComparator(Comparator<? super ParameterDescription> c) {
-        m_parameterDescriptionComparator = c;
+    //
+    // If commands were specified, show them as well
+    //
+    if (hasCommands) {
+      out.append("  Commands:\n");
+      // The magic value 3 is the number of spaces between the name of the option
+      // and its description
+      for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
+        ProgramName progName = commands.getKey();
+        String dispName = progName.getDisplayName();
+        out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");
+
+        // Options for this command
+        usage(progName.getName(), out, "      ");
+        out.append("\n");
+      }
+    }
+  }
+
+  private Comparator<? super ParameterDescription> getParameterDescriptionComparator() {
+    return m_parameterDescriptionComparator;
+  }
+
+  public void setParameterDescriptionComparator(Comparator<? super ParameterDescription> c) {
+    m_parameterDescriptionComparator = c;
+  }
+
+  public void setColumnSize(int columnSize) {
+    m_columnSize = columnSize;
+  }
+
+  public int getColumnSize() {
+    return m_columnSize;
+  }
+
+  private void wrapDescription(StringBuilder out, int indent, String description) {
+    int max = getColumnSize();
+    String[] words = description.split(" ");
+    int current = indent;
+    int i = 0;
+    while (i < words.length) {
+      String word = words[i];
+      if (word.length() > max || current + word.length() <= max) {
+        out.append(" ").append(word);
+        current += word.length() + 1;
+      } else {
+        out.append("\n").append(spaces(indent + 1)).append(word);
+        current = indent;
+      }
+      i++;
+    }
+  }
+
+  private String spaces(int indent) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < indent; i++) sb.append(" ");
+    return sb.toString();
+  }
+
+  /**
+   * @return a Collection of all the \@Parameter annotations found on the
+   *         target class. This can be used to display the usage() in a different
+   *         format (e.g. HTML).
+   */
+  public List<ParameterDescription> getParameters() {
+    return new ArrayList<ParameterDescription>(m_fields.values());
+  }
+
+  /**
+   * @return the main parameter description or null if none is defined.
+   */
+  public ParameterDescription getMainParameter() {
+    return m_mainParameterDescription;
+  }
+
+  private void p(String string) {
+    if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
+      getConsole().println("[JCommander] " + string);
+    }
+  }
+
+  /**
+   * Define the default provider for this instance.
+   */
+  public void setDefaultProvider(IDefaultProvider defaultProvider) {
+    m_defaultProvider = defaultProvider;
+
+    for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+      entry.getValue().setDefaultProvider(defaultProvider);
+    }
+  }
+
+  public void addConverterFactory(IStringConverterFactory converterFactory) {
+    CONVERTER_FACTORIES.addFirst(converterFactory);
+  }
+
+  public <T> Class<? extends IStringConverter<T>> findConverter(Class<T> cls) {
+    for (IStringConverterFactory f : CONVERTER_FACTORIES) {
+      Class<? extends IStringConverter<T>> result = f.getConverter(cls);
+      if (result != null) return result;
     }
 
-    public void setColumnSize(int columnSize) {
-        m_columnSize = columnSize;
+    return null;
+  }
+
+  public Object convertValue(ParameterDescription pd, String value) {
+    return convertValue(pd.getField(), pd.getField().getType(), value);
+  }
+
+  /**
+   * @param field The field
+   * @param type  The type of the actual parameter
+   * @param value The value to convert
+   */
+  public Object convertValue(Field field, Class type, String value) {
+    Parameter annotation = field.getAnnotation(Parameter.class);
+
+    // Do nothing if it's a @DynamicParameter
+    if (annotation == null) return value;
+
+    Class<? extends IStringConverter<?>> converterClass = annotation.converter();
+    boolean listConverterWasSpecified = annotation.listConverter() != NoConverter.class;
+
+    //
+    // Try to find a converter on the annotation
+    //
+    if (converterClass == null || converterClass == NoConverter.class) {
+      // If no converter specified and type is enum, used enum values to convert
+      if (type.isEnum()) {
+        converterClass = type;
+      } else {
+        converterClass = findConverter(type);
+      }
     }
 
-    public int getColumnSize() {
-        return m_columnSize;
+    if (converterClass == null) {
+      Type elementType = findFieldGenericType(field);
+      converterClass = elementType != null
+              ? findConverter((Class<? extends IStringConverter<?>>) elementType)
+              : StringConverter.class;
     }
 
-    private void wrapDescription(StringBuilder out, int indent, String description) {
-        int max = getColumnSize();
-        String[] words = description.split(" ");
-        int current = indent;
-        int i = 0;
-        while (i < words.length) {
-            String word = words[i];
-            if (word.length() > max || current + word.length() <= max) {
-                out.append(" ").append(word);
-                current += word.length() + 1;
-            } else {
-                out.append("\n").append(spaces(indent + 1)).append(word);
-                current = indent;
-            }
-            i++;
-        }
-    }
-
-    private String spaces(int indent) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < indent; i++) sb.append(" ");
-        return sb.toString();
-    }
-
-    /**
-     * @return a Collection of all the \@Parameter annotations found on the
-     *         target class. This can be used to display the usage() in a different
-     *         format (e.g. HTML).
-     */
-    public List<ParameterDescription> getParameters() {
-        return new ArrayList<ParameterDescription>(m_fields.values());
-    }
-
-    /**
-     * @return the main parameter description or null if none is defined.
-     */
-    public ParameterDescription getMainParameter() {
-        return m_mainParameterDescription;
-    }
-
-    private void p(String string) {
-        if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
-            getConsole().println("[JCommander] " + string);
-        }
-    }
-
-    /**
-     * Define the default provider for this instance.
-     */
-    public void setDefaultProvider(IDefaultProvider defaultProvider) {
-        m_defaultProvider = defaultProvider;
-
-        for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-            entry.getValue().setDefaultProvider(defaultProvider);
-        }
-    }
-
-    public void addConverterFactory(IStringConverterFactory converterFactory) {
-        CONVERTER_FACTORIES.addFirst(converterFactory);
-    }
-
-    public <T> Class<? extends IStringConverter<T>> findConverter(Class<T> cls) {
-        for (IStringConverterFactory f : CONVERTER_FACTORIES) {
-            Class<? extends IStringConverter<T>> result = f.getConverter(cls);
-            if (result != null) return result;
-        }
-
-        return null;
-    }
-
-    public Object convertValue(ParameterDescription pd, String value) {
-        return convertValue(pd.getField(), pd.getField().getType(), value);
-    }
-
-    /**
-     * @param field The field
-     * @param type  The type of the actual parameter
-     * @param value The value to convert
-     */
-    public Object convertValue(Field field, Class type, String value) {
-        Parameter annotation = field.getAnnotation(Parameter.class);
-
-        // Do nothing if it's a @DynamicParameter
-        if (annotation == null) return value;
-
-        Class<? extends IStringConverter<?>> converterClass = annotation.converter();
-        boolean listConverterWasSpecified = annotation.listConverter() != NoConverter.class;
-
-        //
-        // Try to find a converter on the annotation
-        //
-        if (converterClass == null || converterClass == NoConverter.class) {
-            // If no converter specified and type is enum, used enum values to convert
-            if (type.isEnum()) {
-                converterClass = type;
-            } else {
-                converterClass = findConverter(type);
-            }
-        }
-
-        if (converterClass == null) {
-            Type elementType = findFieldGenericType(field);
-            converterClass = elementType != null
-                  ? findConverter((Class<? extends IStringConverter<?>>) elementType)
-                  : StringConverter.class;
-        }
-
-        //
+    //
 //    //
 //    // Try to find a converter in the factory
 //    //
@@ -1207,265 +1207,265 @@ public class JCommander {
 //          + " to type " + type + " (field: " + field.getName() + ")");
 //    }
 
-        IStringConverter<?> converter;
-        Object result = null;
+    IStringConverter<?> converter;
+    Object result = null;
+    try {
+      String[] names = annotation.names();
+      String optionName = names.length > 0 ? names[0] : "[Main class]";
+      if (converterClass.isEnum()) {
         try {
-            String[] names = annotation.names();
-            String optionName = names.length > 0 ? names[0] : "[Main class]";
-            if (converterClass.isEnum()) {
-                try {
-                    result = Enum.valueOf((Class<? extends Enum>) converterClass, value.toUpperCase());
-                } catch (Exception e) {
-                    throw new ParameterException("Invalid value for " + optionName + " parameter. Allowed values:" +
-                          EnumSet.allOf((Class<? extends Enum>) converterClass));
-                }
-            } else {
-                converter = instantiateConverter(optionName, converterClass);
-                if (type.isAssignableFrom(List.class)
-                      && field.getGenericType() instanceof ParameterizedType) {
-
-                    // The field is a List
-                    if (listConverterWasSpecified) {
-                        // If a list converter was specified, pass the value to it
-                        // for direct conversion
-                        IStringConverter<?> listConverter =
-                              instantiateConverter(optionName, annotation.listConverter());
-                        result = listConverter.convert(value);
-                    } else {
-                        // No list converter: use the single value converter and pass each
-                        // parsed value to it individually
-                        result = convertToList(value, converter, annotation.splitter());
-                    }
-                } else {
-                    result = converter.convert(value);
-                }
-            }
-        } catch (InstantiationException e) {
-            throw new ParameterException(e);
-        } catch (IllegalAccessException e) {
-            throw new ParameterException(e);
-        } catch (InvocationTargetException e) {
-            throw new ParameterException(e);
+          result = Enum.valueOf((Class<? extends Enum>) converterClass, value.toUpperCase());
+        } catch (Exception e) {
+          throw new ParameterException("Invalid value for " + optionName + " parameter. Allowed values:" +
+                  EnumSet.allOf((Class<? extends Enum>) converterClass));
         }
+      } else {
+        converter = instantiateConverter(optionName, converterClass);
+        if (type.isAssignableFrom(List.class)
+                && field.getGenericType() instanceof ParameterizedType) {
 
-        return result;
+          // The field is a List
+          if (listConverterWasSpecified) {
+            // If a list converter was specified, pass the value to it
+            // for direct conversion
+            IStringConverter<?> listConverter =
+                    instantiateConverter(optionName, annotation.listConverter());
+            result = listConverter.convert(value);
+          } else {
+            // No list converter: use the single value converter and pass each
+            // parsed value to it individually
+            result = convertToList(value, converter, annotation.splitter());
+          }
+        } else {
+          result = converter.convert(value);
+        }
+      }
+    } catch (InstantiationException e) {
+      throw new ParameterException(e);
+    } catch (IllegalAccessException e) {
+      throw new ParameterException(e);
+    } catch (InvocationTargetException e) {
+      throw new ParameterException(e);
     }
 
-    /**
-     * Use the splitter to split the value into multiple values and then convert
-     * each of them individually.
-     */
-    private Object convertToList(String value, IStringConverter<?> converter,
-                                 Class<? extends IParameterSplitter> splitterClass)
+    return result;
+  }
+
+  /**
+   * Use the splitter to split the value into multiple values and then convert
+   * each of them individually.
+   */
+  private Object convertToList(String value, IStringConverter<?> converter,
+                               Class<? extends IParameterSplitter> splitterClass)
           throws InstantiationException, IllegalAccessException {
-        IParameterSplitter splitter = splitterClass.newInstance();
-        List<Object> result = Lists.newArrayList();
-        for (String param : splitter.split(value)) {
-            result.add(converter.convert(param));
-        }
-        return result;
+    IParameterSplitter splitter = splitterClass.newInstance();
+    List<Object> result = Lists.newArrayList();
+    for (String param : splitter.split(value)) {
+      result.add(converter.convert(param));
     }
+    return result;
+  }
 
-    private IStringConverter<?> instantiateConverter(String optionName,
-                                                     Class<? extends IStringConverter<?>> converterClass)
+  private IStringConverter<?> instantiateConverter(String optionName,
+                                                   Class<? extends IStringConverter<?>> converterClass)
           throws IllegalArgumentException, InstantiationException, IllegalAccessException,
           InvocationTargetException {
-        Constructor<IStringConverter<?>> ctor = null;
-        Constructor<IStringConverter<?>> stringCtor = null;
-        Constructor<IStringConverter<?>>[] ctors
-              = (Constructor<IStringConverter<?>>[]) converterClass.getDeclaredConstructors();
-        for (Constructor<IStringConverter<?>> c : ctors) {
-            Class<?>[] types = c.getParameterTypes();
-            if (types.length == 1 && types[0].equals(String.class)) {
-                stringCtor = c;
-            } else if (types.length == 0) {
-                ctor = c;
-            }
+    Constructor<IStringConverter<?>> ctor = null;
+    Constructor<IStringConverter<?>> stringCtor = null;
+    Constructor<IStringConverter<?>>[] ctors
+            = (Constructor<IStringConverter<?>>[]) converterClass.getDeclaredConstructors();
+    for (Constructor<IStringConverter<?>> c : ctors) {
+      Class<?>[] types = c.getParameterTypes();
+      if (types.length == 1 && types[0].equals(String.class)) {
+        stringCtor = c;
+      } else if (types.length == 0) {
+        ctor = c;
+      }
+    }
+
+    IStringConverter<?> result = stringCtor != null
+            ? stringCtor.newInstance(optionName)
+            : ctor.newInstance();
+
+    return result;
+  }
+
+  /**
+   * Add a command object.
+   */
+  public void addCommand(String name, Object object) {
+    addCommand(name, object, new String[0]);
+  }
+
+  public void addCommand(Object object) {
+    Parameters p = object.getClass().getAnnotation(Parameters.class);
+    if (p != null && p.commandNames().length > 0) {
+      for (String commandName : p.commandNames()) {
+        addCommand(commandName, object);
+      }
+    } else {
+      throw new ParameterException("Trying to add command " + object.getClass().getName()
+              + " without specifying its names in @Parameters");
+    }
+  }
+
+  /**
+   * Add a command object and its aliases.
+   */
+  public void addCommand(String name, Object object, String... aliases) {
+    JCommander jc = new JCommander(object);
+    jc.setProgramName(name, aliases);
+    jc.setDefaultProvider(m_defaultProvider);
+    ProgramName progName = jc.m_programName;
+    m_commands.put(progName, jc);
+
+    /*
+    * Register aliases
+    */
+    //register command name as an alias of itself for reverse lookup
+    //Note: Name clash check is intentionally omitted to resemble the
+    //     original behaviour of clashing commands.
+    //     Aliases are, however, are strictly checked for name clashes.
+    aliasMap.put(name, progName);
+    for (String alias : aliases) {
+      //omit pointless aliases to avoid name clash exception
+      if (!alias.equals(name)) {
+        ProgramName mappedName = aliasMap.get(alias);
+        if (mappedName != null && !mappedName.equals(progName)) {
+          throw new ParameterException("Cannot set alias " + alias
+                  + " for " + name
+                  + " command because it has already been defined for "
+                  + mappedName.m_name + " command");
         }
+        aliasMap.put(alias, progName);
+      }
+    }
+  }
 
-        IStringConverter<?> result = stringCtor != null
-              ? stringCtor.newInstance(optionName)
-              : ctor.newInstance();
+  public Map<String, JCommander> getCommands() {
+    Map<String, JCommander> res = Maps.newLinkedHashMap();
+    for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
+      res.put(entry.getKey().m_name, entry.getValue());
+    }
+    return res;
+  }
 
-        return result;
+  public String getParsedCommand() {
+    return m_parsedCommand;
+  }
+
+  /**
+   * The name of the command or the alias in the form it was
+   * passed to the command line. <code>null</code> if no
+   * command or alias was specified.
+   *
+   * @return Name of command or alias passed to command line. If none passed: <code>null</code>.
+   */
+  public String getParsedAlias() {
+    return m_parsedAlias;
+  }
+
+  /**
+   * @return n spaces
+   */
+  private String s(int count) {
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < count; i++) {
+      result.append(" ");
     }
 
-    /**
-     * Add a command object.
-     */
-    public void addCommand(String name, Object object) {
-        addCommand(name, object, new String[0]);
+    return result.toString();
+  }
+
+  /**
+   * @return the objects that JCommander will fill with the result of
+   *         parsing the command line.
+   */
+  public List<Object> getObjects() {
+    return m_objects;
+  }
+
+  /*
+  * Reverse lookup JCommand object by command's name or its alias
+  */
+  private JCommander findCommandByAlias(String commandOrAlias) {
+    ProgramName progName = aliasMap.get(commandOrAlias);
+    if (progName == null) {
+      return null;
+    }
+    JCommander jc = m_commands.get(progName);
+    if (jc == null) {
+      throw new IllegalStateException(
+              "There appears to be inconsistency in the internal command database. " +
+                      " This is likely a bug. Please report.");
+    }
+    return jc;
+  }
+
+  private static final class ProgramName {
+    private final String m_name;
+    private final List<String> m_aliases;
+
+    ProgramName(String name, List<String> aliases) {
+      m_name = name;
+      m_aliases = aliases;
     }
 
-    public void addCommand(Object object) {
-        Parameters p = object.getClass().getAnnotation(Parameters.class);
-        if (p != null && p.commandNames().length > 0) {
-            for (String commandName : p.commandNames()) {
-                addCommand(commandName, object);
-            }
-        } else {
-            throw new ParameterException("Trying to add command " + object.getClass().getName()
-                  + " without specifying its names in @Parameters");
+    public String getName() {
+      return m_name;
+    }
+
+    private String getDisplayName() {
+      StringBuilder sb = new StringBuilder();
+      sb.append(m_name);
+      if (!m_aliases.isEmpty()) {
+        sb.append("(");
+        Iterator<String> aliasesIt = m_aliases.iterator();
+        while (aliasesIt.hasNext()) {
+          sb.append(aliasesIt.next());
+          if (aliasesIt.hasNext()) {
+            sb.append(",");
+          }
         }
+        sb.append(")");
+      }
+      return sb.toString();
     }
 
-    /**
-     * Add a command object and its aliases.
-     */
-    public void addCommand(String name, Object object, String... aliases) {
-        JCommander jc = new JCommander(object);
-        jc.setProgramName(name, aliases);
-        jc.setDefaultProvider(m_defaultProvider);
-        ProgramName progName = jc.m_programName;
-        m_commands.put(progName, jc);
-
-        /*
-        * Register aliases
-        */
-        //register command name as an alias of itself for reverse lookup
-        //Note: Name clash check is intentionally omitted to resemble the
-        //     original behaviour of clashing commands.
-        //     Aliases are, however, are strictly checked for name clashes.
-        aliasMap.put(name, progName);
-        for (String alias : aliases) {
-            //omit pointless aliases to avoid name clash exception
-            if (!alias.equals(name)) {
-                ProgramName mappedName = aliasMap.get(alias);
-                if (mappedName != null && !mappedName.equals(progName)) {
-                    throw new ParameterException("Cannot set alias " + alias
-                          + " for " + name
-                          + " command because it has already been defined for "
-                          + mappedName.m_name + " command");
-                }
-                aliasMap.put(alias, progName);
-            }
-        }
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((m_name == null) ? 0 : m_name.hashCode());
+      return result;
     }
 
-    public Map<String, JCommander> getCommands() {
-        Map<String, JCommander> res = Maps.newLinkedHashMap();
-        for (Map.Entry<ProgramName, JCommander> entry : m_commands.entrySet()) {
-            res.put(entry.getKey().m_name, entry.getValue());
-        }
-        return res;
-    }
-
-    public String getParsedCommand() {
-        return m_parsedCommand;
-    }
-
-    /**
-     * The name of the command or the alias in the form it was
-     * passed to the command line. <code>null</code> if no
-     * command or alias was specified.
-     *
-     * @return Name of command or alias passed to command line. If none passed: <code>null</code>.
-     */
-    public String getParsedAlias() {
-        return m_parsedAlias;
-    }
-
-    /**
-     * @return n spaces
-     */
-    private String s(int count) {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < count; i++) {
-            result.append(" ");
-        }
-
-        return result.toString();
-    }
-
-    /**
-     * @return the objects that JCommander will fill with the result of
-     *         parsing the command line.
-     */
-    public List<Object> getObjects() {
-        return m_objects;
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      ProgramName other = (ProgramName) obj;
+      if (m_name == null) {
+        if (other.m_name != null)
+          return false;
+      } else if (!m_name.equals(other.m_name))
+        return false;
+      return true;
     }
 
     /*
-    * Reverse lookup JCommand object by command's name or its alias
+    * Important: ProgramName#toString() is used by longestName(Collection) function
+    * to format usage output.
     */
-    private JCommander findCommandByAlias(String commandOrAlias) {
-        ProgramName progName = aliasMap.get(commandOrAlias);
-        if (progName == null) {
-            return null;
-        }
-        JCommander jc = m_commands.get(progName);
-        if (jc == null) {
-            throw new IllegalStateException(
-                  "There appears to be inconsistency in the internal command database. " +
-                        " This is likely a bug. Please report.");
-        }
-        return jc;
+    @Override
+    public String toString() {
+      return getDisplayName();
+
     }
-
-    private static final class ProgramName {
-        private final String m_name;
-        private final List<String> m_aliases;
-
-        ProgramName(String name, List<String> aliases) {
-            m_name = name;
-            m_aliases = aliases;
-        }
-
-        public String getName() {
-            return m_name;
-        }
-
-        private String getDisplayName() {
-            StringBuilder sb = new StringBuilder();
-            sb.append(m_name);
-            if (!m_aliases.isEmpty()) {
-                sb.append("(");
-                Iterator<String> aliasesIt = m_aliases.iterator();
-                while (aliasesIt.hasNext()) {
-                    sb.append(aliasesIt.next());
-                    if (aliasesIt.hasNext()) {
-                        sb.append(",");
-                    }
-                }
-                sb.append(")");
-            }
-            return sb.toString();
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((m_name == null) ? 0 : m_name.hashCode());
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            ProgramName other = (ProgramName) obj;
-            if (m_name == null) {
-                if (other.m_name != null)
-                    return false;
-            } else if (!m_name.equals(other.m_name))
-                return false;
-            return true;
-        }
-
-        /*
-        * Important: ProgramName#toString() is used by longestName(Collection) function
-        * to format usage output.
-        */
-        @Override
-        public String toString() {
-            return getDisplayName();
-
-        }
-    }
+  }
 }
 

--- a/src/main/java/com/beust/jcommander/internal/AbbreviationMap.java
+++ b/src/main/java/com/beust/jcommander/internal/AbbreviationMap.java
@@ -1,0 +1,234 @@
+/*
+ The MIT License
+
+ Copyright (c) 2004-2011 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.beust.jcommander.internal;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * <p>A map whose keys are strings; when a key/value pair is added to the map, the longest unique abbreviations of that
+ * key are added as well, and associated with the value. Thus:</p>
+ *
+ * <pre>
+ *   <code>
+ *   abbreviations.put( "good", "bye" );
+ *   </code>
+ * </pre>
+ *
+ * <p>would make it such that you could retrieve the value {@code "bye"} from the map using the keys {@code "good"},
+ * {@code "goo"}, {@code "go"}, and {@code "g"}. A subsequent invocation of:</p>
+ * <pre>
+ *   <code>
+ *   abbreviations.put( "go", "fish" );
+ *   </code>
+ * </pre>
+ *
+ * <p>would make it such that you could retrieve the value {@code "bye"} using the keys {@code "good"} and
+ * {@code "goo"}, and the value {@code "fish"} using the key {@code "go"}.  The key {@code "g"} would yield
+ * {@code null}, since it would no longer be a unique abbreviation.</p>
+ *
+ * <p>The data structure is much like a "trie".</p>
+ *
+ * @param <V> a constraint on the types of the values in the map
+ * @author <a href="mailto:pholser@alumni.rice.edu">Paul Holser</a>
+ * @see <a href="http://www.perldoc.com/perl5.8.0/lib/Text/Abbrev.html">Perl's Text::Abbrev module</a>
+ */
+public class AbbreviationMap<V> {
+    private String key;
+    private V value;
+    private final Map<Character, AbbreviationMap<V>> children = new TreeMap<Character, AbbreviationMap<V>>();
+    private int keysBeyond;
+
+    /**
+     * <p>Tells whether the given key is in the map, or whether the given key is a unique
+     * abbreviation of a key that is in the map.</p>
+     *
+     * @param aKey key to look up
+     * @return {@code true} if {@code key} is present in the map
+     * @throws NullPointerException if {@code key} is {@code null}
+     */
+    public boolean contains( String aKey ) {
+        return get( aKey ) != null;
+    }
+
+    /**
+     * <p>Answers the value associated with the given key.  The key can be a unique
+     * abbreviation of a key that is in the map. </p>
+     *
+     * @param aKey key to look up
+     * @return the value associated with {@code aKey}; or {@code null} if there is no
+     * such value or {@code aKey} is not a unique abbreviation of a key in the map
+     * @throws NullPointerException if {@code aKey} is {@code null}
+     */
+    public V get( String aKey ) {
+        char[] chars = charsOf( aKey );
+
+        AbbreviationMap<V> child = this;
+        for ( char each : chars ) {
+            child = child.children.get( each );
+            if ( child == null )
+                return null;
+        }
+
+        return child.value;
+    }
+
+    /**
+     * <p>Associates a given value with a given key.  If there was a previous
+     * association, the old value is replaced with the new one.</p>
+     *
+     * @param aKey key to create in the map
+     * @param newValue value to associate with the key
+     * @throws NullPointerException if {@code aKey} or {@code newValue} is {@code null}
+     * @throws IllegalArgumentException if {@code aKey} is a zero-length string
+     */
+    public void put( String aKey, V newValue ) {
+        if ( newValue == null )
+            throw new NullPointerException();
+        if ( aKey.length() == 0 )
+            throw new IllegalArgumentException();
+
+        char[] chars = charsOf( aKey );
+        add( chars, newValue, 0, chars.length );
+    }
+
+    /**
+     * <p>Associates a given value with a given set of keys.  If there was a previous
+     * association, the old value is replaced with the new one.</p>
+     *
+     * @param keys keys to create in the map
+     * @param newValue value to associate with the key
+     * @throws NullPointerException if {@code keys} or {@code newValue} is {@code null}
+     * @throws IllegalArgumentException if any of {@code keys} is a zero-length string
+     */
+    public void putAll( Iterable<String> keys, V newValue ) {
+        for ( String each : keys )
+            put( each, newValue );
+    }
+
+    private boolean add( char[] chars, V newValue, int offset, int length ) {
+        if ( offset == length ) {
+            value = newValue;
+            boolean wasAlreadyAKey = key != null;
+            key = new String( chars );
+            return !wasAlreadyAKey;
+        }
+
+        char nextChar = chars[ offset ];
+        AbbreviationMap<V> child = children.get( nextChar );
+        if ( child == null ) {
+            child = new AbbreviationMap<V>();
+            children.put( nextChar, child );
+        }
+
+        boolean newKeyAdded = child.add( chars, newValue, offset + 1, length );
+
+        if ( newKeyAdded )
+            ++keysBeyond;
+
+        if ( key == null )
+            value = keysBeyond > 1 ? null : newValue;
+
+        return newKeyAdded;
+    }
+
+    /**
+     * <p>If the map contains the given key, dissociates the key from its value.</p>
+     *
+     * @param aKey key to remove
+     * @throws NullPointerException if {@code aKey} is {@code null}
+     * @throws IllegalArgumentException if {@code aKey} is a zero-length string
+     */
+    public void remove( String aKey ) {
+        if ( aKey.length() == 0 )
+            throw new IllegalArgumentException();
+
+        char[] keyChars = charsOf( aKey );
+        remove( keyChars, 0, keyChars.length );
+    }
+
+    private boolean remove( char[] aKey, int offset, int length ) {
+        if ( offset == length )
+            return removeAtEndOfKey();
+
+        char nextChar = aKey[ offset ];
+        AbbreviationMap<V> child = children.get( nextChar );
+        if ( child == null || !child.remove( aKey, offset + 1, length ) )
+            return false;
+
+        --keysBeyond;
+        if ( child.keysBeyond == 0 )
+            children.remove( nextChar );
+        if ( keysBeyond == 1 && key == null )
+            setValueToThatOfOnlyChild();
+
+        return true;
+    }
+
+    private void setValueToThatOfOnlyChild() {
+        Map.Entry<Character, AbbreviationMap<V>> entry = children.entrySet().iterator().next();
+        AbbreviationMap<V> onlyChild = entry.getValue();
+        value = onlyChild.value;
+    }
+
+    private boolean removeAtEndOfKey() {
+        if ( key == null )
+            return false;
+
+        key = null;
+        if ( keysBeyond == 1 )
+            setValueToThatOfOnlyChild();
+        else
+            value = null;
+
+        return true;
+    }
+
+    /**
+    * Gives a Java map representation of this abbreviation map.
+     *
+     * @return a Java map corresponding to this abbreviation map
+     */
+    public Map<String, V> toJavaUtilMap() {
+        Map<String, V> mappings = new TreeMap<String, V>();
+        addToMappings( mappings );
+        return mappings;
+    }
+
+    private void addToMappings( Map<String, V> mappings ) {
+        if ( key != null )
+            mappings.put( key, value );
+
+        for ( AbbreviationMap<V> each : children.values() )
+            each.addToMappings( mappings );
+    }
+
+    private static char[] charsOf( String aKey ) {
+        char[] chars = new char[ aKey.length() ];
+        aKey.getChars( 0, aKey.length(), chars, 0 );
+        return chars;
+    }
+}

--- a/src/main/java/com/beust/jcommander/internal/AbbreviationMap.java
+++ b/src/main/java/com/beust/jcommander/internal/AbbreviationMap.java
@@ -31,13 +31,13 @@ import java.util.TreeMap;
 /**
  * <p>A map whose keys are strings; when a key/value pair is added to the map, the longest unique abbreviations of that
  * key are added as well, and associated with the value. Thus:</p>
- *
+ * <p/>
  * <pre>
  *   <code>
  *   abbreviations.put( "good", "bye" );
  *   </code>
  * </pre>
- *
+ * <p/>
  * <p>would make it such that you could retrieve the value {@code "bye"} from the map using the keys {@code "good"},
  * {@code "goo"}, {@code "go"}, and {@code "g"}. A subsequent invocation of:</p>
  * <pre>
@@ -45,11 +45,11 @@ import java.util.TreeMap;
  *   abbreviations.put( "go", "fish" );
  *   </code>
  * </pre>
- *
+ * <p/>
  * <p>would make it such that you could retrieve the value {@code "bye"} using the keys {@code "good"} and
  * {@code "goo"}, and the value {@code "fish"} using the key {@code "go"}.  The key {@code "g"} would yield
  * {@code null}, since it would no longer be a unique abbreviation.</p>
- *
+ * <p/>
  * <p>The data structure is much like a "trie".</p>
  *
  * @param <V> a constraint on the types of the values in the map
@@ -57,178 +57,178 @@ import java.util.TreeMap;
  * @see <a href="http://www.perldoc.com/perl5.8.0/lib/Text/Abbrev.html">Perl's Text::Abbrev module</a>
  */
 public class AbbreviationMap<V> {
-    private String key;
-    private V value;
-    private final Map<Character, AbbreviationMap<V>> children = new TreeMap<Character, AbbreviationMap<V>>();
-    private int keysBeyond;
+  private String key;
+  private V value;
+  private final Map<Character, AbbreviationMap<V>> children = new TreeMap<Character, AbbreviationMap<V>>();
+  private int keysBeyond;
 
-    /**
-     * <p>Tells whether the given key is in the map, or whether the given key is a unique
-     * abbreviation of a key that is in the map.</p>
-     *
-     * @param aKey key to look up
-     * @return {@code true} if {@code key} is present in the map
-     * @throws NullPointerException if {@code key} is {@code null}
-     */
-    public boolean contains(String aKey) {
-        return get(aKey) != null;
+  /**
+   * <p>Tells whether the given key is in the map, or whether the given key is a unique
+   * abbreviation of a key that is in the map.</p>
+   *
+   * @param aKey key to look up
+   * @return {@code true} if {@code key} is present in the map
+   * @throws NullPointerException if {@code key} is {@code null}
+   */
+  public boolean contains(String aKey) {
+    return get(aKey) != null;
+  }
+
+  /**
+   * <p>Answers the value associated with the given key.  The key can be a unique
+   * abbreviation of a key that is in the map. </p>
+   *
+   * @param aKey key to look up
+   * @return the value associated with {@code aKey}; or {@code null} if there is no
+   *         such value or {@code aKey} is not a unique abbreviation of a key in the map
+   * @throws NullPointerException if {@code aKey} is {@code null}
+   */
+  public V get(String aKey) {
+    char[] chars = charsOf(aKey);
+
+    AbbreviationMap<V> child = this;
+    for (char each : chars) {
+      child = child.children.get(each);
+      if (child == null)
+        return null;
     }
 
-    /**
-     * <p>Answers the value associated with the given key.  The key can be a unique
-     * abbreviation of a key that is in the map. </p>
-     *
-     * @param aKey key to look up
-     * @return the value associated with {@code aKey}; or {@code null} if there is no
-     *         such value or {@code aKey} is not a unique abbreviation of a key in the map
-     * @throws NullPointerException if {@code aKey} is {@code null}
-     */
-    public V get(String aKey) {
-        char[] chars = charsOf(aKey);
+    return child.value;
+  }
 
-        AbbreviationMap<V> child = this;
-        for (char each : chars) {
-            child = child.children.get(each);
-            if (child == null)
-                return null;
-        }
+  /**
+   * <p>Associates a given value with a given key.  If there was a previous
+   * association, the old value is replaced with the new one.</p>
+   *
+   * @param aKey     key to create in the map
+   * @param newValue value to associate with the key
+   * @throws NullPointerException     if {@code aKey} or {@code newValue} is {@code null}
+   * @throws IllegalArgumentException if {@code aKey} is a zero-length string
+   */
+  public void put(String aKey, V newValue) {
+    if (newValue == null)
+      throw new NullPointerException();
+    if (aKey.length() == 0)
+      throw new IllegalArgumentException();
 
-        return child.value;
+    char[] chars = charsOf(aKey);
+    add(chars, newValue, 0, chars.length);
+  }
+
+  /**
+   * <p>Associates a given value with a given set of keys.  If there was a previous
+   * association, the old value is replaced with the new one.</p>
+   *
+   * @param keys     keys to create in the map
+   * @param newValue value to associate with the key
+   * @throws NullPointerException     if {@code keys} or {@code newValue} is {@code null}
+   * @throws IllegalArgumentException if any of {@code keys} is a zero-length string
+   */
+  public void putAll(Iterable<String> keys, V newValue) {
+    for (String each : keys)
+      put(each, newValue);
+  }
+
+  private boolean add(char[] chars, V newValue, int offset, int length) {
+    if (offset == length) {
+      value = newValue;
+      boolean wasAlreadyAKey = key != null;
+      key = new String(chars);
+      return !wasAlreadyAKey;
     }
 
-    /**
-     * <p>Associates a given value with a given key.  If there was a previous
-     * association, the old value is replaced with the new one.</p>
-     *
-     * @param aKey     key to create in the map
-     * @param newValue value to associate with the key
-     * @throws NullPointerException     if {@code aKey} or {@code newValue} is {@code null}
-     * @throws IllegalArgumentException if {@code aKey} is a zero-length string
-     */
-    public void put(String aKey, V newValue) {
-        if (newValue == null)
-            throw new NullPointerException();
-        if (aKey.length() == 0)
-            throw new IllegalArgumentException();
-
-        char[] chars = charsOf(aKey);
-        add(chars, newValue, 0, chars.length);
+    char nextChar = chars[offset];
+    AbbreviationMap<V> child = children.get(nextChar);
+    if (child == null) {
+      child = new AbbreviationMap<V>();
+      children.put(nextChar, child);
     }
 
-    /**
-     * <p>Associates a given value with a given set of keys.  If there was a previous
-     * association, the old value is replaced with the new one.</p>
-     *
-     * @param keys     keys to create in the map
-     * @param newValue value to associate with the key
-     * @throws NullPointerException     if {@code keys} or {@code newValue} is {@code null}
-     * @throws IllegalArgumentException if any of {@code keys} is a zero-length string
-     */
-    public void putAll(Iterable<String> keys, V newValue) {
-        for (String each : keys)
-            put(each, newValue);
-    }
+    boolean newKeyAdded = child.add(chars, newValue, offset + 1, length);
 
-    private boolean add(char[] chars, V newValue, int offset, int length) {
-        if (offset == length) {
-            value = newValue;
-            boolean wasAlreadyAKey = key != null;
-            key = new String(chars);
-            return !wasAlreadyAKey;
-        }
+    if (newKeyAdded)
+      ++keysBeyond;
 
-        char nextChar = chars[offset];
-        AbbreviationMap<V> child = children.get(nextChar);
-        if (child == null) {
-            child = new AbbreviationMap<V>();
-            children.put(nextChar, child);
-        }
+    if (key == null)
+      value = keysBeyond > 1 ? null : newValue;
 
-        boolean newKeyAdded = child.add(chars, newValue, offset + 1, length);
+    return newKeyAdded;
+  }
 
-        if (newKeyAdded)
-            ++keysBeyond;
+  /**
+   * <p>If the map contains the given key, dissociates the key from its value.</p>
+   *
+   * @param aKey key to remove
+   * @throws NullPointerException     if {@code aKey} is {@code null}
+   * @throws IllegalArgumentException if {@code aKey} is a zero-length string
+   */
+  public void remove(String aKey) {
+    if (aKey.length() == 0)
+      throw new IllegalArgumentException();
 
-        if (key == null)
-            value = keysBeyond > 1 ? null : newValue;
+    char[] keyChars = charsOf(aKey);
+    remove(keyChars, 0, keyChars.length);
+  }
 
-        return newKeyAdded;
-    }
+  private boolean remove(char[] aKey, int offset, int length) {
+    if (offset == length)
+      return removeAtEndOfKey();
 
-    /**
-     * <p>If the map contains the given key, dissociates the key from its value.</p>
-     *
-     * @param aKey key to remove
-     * @throws NullPointerException     if {@code aKey} is {@code null}
-     * @throws IllegalArgumentException if {@code aKey} is a zero-length string
-     */
-    public void remove(String aKey) {
-        if (aKey.length() == 0)
-            throw new IllegalArgumentException();
+    char nextChar = aKey[offset];
+    AbbreviationMap<V> child = children.get(nextChar);
+    if (child == null || !child.remove(aKey, offset + 1, length))
+      return false;
 
-        char[] keyChars = charsOf(aKey);
-        remove(keyChars, 0, keyChars.length);
-    }
+    --keysBeyond;
+    if (child.keysBeyond == 0)
+      children.remove(nextChar);
+    if (keysBeyond == 1 && key == null)
+      setValueToThatOfOnlyChild();
 
-    private boolean remove(char[] aKey, int offset, int length) {
-        if (offset == length)
-            return removeAtEndOfKey();
+    return true;
+  }
 
-        char nextChar = aKey[offset];
-        AbbreviationMap<V> child = children.get(nextChar);
-        if (child == null || !child.remove(aKey, offset + 1, length))
-            return false;
+  private void setValueToThatOfOnlyChild() {
+    Map.Entry<Character, AbbreviationMap<V>> entry = children.entrySet().iterator().next();
+    AbbreviationMap<V> onlyChild = entry.getValue();
+    value = onlyChild.value;
+  }
 
-        --keysBeyond;
-        if (child.keysBeyond == 0)
-            children.remove(nextChar);
-        if (keysBeyond == 1 && key == null)
-            setValueToThatOfOnlyChild();
+  private boolean removeAtEndOfKey() {
+    if (key == null)
+      return false;
 
-        return true;
-    }
+    key = null;
+    if (keysBeyond == 1)
+      setValueToThatOfOnlyChild();
+    else
+      value = null;
 
-    private void setValueToThatOfOnlyChild() {
-        Map.Entry<Character, AbbreviationMap<V>> entry = children.entrySet().iterator().next();
-        AbbreviationMap<V> onlyChild = entry.getValue();
-        value = onlyChild.value;
-    }
+    return true;
+  }
 
-    private boolean removeAtEndOfKey() {
-        if (key == null)
-            return false;
+  /**
+   * Gives a Java map representation of this abbreviation map.
+   *
+   * @return a Java map corresponding to this abbreviation map
+   */
+  public Map<String, V> toJavaUtilMap() {
+    Map<String, V> mappings = new TreeMap<String, V>();
+    addToMappings(mappings);
+    return mappings;
+  }
 
-        key = null;
-        if (keysBeyond == 1)
-            setValueToThatOfOnlyChild();
-        else
-            value = null;
+  private void addToMappings(Map<String, V> mappings) {
+    if (key != null)
+      mappings.put(key, value);
 
-        return true;
-    }
+    for (AbbreviationMap<V> each : children.values())
+      each.addToMappings(mappings);
+  }
 
-    /**
-     * Gives a Java map representation of this abbreviation map.
-     *
-     * @return a Java map corresponding to this abbreviation map
-     */
-    public Map<String, V> toJavaUtilMap() {
-        Map<String, V> mappings = new TreeMap<String, V>();
-        addToMappings(mappings);
-        return mappings;
-    }
-
-    private void addToMappings(Map<String, V> mappings) {
-        if (key != null)
-            mappings.put(key, value);
-
-        for (AbbreviationMap<V> each : children.values())
-            each.addToMappings(mappings);
-    }
-
-    private static char[] charsOf(String aKey) {
-        char[] chars = new char[aKey.length()];
-        aKey.getChars(0, aKey.length(), chars, 0);
-        return chars;
-    }
+  private static char[] charsOf(String aKey) {
+    char[] chars = new char[aKey.length()];
+    aKey.getChars(0, aKey.length(), chars, 0);
+    return chars;
+  }
 }

--- a/src/main/java/com/beust/jcommander/internal/AbbreviationMap.java
+++ b/src/main/java/com/beust/jcommander/internal/AbbreviationMap.java
@@ -70,8 +70,8 @@ public class AbbreviationMap<V> {
      * @return {@code true} if {@code key} is present in the map
      * @throws NullPointerException if {@code key} is {@code null}
      */
-    public boolean contains( String aKey ) {
-        return get( aKey ) != null;
+    public boolean contains(String aKey) {
+        return get(aKey) != null;
     }
 
     /**
@@ -80,16 +80,16 @@ public class AbbreviationMap<V> {
      *
      * @param aKey key to look up
      * @return the value associated with {@code aKey}; or {@code null} if there is no
-     * such value or {@code aKey} is not a unique abbreviation of a key in the map
+     *         such value or {@code aKey} is not a unique abbreviation of a key in the map
      * @throws NullPointerException if {@code aKey} is {@code null}
      */
-    public V get( String aKey ) {
-        char[] chars = charsOf( aKey );
+    public V get(String aKey) {
+        char[] chars = charsOf(aKey);
 
         AbbreviationMap<V> child = this;
-        for ( char each : chars ) {
-            child = child.children.get( each );
-            if ( child == null )
+        for (char each : chars) {
+            child = child.children.get(each);
+            if (child == null)
                 return null;
         }
 
@@ -100,56 +100,56 @@ public class AbbreviationMap<V> {
      * <p>Associates a given value with a given key.  If there was a previous
      * association, the old value is replaced with the new one.</p>
      *
-     * @param aKey key to create in the map
+     * @param aKey     key to create in the map
      * @param newValue value to associate with the key
-     * @throws NullPointerException if {@code aKey} or {@code newValue} is {@code null}
+     * @throws NullPointerException     if {@code aKey} or {@code newValue} is {@code null}
      * @throws IllegalArgumentException if {@code aKey} is a zero-length string
      */
-    public void put( String aKey, V newValue ) {
-        if ( newValue == null )
+    public void put(String aKey, V newValue) {
+        if (newValue == null)
             throw new NullPointerException();
-        if ( aKey.length() == 0 )
+        if (aKey.length() == 0)
             throw new IllegalArgumentException();
 
-        char[] chars = charsOf( aKey );
-        add( chars, newValue, 0, chars.length );
+        char[] chars = charsOf(aKey);
+        add(chars, newValue, 0, chars.length);
     }
 
     /**
      * <p>Associates a given value with a given set of keys.  If there was a previous
      * association, the old value is replaced with the new one.</p>
      *
-     * @param keys keys to create in the map
+     * @param keys     keys to create in the map
      * @param newValue value to associate with the key
-     * @throws NullPointerException if {@code keys} or {@code newValue} is {@code null}
+     * @throws NullPointerException     if {@code keys} or {@code newValue} is {@code null}
      * @throws IllegalArgumentException if any of {@code keys} is a zero-length string
      */
-    public void putAll( Iterable<String> keys, V newValue ) {
-        for ( String each : keys )
-            put( each, newValue );
+    public void putAll(Iterable<String> keys, V newValue) {
+        for (String each : keys)
+            put(each, newValue);
     }
 
-    private boolean add( char[] chars, V newValue, int offset, int length ) {
-        if ( offset == length ) {
+    private boolean add(char[] chars, V newValue, int offset, int length) {
+        if (offset == length) {
             value = newValue;
             boolean wasAlreadyAKey = key != null;
-            key = new String( chars );
+            key = new String(chars);
             return !wasAlreadyAKey;
         }
 
-        char nextChar = chars[ offset ];
-        AbbreviationMap<V> child = children.get( nextChar );
-        if ( child == null ) {
+        char nextChar = chars[offset];
+        AbbreviationMap<V> child = children.get(nextChar);
+        if (child == null) {
             child = new AbbreviationMap<V>();
-            children.put( nextChar, child );
+            children.put(nextChar, child);
         }
 
-        boolean newKeyAdded = child.add( chars, newValue, offset + 1, length );
+        boolean newKeyAdded = child.add(chars, newValue, offset + 1, length);
 
-        if ( newKeyAdded )
+        if (newKeyAdded)
             ++keysBeyond;
 
-        if ( key == null )
+        if (key == null)
             value = keysBeyond > 1 ? null : newValue;
 
         return newKeyAdded;
@@ -159,30 +159,30 @@ public class AbbreviationMap<V> {
      * <p>If the map contains the given key, dissociates the key from its value.</p>
      *
      * @param aKey key to remove
-     * @throws NullPointerException if {@code aKey} is {@code null}
+     * @throws NullPointerException     if {@code aKey} is {@code null}
      * @throws IllegalArgumentException if {@code aKey} is a zero-length string
      */
-    public void remove( String aKey ) {
-        if ( aKey.length() == 0 )
+    public void remove(String aKey) {
+        if (aKey.length() == 0)
             throw new IllegalArgumentException();
 
-        char[] keyChars = charsOf( aKey );
-        remove( keyChars, 0, keyChars.length );
+        char[] keyChars = charsOf(aKey);
+        remove(keyChars, 0, keyChars.length);
     }
 
-    private boolean remove( char[] aKey, int offset, int length ) {
-        if ( offset == length )
+    private boolean remove(char[] aKey, int offset, int length) {
+        if (offset == length)
             return removeAtEndOfKey();
 
-        char nextChar = aKey[ offset ];
-        AbbreviationMap<V> child = children.get( nextChar );
-        if ( child == null || !child.remove( aKey, offset + 1, length ) )
+        char nextChar = aKey[offset];
+        AbbreviationMap<V> child = children.get(nextChar);
+        if (child == null || !child.remove(aKey, offset + 1, length))
             return false;
 
         --keysBeyond;
-        if ( child.keysBeyond == 0 )
-            children.remove( nextChar );
-        if ( keysBeyond == 1 && key == null )
+        if (child.keysBeyond == 0)
+            children.remove(nextChar);
+        if (keysBeyond == 1 && key == null)
             setValueToThatOfOnlyChild();
 
         return true;
@@ -195,11 +195,11 @@ public class AbbreviationMap<V> {
     }
 
     private boolean removeAtEndOfKey() {
-        if ( key == null )
+        if (key == null)
             return false;
 
         key = null;
-        if ( keysBeyond == 1 )
+        if (keysBeyond == 1)
             setValueToThatOfOnlyChild();
         else
             value = null;
@@ -208,27 +208,27 @@ public class AbbreviationMap<V> {
     }
 
     /**
-    * Gives a Java map representation of this abbreviation map.
+     * Gives a Java map representation of this abbreviation map.
      *
      * @return a Java map corresponding to this abbreviation map
      */
     public Map<String, V> toJavaUtilMap() {
         Map<String, V> mappings = new TreeMap<String, V>();
-        addToMappings( mappings );
+        addToMappings(mappings);
         return mappings;
     }
 
-    private void addToMappings( Map<String, V> mappings ) {
-        if ( key != null )
-            mappings.put( key, value );
+    private void addToMappings(Map<String, V> mappings) {
+        if (key != null)
+            mappings.put(key, value);
 
-        for ( AbbreviationMap<V> each : children.values() )
-            each.addToMappings( mappings );
+        for (AbbreviationMap<V> each : children.values())
+            each.addToMappings(mappings);
     }
 
-    private static char[] charsOf( String aKey ) {
-        char[] chars = new char[ aKey.length() ];
-        aKey.getChars( 0, aKey.length(), chars, 0 );
+    private static char[] charsOf(String aKey) {
+        char[] chars = new char[aKey.length()];
+        aKey.getChars(0, aKey.length(), chars, 0);
         return chars;
     }
 }

--- a/src/test/java/com/beust/jcommander/JCommanderWithAbbreviationsTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderWithAbbreviationsTest.java
@@ -20,265 +20,265 @@ import java.util.List;
 
 public class JCommanderWithAbbreviationsTest {
 
-   public static class OptionSet1 {
-      @Parameter(names = "--alpha")
-      private int alpha;
+    public static class OptionSet1 {
+        @Parameter(names = "--alpha")
+        private int alpha;
 
-      @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
-      private String beta;
+        @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
+        private String beta;
 
-      @Parameter(names = "--bellamy")
-      public boolean bellamy;
-
-
-      public int getAlpha() {
-         return alpha;
-      }
-
-      public String getBeta() {
-         return beta;
-      }
-   }
-
-   public static class OptionSet1WithMain extends OptionSet1 {
-      @Parameter
-      private List<String> theRest;
-   }
-
-   @Parameters(optionPrefixes = "^")
-   public static class OptionSet2 {
-      @Parameter(names = "^aleph")
-      private int aleph;
-
-      @Parameter(names = {"^beit", "^veit", "^triskaidekaphobia"})
-      private String beit;
-
-      @Parameter(names = "^better")
-      public boolean better;
-
-      public int getAleph() {
-         return aleph;
-      }
-
-      public String getBeit() {
-         return beit;
-      }
-   }
-
-   @Parameters(optionPrefixes = "^")
-   public static class OptionSet2WithMain extends OptionSet2 {
-      @Parameter
-      private List<String> everythingElse;
-   }
+        @Parameter(names = "--bellamy")
+        public boolean bellamy;
 
 
-   public static class OptionSet3 {
-      @Parameter(names = "--alpha", required = true)
-      private int alpha;
+        public int getAlpha() {
+            return alpha;
+        }
 
-      @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
-      private String beta;
+        public String getBeta() {
+            return beta;
+        }
+    }
 
-      @Parameter(names = "--bellamy")
-      public boolean bellamy;
+    public static class OptionSet1WithMain extends OptionSet1 {
+        @Parameter
+        private List<String> theRest;
+    }
 
-      public int getAlpha() {
-         return alpha;
-      }
+    @Parameters(optionPrefixes = "^")
+    public static class OptionSet2 {
+        @Parameter(names = "^aleph")
+        private int aleph;
 
-      public String getBeta() {
-         return beta;
-      }
-   }
+        @Parameter(names = {"^beit", "^veit", "^triskaidekaphobia"})
+        private String beit;
 
-   public static class OptionSet4 {
-      @Parameter(names = "-v")
-      private boolean verbose;
-   }
+        @Parameter(names = "^better")
+        public boolean better;
 
-   //
-   // parseWithAbbreviations -- basic behavior
-   //
+        public int getAleph() {
+            return aleph;
+        }
 
+        public String getBeit() {
+            return beit;
+        }
+    }
 
-   @Test
-   public void parseWithAbbreviationsHandlesFullOptionNames() throws Throwable {
-      String[] args = {"--beta", "bs", "--alpha", "14", "--bellamy"};
-      OptionSet1 opt = new OptionSet1();
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(true, args);
-      Assert.assertEquals(opt.getBeta(), "bs");
-      Assert.assertEquals(opt.getAlpha(), 14);
-      Assert.assertTrue(opt.bellamy);
-   }
-
-   @Test
-   public void parseWithAbbreviationsHandlesFullOptionNames_differentPrefix() throws Throwable {
-      String[] args = {"^beit", "bs", "^aleph", "14", "^better"};
-      OptionSet2 opt = new OptionSet2();
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(true, args);
-      Assert.assertEquals(opt.getBeit(), "bs");
-      Assert.assertEquals(opt.getAleph(), 14);
-      Assert.assertTrue(opt.better);
-   }
-
-   @Test
-   public void parseWithAbbreviationsHandlesAbbreviatedOptionNames() throws Throwable {
-      String[] args = {"--bet", "bs", "--a", "14", "--bel"};
-      OptionSet1 opt = new OptionSet1();
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(true, args);
-      Assert.assertEquals(opt.getBeta(), "bs");
-      Assert.assertEquals(opt.getAlpha(), 14);
-      Assert.assertTrue(opt.bellamy);
-   }
-
-   @Test
-   public void parseWithAbbreviationsHandlesAbbreviatedOptionNames_differentPrefix() throws Throwable {
-      String[] args = {"^bei", "bs", "^a", "14", "^bet"};
-      OptionSet2 opt = new OptionSet2();
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(true, args);
-      Assert.assertEquals(opt.getBeit(), "bs");
-      Assert.assertEquals(opt.getAleph(), 14);
-      Assert.assertTrue(opt.better);
-   }
-
-   //
-   // parseWithAbbreviations -- Error detection
-   //
+    @Parameters(optionPrefixes = "^")
+    public static class OptionSet2WithMain extends OptionSet2 {
+        @Parameter
+        private List<String> everythingElse;
+    }
 
 
-   @Test(expectedExceptions = ParameterException.class)
-   public void parseWithAbbreviationsThrowsExceptionIfParameterNotRecognized() throws Throwable {
-      String[] args = {"--noSuchParam"};
-      OptionSet1 opt = new OptionSet1();
+    public static class OptionSet3 {
+        @Parameter(names = "--alpha", required = true)
+        private int alpha;
 
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(args);
-   }
+        @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
+        private String beta;
 
-   @Test(expectedExceptions = ParameterException.class)
-   public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort() throws Throwable {
-      String[] args = {"--be", "bs"};
-      OptionSet1 opt = new OptionSet1();
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(true, args);
-   }
+        @Parameter(names = "--bellamy")
+        public boolean bellamy;
 
-   @Test
-   public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort_differentPrefix() throws Throwable {
-      String[] args = {"^be", "bs"};
-      OptionSet2 opt = new OptionSet2();
-      JCommander jc = new JCommander(opt);
-      try {
-         jc.parseWithAbbreviations(true, args);
-         Assert.fail("ParamterException should be thrown because ^be is not a unique prefix");
-      } catch (ParameterException e) {
-         // If the exception messge contains "main parameter", it means that ^be was not recognized as a parameter.
-         Assert.assertFalse(e.getMessage().contains("main parameter"), "Prefix not correctly recognized");
-         Assert.assertTrue(e.getMessage().contains("Unknown"));
-      }
-   }
+        public int getAlpha() {
+            return alpha;
+        }
 
-   @Test
-   public void parseWithAbbreviationsThrowsExceptionIfWrongPrefixUsed() {
-      String[] args = {"=be", "bs"};
-      OptionSet2 opt = new OptionSet2();
-      JCommander jc = new JCommander(opt);
-      try {
-         jc.parseWithAbbreviations(true, args);
-         Assert.fail("ParamterException should be thrown because = is the wrong prefix");
-      } catch (ParameterException e) {
-         Assert.assertTrue(e.getMessage().contains("main parameter"));
-         Assert.assertFalse(e.getMessage().contains("Unknown"));
-      }
-   }
+        public String getBeta() {
+            return beta;
+        }
+    }
+
+    public static class OptionSet4 {
+        @Parameter(names = "-v")
+        private boolean verbose;
+    }
+
+    //
+    // parseWithAbbreviations -- basic behavior
+    //
 
 
-   @Test(expectedExceptions = ParameterException.class)
-   public void parseWithAbbreviationsThrowsExceptionIfParameterTooLong() throws Throwable {
-      String[] args = {"--alphax"};
-      OptionSet1 opt = new OptionSet1();
+    @Test
+    public void parseWithAbbreviationsHandlesFullOptionNames() throws Throwable {
+        String[] args = {"--beta", "bs", "--alpha", "14", "--bellamy"};
+        OptionSet1 opt = new OptionSet1();
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(true, args);
+        Assert.assertEquals(opt.getBeta(), "bs");
+        Assert.assertEquals(opt.getAlpha(), 14);
+        Assert.assertTrue(opt.bellamy);
+    }
 
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(true, args);
-   }
+    @Test
+    public void parseWithAbbreviationsHandlesFullOptionNames_differentPrefix() throws Throwable {
+        String[] args = {"^beit", "bs", "^aleph", "14", "^better"};
+        OptionSet2 opt = new OptionSet2();
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(true, args);
+        Assert.assertEquals(opt.getBeit(), "bs");
+        Assert.assertEquals(opt.getAleph(), 14);
+        Assert.assertTrue(opt.better);
+    }
 
-   //
-   // parseWithAbbreviations -- validation
-   //
+    @Test
+    public void parseWithAbbreviationsHandlesAbbreviatedOptionNames() throws Throwable {
+        String[] args = {"--bet", "bs", "--a", "14", "--bel"};
+        OptionSet1 opt = new OptionSet1();
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(true, args);
+        Assert.assertEquals(opt.getBeta(), "bs");
+        Assert.assertEquals(opt.getAlpha(), 14);
+        Assert.assertTrue(opt.bellamy);
+    }
 
-   @Test
-   public void parseWithAbbreviationsValidatesByDefault() {
-      String[] args = {"--bet", "bs"};
-      OptionSet3 opt = new OptionSet3();
-      JCommander jc = new JCommander(opt);
-      try {
-         jc.parseWithAbbreviations(args);
-         Assert.fail("Expected exception to be thrown complaining about lack of required option");
-      } catch (ParameterException e) {
-         String actual = e.getMessage();
-         Assert.assertTrue(actual.contains("option is required"), "Exception should mention parameter is required.");
-         Assert.assertTrue(actual.contains("--alpha"), "Exception should specifically mention required parameter.");
-      }
-   }
+    @Test
+    public void parseWithAbbreviationsHandlesAbbreviatedOptionNames_differentPrefix() throws Throwable {
+        String[] args = {"^bei", "bs", "^a", "14", "^bet"};
+        OptionSet2 opt = new OptionSet2();
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(true, args);
+        Assert.assertEquals(opt.getBeit(), "bs");
+        Assert.assertEquals(opt.getAleph(), 14);
+        Assert.assertTrue(opt.better);
+    }
 
-   @Test
-   public void parseWithAbbreviationsCanChooseNotToValidate() {
-      String[] args = {"--bet", "bs"};
-      OptionSet3 opt = new OptionSet3();
-      JCommander jc = new JCommander(opt);
-      jc.parseWithAbbreviations(false, args);
-      Assert.assertEquals(opt.getBeta(), "bs");
-      Assert.assertEquals(opt.getAlpha(), 0);
-      Assert.assertFalse(opt.bellamy);
-   }
+    //
+    // parseWithAbbreviations -- Error detection
+    //
 
-   //
-   // parseWithAbbreviations -- commands
-   //
 
-   @Test
-   public void parseWithAbbreviationsWorksWithCommands() {
+    @Test(expectedExceptions = ParameterException.class)
+    public void parseWithAbbreviationsThrowsExceptionIfParameterNotRecognized() throws Throwable {
+        String[] args = {"--noSuchParam"};
+        OptionSet1 opt = new OptionSet1();
 
-      OptionSet4 os4 = new OptionSet4();
-      OptionSet1WithMain os1 = new OptionSet1WithMain();
-      OptionSet2 os2 = new OptionSet2();
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(args);
+    }
 
-      JCommander jc = new JCommander(os4);
-      jc.addCommand("c1", os1);
-      jc.addCommand("c2", os2);
+    @Test(expectedExceptions = ParameterException.class)
+    public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort() throws Throwable {
+        String[] args = {"--be", "bs"};
+        OptionSet1 opt = new OptionSet1();
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(true, args);
+    }
 
-      String[] args = {"-v", "c1", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
-      jc.parseWithAbbreviations(true, args);
-      Assert.assertTrue(os4.verbose);
-      Assert.assertEquals(os1.getBeta(), "bs");
-      Assert.assertEquals(os1.getAlpha(), 14);
-      Assert.assertTrue(os1.bellamy);
-      Assert.assertEquals(os1.theRest, java.util.Arrays.asList(new String[]{"^bei", "zzg", "^a", "19", "^bet"}));
-   }
+    @Test
+    public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort_differentPrefix() throws Throwable {
+        String[] args = {"^be", "bs"};
+        OptionSet2 opt = new OptionSet2();
+        JCommander jc = new JCommander(opt);
+        try {
+            jc.parseWithAbbreviations(true, args);
+            Assert.fail("ParamterException should be thrown because ^be is not a unique prefix");
+        } catch (ParameterException e) {
+            // If the exception messge contains "main parameter", it means that ^be was not recognized as a parameter.
+            Assert.assertFalse(e.getMessage().contains("main parameter"), "Prefix not correctly recognized");
+            Assert.assertTrue(e.getMessage().contains("Unknown"));
+        }
+    }
 
-   @Test
-   public void parseWithAbbreviationsWorksWithCommands_differentPrefix() {
+    @Test
+    public void parseWithAbbreviationsThrowsExceptionIfWrongPrefixUsed() {
+        String[] args = {"=be", "bs"};
+        OptionSet2 opt = new OptionSet2();
+        JCommander jc = new JCommander(opt);
+        try {
+            jc.parseWithAbbreviations(true, args);
+            Assert.fail("ParamterException should be thrown because = is the wrong prefix");
+        } catch (ParameterException e) {
+            Assert.assertTrue(e.getMessage().contains("main parameter"));
+            Assert.assertFalse(e.getMessage().contains("Unknown"));
+        }
+    }
 
-      OptionSet4 os4 = new OptionSet4();
-      OptionSet1WithMain os1 = new OptionSet1WithMain();
-      OptionSet2WithMain os2 = new OptionSet2WithMain();
 
-      JCommander jc = new JCommander(os4);
-      jc.addCommand("c1", os1);
-      jc.addCommand("c2", os2);
+    @Test(expectedExceptions = ParameterException.class)
+    public void parseWithAbbreviationsThrowsExceptionIfParameterTooLong() throws Throwable {
+        String[] args = {"--alphax"};
+        OptionSet1 opt = new OptionSet1();
 
-      String[] args = {"-v", "c2", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
-      jc.parseWithAbbreviations(true, args);
-      Assert.assertTrue(os4.verbose);
-      Assert.assertEquals(os2.getBeit(), "zzg");
-      Assert.assertEquals(os2.getAleph(), 19);
-      Assert.assertTrue(os2.better);
-      Assert.assertEquals(os2.everythingElse, java.util.Arrays.asList(new String[]{"--beta", "bs", "--alpha", "14", "--bellamy"}));
-   }
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(true, args);
+    }
+
+    //
+    // parseWithAbbreviations -- validation
+    //
+
+    @Test
+    public void parseWithAbbreviationsValidatesByDefault() {
+        String[] args = {"--bet", "bs"};
+        OptionSet3 opt = new OptionSet3();
+        JCommander jc = new JCommander(opt);
+        try {
+            jc.parseWithAbbreviations(args);
+            Assert.fail("Expected exception to be thrown complaining about lack of required option");
+        } catch (ParameterException e) {
+            String actual = e.getMessage();
+            Assert.assertTrue(actual.contains("option is required"), "Exception should mention parameter is required.");
+            Assert.assertTrue(actual.contains("--alpha"), "Exception should specifically mention required parameter.");
+        }
+    }
+
+    @Test
+    public void parseWithAbbreviationsCanChooseNotToValidate() {
+        String[] args = {"--bet", "bs"};
+        OptionSet3 opt = new OptionSet3();
+        JCommander jc = new JCommander(opt);
+        jc.parseWithAbbreviations(false, args);
+        Assert.assertEquals(opt.getBeta(), "bs");
+        Assert.assertEquals(opt.getAlpha(), 0);
+        Assert.assertFalse(opt.bellamy);
+    }
+
+    //
+    // parseWithAbbreviations -- commands
+    //
+
+    @Test
+    public void parseWithAbbreviationsWorksWithCommands() {
+
+        OptionSet4 os4 = new OptionSet4();
+        OptionSet1WithMain os1 = new OptionSet1WithMain();
+        OptionSet2 os2 = new OptionSet2();
+
+        JCommander jc = new JCommander(os4);
+        jc.addCommand("c1", os1);
+        jc.addCommand("c2", os2);
+
+        String[] args = {"-v", "c1", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
+        jc.parseWithAbbreviations(true, args);
+        Assert.assertTrue(os4.verbose);
+        Assert.assertEquals(os1.getBeta(), "bs");
+        Assert.assertEquals(os1.getAlpha(), 14);
+        Assert.assertTrue(os1.bellamy);
+        Assert.assertEquals(os1.theRest, java.util.Arrays.asList(new String[]{"^bei", "zzg", "^a", "19", "^bet"}));
+    }
+
+    @Test
+    public void parseWithAbbreviationsWorksWithCommands_differentPrefix() {
+
+        OptionSet4 os4 = new OptionSet4();
+        OptionSet1WithMain os1 = new OptionSet1WithMain();
+        OptionSet2WithMain os2 = new OptionSet2WithMain();
+
+        JCommander jc = new JCommander(os4);
+        jc.addCommand("c1", os1);
+        jc.addCommand("c2", os2);
+
+        String[] args = {"-v", "c2", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
+        jc.parseWithAbbreviations(true, args);
+        Assert.assertTrue(os4.verbose);
+        Assert.assertEquals(os2.getBeit(), "zzg");
+        Assert.assertEquals(os2.getAleph(), 19);
+        Assert.assertTrue(os2.better);
+        Assert.assertEquals(os2.everythingElse, java.util.Arrays.asList(new String[]{"--beta", "bs", "--alpha", "14", "--bellamy"}));
+    }
 
 
 }

--- a/src/test/java/com/beust/jcommander/JCommanderWithAbbreviationsTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderWithAbbreviationsTest.java
@@ -20,265 +20,263 @@ import java.util.List;
 
 public class JCommanderWithAbbreviationsTest {
 
-    public static class OptionSet1 {
-        @Parameter(names = "--alpha")
-        private int alpha;
+  public static class OptionSet1 {
+    @Parameter(names = "--alpha")
+    private int alpha;
 
-        @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
-        private String beta;
+    @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
+    private String beta;
 
-        @Parameter(names = "--bellamy")
-        public boolean bellamy;
+    @Parameter(names = "--bellamy")
+    public boolean bellamy;
 
 
-        public int getAlpha() {
-            return alpha;
-        }
-
-        public String getBeta() {
-            return beta;
-        }
+    public int getAlpha() {
+      return alpha;
     }
 
-    public static class OptionSet1WithMain extends OptionSet1 {
-        @Parameter
-        private List<String> theRest;
+    public String getBeta() {
+      return beta;
+    }
+  }
+
+  public static class OptionSet1WithMain extends OptionSet1 {
+    @Parameter
+    private List<String> theRest;
+  }
+
+  @Parameters(optionPrefixes = "^")
+  public static class OptionSet2 {
+    @Parameter(names = "^aleph")
+    private int aleph;
+
+    @Parameter(names = {"^beit", "^veit", "^triskaidekaphobia"})
+    private String beit;
+
+    @Parameter(names = "^better")
+    public boolean better;
+
+    public int getAleph() {
+      return aleph;
     }
 
-    @Parameters(optionPrefixes = "^")
-    public static class OptionSet2 {
-        @Parameter(names = "^aleph")
-        private int aleph;
+    public String getBeit() {
+      return beit;
+    }
+  }
 
-        @Parameter(names = {"^beit", "^veit", "^triskaidekaphobia"})
-        private String beit;
+  @Parameters(optionPrefixes = "^")
+  public static class OptionSet2WithMain extends OptionSet2 {
+    @Parameter
+    private List<String> everythingElse;
+  }
 
-        @Parameter(names = "^better")
-        public boolean better;
 
-        public int getAleph() {
-            return aleph;
-        }
+  public static class OptionSet3 {
+    @Parameter(names = "--alpha", required = true)
+    private int alpha;
 
-        public String getBeit() {
-            return beit;
-        }
+    @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
+    private String beta;
+
+    @Parameter(names = "--bellamy")
+    public boolean bellamy;
+
+    public int getAlpha() {
+      return alpha;
     }
 
-    @Parameters(optionPrefixes = "^")
-    public static class OptionSet2WithMain extends OptionSet2 {
-        @Parameter
-        private List<String> everythingElse;
+    public String getBeta() {
+      return beta;
     }
+  }
+
+  public static class OptionSet4 {
+    @Parameter(names = "-v")
+    private boolean verbose;
+  }
+
+  //
+  // parseWithAbbreviations -- basic behavior
+  //
 
 
-    public static class OptionSet3 {
-        @Parameter(names = "--alpha", required = true)
-        private int alpha;
+  @Test
+  public void parseWithAbbreviationsHandlesFullOptionNames() throws Throwable {
+    String[] args = {"--beta", "bs", "--alpha", "14", "--bellamy"};
+    OptionSet1 opt = new OptionSet1();
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(true, args);
+    Assert.assertEquals(opt.getBeta(), "bs");
+    Assert.assertEquals(opt.getAlpha(), 14);
+    Assert.assertTrue(opt.bellamy);
+  }
 
-        @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
-        private String beta;
+  @Test
+  public void parseWithAbbreviationsHandlesFullOptionNames_differentPrefix() throws Throwable {
+    String[] args = {"^beit", "bs", "^aleph", "14", "^better"};
+    OptionSet2 opt = new OptionSet2();
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(true, args);
+    Assert.assertEquals(opt.getBeit(), "bs");
+    Assert.assertEquals(opt.getAleph(), 14);
+    Assert.assertTrue(opt.better);
+  }
 
-        @Parameter(names = "--bellamy")
-        public boolean bellamy;
+  @Test
+  public void parseWithAbbreviationsHandlesAbbreviatedOptionNames() throws Throwable {
+    String[] args = {"--bet", "bs", "--a", "14", "--bel"};
+    OptionSet1 opt = new OptionSet1();
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(true, args);
+    Assert.assertEquals(opt.getBeta(), "bs");
+    Assert.assertEquals(opt.getAlpha(), 14);
+    Assert.assertTrue(opt.bellamy);
+  }
 
-        public int getAlpha() {
-            return alpha;
-        }
+  @Test
+  public void parseWithAbbreviationsHandlesAbbreviatedOptionNames_differentPrefix() throws Throwable {
+    String[] args = {"^bei", "bs", "^a", "14", "^bet"};
+    OptionSet2 opt = new OptionSet2();
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(true, args);
+    Assert.assertEquals(opt.getBeit(), "bs");
+    Assert.assertEquals(opt.getAleph(), 14);
+    Assert.assertTrue(opt.better);
+  }
 
-        public String getBeta() {
-            return beta;
-        }
+  //
+  // parseWithAbbreviations -- Error detection
+  //
+
+
+  @Test(expectedExceptions = ParameterException.class)
+  public void parseWithAbbreviationsThrowsExceptionIfParameterNotRecognized() throws Throwable {
+    String[] args = {"--noSuchParam"};
+    OptionSet1 opt = new OptionSet1();
+
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(args);
+  }
+
+  @Test(expectedExceptions = ParameterException.class)
+  public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort() throws Throwable {
+    String[] args = {"--be", "bs"};
+    OptionSet1 opt = new OptionSet1();
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(true, args);
+  }
+
+  @Test
+  public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort_differentPrefix() throws Throwable {
+    String[] args = {"^be", "bs"};
+    OptionSet2 opt = new OptionSet2();
+    JCommander jc = new JCommander(opt);
+    try {
+      jc.parseWithAbbreviations(true, args);
+      Assert.fail("ParamterException should be thrown because ^be is not a unique prefix");
+    } catch (ParameterException e) {
+      // If the exception messge contains "main parameter", it means that ^be was not recognized as a parameter.
+      Assert.assertFalse(e.getMessage().contains("main parameter"), "Prefix not correctly recognized");
+      Assert.assertTrue(e.getMessage().contains("Unknown"));
     }
+  }
 
-    public static class OptionSet4 {
-        @Parameter(names = "-v")
-        private boolean verbose;
+  @Test
+  public void parseWithAbbreviationsThrowsExceptionIfWrongPrefixUsed() {
+    String[] args = {"=be", "bs"};
+    OptionSet2 opt = new OptionSet2();
+    JCommander jc = new JCommander(opt);
+    try {
+      jc.parseWithAbbreviations(true, args);
+      Assert.fail("ParamterException should be thrown because = is the wrong prefix");
+    } catch (ParameterException e) {
+      Assert.assertTrue(e.getMessage().contains("main parameter"));
+      Assert.assertFalse(e.getMessage().contains("Unknown"));
     }
-
-    //
-    // parseWithAbbreviations -- basic behavior
-    //
+  }
 
 
-    @Test
-    public void parseWithAbbreviationsHandlesFullOptionNames() throws Throwable {
-        String[] args = {"--beta", "bs", "--alpha", "14", "--bellamy"};
-        OptionSet1 opt = new OptionSet1();
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(true, args);
-        Assert.assertEquals(opt.getBeta(), "bs");
-        Assert.assertEquals(opt.getAlpha(), 14);
-        Assert.assertTrue(opt.bellamy);
+  @Test(expectedExceptions = ParameterException.class)
+  public void parseWithAbbreviationsThrowsExceptionIfParameterTooLong() throws Throwable {
+    String[] args = {"--alphax"};
+    OptionSet1 opt = new OptionSet1();
+
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(true, args);
+  }
+
+  //
+  // parseWithAbbreviations -- validation
+  //
+
+  @Test
+  public void parseWithAbbreviationsValidatesByDefault() {
+    String[] args = {"--bet", "bs"};
+    OptionSet3 opt = new OptionSet3();
+    JCommander jc = new JCommander(opt);
+    try {
+      jc.parseWithAbbreviations(args);
+      Assert.fail("Expected exception to be thrown complaining about lack of required option");
+    } catch (ParameterException e) {
+      String actual = e.getMessage();
+      Assert.assertTrue(actual.contains("option is required"), "Exception should mention parameter is required.");
+      Assert.assertTrue(actual.contains("--alpha"), "Exception should specifically mention required parameter.");
     }
+  }
 
-    @Test
-    public void parseWithAbbreviationsHandlesFullOptionNames_differentPrefix() throws Throwable {
-        String[] args = {"^beit", "bs", "^aleph", "14", "^better"};
-        OptionSet2 opt = new OptionSet2();
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(true, args);
-        Assert.assertEquals(opt.getBeit(), "bs");
-        Assert.assertEquals(opt.getAleph(), 14);
-        Assert.assertTrue(opt.better);
-    }
+  @Test
+  public void parseWithAbbreviationsCanChooseNotToValidate() {
+    String[] args = {"--bet", "bs"};
+    OptionSet3 opt = new OptionSet3();
+    JCommander jc = new JCommander(opt);
+    jc.parseWithAbbreviations(false, args);
+    Assert.assertEquals(opt.getBeta(), "bs");
+    Assert.assertEquals(opt.getAlpha(), 0);
+    Assert.assertFalse(opt.bellamy);
+  }
 
-    @Test
-    public void parseWithAbbreviationsHandlesAbbreviatedOptionNames() throws Throwable {
-        String[] args = {"--bet", "bs", "--a", "14", "--bel"};
-        OptionSet1 opt = new OptionSet1();
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(true, args);
-        Assert.assertEquals(opt.getBeta(), "bs");
-        Assert.assertEquals(opt.getAlpha(), 14);
-        Assert.assertTrue(opt.bellamy);
-    }
+  //
+  // parseWithAbbreviations -- commands
+  //
 
-    @Test
-    public void parseWithAbbreviationsHandlesAbbreviatedOptionNames_differentPrefix() throws Throwable {
-        String[] args = {"^bei", "bs", "^a", "14", "^bet"};
-        OptionSet2 opt = new OptionSet2();
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(true, args);
-        Assert.assertEquals(opt.getBeit(), "bs");
-        Assert.assertEquals(opt.getAleph(), 14);
-        Assert.assertTrue(opt.better);
-    }
+  @Test
+  public void parseWithAbbreviationsWorksWithCommands() {
 
-    //
-    // parseWithAbbreviations -- Error detection
-    //
+    OptionSet4 os4 = new OptionSet4();
+    OptionSet1WithMain os1 = new OptionSet1WithMain();
+    OptionSet2 os2 = new OptionSet2();
 
+    JCommander jc = new JCommander(os4);
+    jc.addCommand("c1", os1);
+    jc.addCommand("c2", os2);
 
-    @Test(expectedExceptions = ParameterException.class)
-    public void parseWithAbbreviationsThrowsExceptionIfParameterNotRecognized() throws Throwable {
-        String[] args = {"--noSuchParam"};
-        OptionSet1 opt = new OptionSet1();
+    String[] args = {"-v", "c1", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
+    jc.parseWithAbbreviations(true, args);
+    Assert.assertTrue(os4.verbose);
+    Assert.assertEquals(os1.getBeta(), "bs");
+    Assert.assertEquals(os1.getAlpha(), 14);
+    Assert.assertTrue(os1.bellamy);
+    Assert.assertEquals(os1.theRest, java.util.Arrays.asList(new String[]{"^bei", "zzg", "^a", "19", "^bet"}));
+  }
 
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(args);
-    }
+  @Test
+  public void parseWithAbbreviationsWorksWithCommands_differentPrefix() {
 
-    @Test(expectedExceptions = ParameterException.class)
-    public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort() throws Throwable {
-        String[] args = {"--be", "bs"};
-        OptionSet1 opt = new OptionSet1();
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(true, args);
-    }
+    OptionSet4 os4 = new OptionSet4();
+    OptionSet1WithMain os1 = new OptionSet1WithMain();
+    OptionSet2WithMain os2 = new OptionSet2WithMain();
 
-    @Test
-    public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort_differentPrefix() throws Throwable {
-        String[] args = {"^be", "bs"};
-        OptionSet2 opt = new OptionSet2();
-        JCommander jc = new JCommander(opt);
-        try {
-            jc.parseWithAbbreviations(true, args);
-            Assert.fail("ParamterException should be thrown because ^be is not a unique prefix");
-        } catch (ParameterException e) {
-            // If the exception messge contains "main parameter", it means that ^be was not recognized as a parameter.
-            Assert.assertFalse(e.getMessage().contains("main parameter"), "Prefix not correctly recognized");
-            Assert.assertTrue(e.getMessage().contains("Unknown"));
-        }
-    }
+    JCommander jc = new JCommander(os4);
+    jc.addCommand("c1", os1);
+    jc.addCommand("c2", os2);
 
-    @Test
-    public void parseWithAbbreviationsThrowsExceptionIfWrongPrefixUsed() {
-        String[] args = {"=be", "bs"};
-        OptionSet2 opt = new OptionSet2();
-        JCommander jc = new JCommander(opt);
-        try {
-            jc.parseWithAbbreviations(true, args);
-            Assert.fail("ParamterException should be thrown because = is the wrong prefix");
-        } catch (ParameterException e) {
-            Assert.assertTrue(e.getMessage().contains("main parameter"));
-            Assert.assertFalse(e.getMessage().contains("Unknown"));
-        }
-    }
-
-
-    @Test(expectedExceptions = ParameterException.class)
-    public void parseWithAbbreviationsThrowsExceptionIfParameterTooLong() throws Throwable {
-        String[] args = {"--alphax"};
-        OptionSet1 opt = new OptionSet1();
-
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(true, args);
-    }
-
-    //
-    // parseWithAbbreviations -- validation
-    //
-
-    @Test
-    public void parseWithAbbreviationsValidatesByDefault() {
-        String[] args = {"--bet", "bs"};
-        OptionSet3 opt = new OptionSet3();
-        JCommander jc = new JCommander(opt);
-        try {
-            jc.parseWithAbbreviations(args);
-            Assert.fail("Expected exception to be thrown complaining about lack of required option");
-        } catch (ParameterException e) {
-            String actual = e.getMessage();
-            Assert.assertTrue(actual.contains("option is required"), "Exception should mention parameter is required.");
-            Assert.assertTrue(actual.contains("--alpha"), "Exception should specifically mention required parameter.");
-        }
-    }
-
-    @Test
-    public void parseWithAbbreviationsCanChooseNotToValidate() {
-        String[] args = {"--bet", "bs"};
-        OptionSet3 opt = new OptionSet3();
-        JCommander jc = new JCommander(opt);
-        jc.parseWithAbbreviations(false, args);
-        Assert.assertEquals(opt.getBeta(), "bs");
-        Assert.assertEquals(opt.getAlpha(), 0);
-        Assert.assertFalse(opt.bellamy);
-    }
-
-    //
-    // parseWithAbbreviations -- commands
-    //
-
-    @Test
-    public void parseWithAbbreviationsWorksWithCommands() {
-
-        OptionSet4 os4 = new OptionSet4();
-        OptionSet1WithMain os1 = new OptionSet1WithMain();
-        OptionSet2 os2 = new OptionSet2();
-
-        JCommander jc = new JCommander(os4);
-        jc.addCommand("c1", os1);
-        jc.addCommand("c2", os2);
-
-        String[] args = {"-v", "c1", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
-        jc.parseWithAbbreviations(true, args);
-        Assert.assertTrue(os4.verbose);
-        Assert.assertEquals(os1.getBeta(), "bs");
-        Assert.assertEquals(os1.getAlpha(), 14);
-        Assert.assertTrue(os1.bellamy);
-        Assert.assertEquals(os1.theRest, java.util.Arrays.asList(new String[]{"^bei", "zzg", "^a", "19", "^bet"}));
-    }
-
-    @Test
-    public void parseWithAbbreviationsWorksWithCommands_differentPrefix() {
-
-        OptionSet4 os4 = new OptionSet4();
-        OptionSet1WithMain os1 = new OptionSet1WithMain();
-        OptionSet2WithMain os2 = new OptionSet2WithMain();
-
-        JCommander jc = new JCommander(os4);
-        jc.addCommand("c1", os1);
-        jc.addCommand("c2", os2);
-
-        String[] args = {"-v", "c2", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
-        jc.parseWithAbbreviations(true, args);
-        Assert.assertTrue(os4.verbose);
-        Assert.assertEquals(os2.getBeit(), "zzg");
-        Assert.assertEquals(os2.getAleph(), 19);
-        Assert.assertTrue(os2.better);
-        Assert.assertEquals(os2.everythingElse, java.util.Arrays.asList(new String[]{"--beta", "bs", "--alpha", "14", "--bellamy"}));
-    }
-
-
+    String[] args = {"-v", "c2", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
+    jc.parseWithAbbreviations(true, args);
+    Assert.assertTrue(os4.verbose);
+    Assert.assertEquals(os2.getBeit(), "zzg");
+    Assert.assertEquals(os2.getAleph(), 19);
+    Assert.assertTrue(os2.better);
+    Assert.assertEquals(os2.everythingElse, java.util.Arrays.asList(new String[]{"--beta", "bs", "--alpha", "14", "--bellamy"}));
+  }
 }

--- a/src/test/java/com/beust/jcommander/JCommanderWithAbbreviationsTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderWithAbbreviationsTest.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) Zachary Kurmas 2011
+ *
+ */
+package com.beust.jcommander;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * @author Zachary Kurmas
+ */
+// Created  11/14/11 at 9:20 PM
+// (C) Zachary Kurmas 2011
+
+public class JCommanderWithAbbreviationsTest {
+
+   public static class OptionSet1 {
+      @Parameter(names = "--alpha")
+      private int alpha;
+
+      @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
+      private String beta;
+
+      @Parameter(names = "--bellamy")
+      public boolean bellamy;
+
+
+      public int getAlpha() {
+         return alpha;
+      }
+
+      public String getBeta() {
+         return beta;
+      }
+   }
+
+   public static class OptionSet1WithMain extends OptionSet1 {
+      @Parameter
+      private List<String> theRest;
+   }
+
+   @Parameters(optionPrefixes = "^")
+   public static class OptionSet2 {
+      @Parameter(names = "^aleph")
+      private int aleph;
+
+      @Parameter(names = {"^beit", "^veit", "^triskaidekaphobia"})
+      private String beit;
+
+      @Parameter(names = "^better")
+      public boolean better;
+
+      public int getAleph() {
+         return aleph;
+      }
+
+      public String getBeit() {
+         return beit;
+      }
+   }
+
+   @Parameters(optionPrefixes = "^")
+   public static class OptionSet2WithMain extends OptionSet2 {
+      @Parameter
+      private List<String> everythingElse;
+   }
+
+
+   public static class OptionSet3 {
+      @Parameter(names = "--alpha", required = true)
+      private int alpha;
+
+      @Parameter(names = {"--beta", "--gamma", "--triskaidekaphobia"})
+      private String beta;
+
+      @Parameter(names = "--bellamy")
+      public boolean bellamy;
+
+      public int getAlpha() {
+         return alpha;
+      }
+
+      public String getBeta() {
+         return beta;
+      }
+   }
+
+   public static class OptionSet4 {
+      @Parameter(names = "-v")
+      private boolean verbose;
+   }
+
+   //
+   // parseWithAbbreviations -- basic behavior
+   //
+
+
+   @Test
+   public void parseWithAbbreviationsHandlesFullOptionNames() throws Throwable {
+      String[] args = {"--beta", "bs", "--alpha", "14", "--bellamy"};
+      OptionSet1 opt = new OptionSet1();
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(true, args);
+      Assert.assertEquals(opt.getBeta(), "bs");
+      Assert.assertEquals(opt.getAlpha(), 14);
+      Assert.assertTrue(opt.bellamy);
+   }
+
+   @Test
+   public void parseWithAbbreviationsHandlesFullOptionNames_differentPrefix() throws Throwable {
+      String[] args = {"^beit", "bs", "^aleph", "14", "^better"};
+      OptionSet2 opt = new OptionSet2();
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(true, args);
+      Assert.assertEquals(opt.getBeit(), "bs");
+      Assert.assertEquals(opt.getAleph(), 14);
+      Assert.assertTrue(opt.better);
+   }
+
+   @Test
+   public void parseWithAbbreviationsHandlesAbbreviatedOptionNames() throws Throwable {
+      String[] args = {"--bet", "bs", "--a", "14", "--bel"};
+      OptionSet1 opt = new OptionSet1();
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(true, args);
+      Assert.assertEquals(opt.getBeta(), "bs");
+      Assert.assertEquals(opt.getAlpha(), 14);
+      Assert.assertTrue(opt.bellamy);
+   }
+
+   @Test
+   public void parseWithAbbreviationsHandlesAbbreviatedOptionNames_differentPrefix() throws Throwable {
+      String[] args = {"^bei", "bs", "^a", "14", "^bet"};
+      OptionSet2 opt = new OptionSet2();
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(true, args);
+      Assert.assertEquals(opt.getBeit(), "bs");
+      Assert.assertEquals(opt.getAleph(), 14);
+      Assert.assertTrue(opt.better);
+   }
+
+   //
+   // parseWithAbbreviations -- Error detection
+   //
+
+
+   @Test(expectedExceptions = ParameterException.class)
+   public void parseWithAbbreviationsThrowsExceptionIfParameterNotRecognized() throws Throwable {
+      String[] args = {"--noSuchParam"};
+      OptionSet1 opt = new OptionSet1();
+
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(args);
+   }
+
+   @Test(expectedExceptions = ParameterException.class)
+   public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort() throws Throwable {
+      String[] args = {"--be", "bs"};
+      OptionSet1 opt = new OptionSet1();
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(true, args);
+   }
+
+   @Test
+   public void parseWithAbbreviationsThrowsExceptionIfAbbreviationIsTooShort_differentPrefix() throws Throwable {
+      String[] args = {"^be", "bs"};
+      OptionSet2 opt = new OptionSet2();
+      JCommander jc = new JCommander(opt);
+      try {
+         jc.parseWithAbbreviations(true, args);
+         Assert.fail("ParamterException should be thrown because ^be is not a unique prefix");
+      } catch (ParameterException e) {
+         // If the exception messge contains "main parameter", it means that ^be was not recognized as a parameter.
+         Assert.assertFalse(e.getMessage().contains("main parameter"), "Prefix not correctly recognized");
+         Assert.assertTrue(e.getMessage().contains("Unknown"));
+      }
+   }
+
+   @Test
+   public void parseWithAbbreviationsThrowsExceptionIfWrongPrefixUsed() {
+      String[] args = {"=be", "bs"};
+      OptionSet2 opt = new OptionSet2();
+      JCommander jc = new JCommander(opt);
+      try {
+         jc.parseWithAbbreviations(true, args);
+         Assert.fail("ParamterException should be thrown because = is the wrong prefix");
+      } catch (ParameterException e) {
+         Assert.assertTrue(e.getMessage().contains("main parameter"));
+         Assert.assertFalse(e.getMessage().contains("Unknown"));
+      }
+   }
+
+
+   @Test(expectedExceptions = ParameterException.class)
+   public void parseWithAbbreviationsThrowsExceptionIfParameterTooLong() throws Throwable {
+      String[] args = {"--alphax"};
+      OptionSet1 opt = new OptionSet1();
+
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(true, args);
+   }
+
+   //
+   // parseWithAbbreviations -- validation
+   //
+
+   @Test
+   public void parseWithAbbreviationsValidatesByDefault() {
+      String[] args = {"--bet", "bs"};
+      OptionSet3 opt = new OptionSet3();
+      JCommander jc = new JCommander(opt);
+      try {
+         jc.parseWithAbbreviations(args);
+         Assert.fail("Expected exception to be thrown complaining about lack of required option");
+      } catch (ParameterException e) {
+         String actual = e.getMessage();
+         Assert.assertTrue(actual.contains("option is required"), "Exception should mention parameter is required.");
+         Assert.assertTrue(actual.contains("--alpha"), "Exception should specifically mention required parameter.");
+      }
+   }
+
+   @Test
+   public void parseWithAbbreviationsCanChooseNotToValidate() {
+      String[] args = {"--bet", "bs"};
+      OptionSet3 opt = new OptionSet3();
+      JCommander jc = new JCommander(opt);
+      jc.parseWithAbbreviations(false, args);
+      Assert.assertEquals(opt.getBeta(), "bs");
+      Assert.assertEquals(opt.getAlpha(), 0);
+      Assert.assertFalse(opt.bellamy);
+   }
+
+   //
+   // parseWithAbbreviations -- commands
+   //
+
+   @Test
+   public void parseWithAbbreviationsWorksWithCommands() {
+
+      OptionSet4 os4 = new OptionSet4();
+      OptionSet1WithMain os1 = new OptionSet1WithMain();
+      OptionSet2 os2 = new OptionSet2();
+
+      JCommander jc = new JCommander(os4);
+      jc.addCommand("c1", os1);
+      jc.addCommand("c2", os2);
+
+      String[] args = {"-v", "c1", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
+      jc.parseWithAbbreviations(true, args);
+      Assert.assertTrue(os4.verbose);
+      Assert.assertEquals(os1.getBeta(), "bs");
+      Assert.assertEquals(os1.getAlpha(), 14);
+      Assert.assertTrue(os1.bellamy);
+      Assert.assertEquals(os1.theRest, java.util.Arrays.asList(new String[]{"^bei", "zzg", "^a", "19", "^bet"}));
+   }
+
+   @Test
+   public void parseWithAbbreviationsWorksWithCommands_differentPrefix() {
+
+      OptionSet4 os4 = new OptionSet4();
+      OptionSet1WithMain os1 = new OptionSet1WithMain();
+      OptionSet2WithMain os2 = new OptionSet2WithMain();
+
+      JCommander jc = new JCommander(os4);
+      jc.addCommand("c1", os1);
+      jc.addCommand("c2", os2);
+
+      String[] args = {"-v", "c2", "--beta", "bs", "--alpha", "14", "--bellamy", "^bei", "zzg", "^a", "19", "^bet"};
+      jc.parseWithAbbreviations(true, args);
+      Assert.assertTrue(os4.verbose);
+      Assert.assertEquals(os2.getBeit(), "zzg");
+      Assert.assertEquals(os2.getAleph(), 19);
+      Assert.assertTrue(os2.better);
+      Assert.assertEquals(os2.everythingElse, java.util.Arrays.asList(new String[]{"--beta", "bs", "--alpha", "14", "--bellamy"}));
+   }
+
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -10,6 +10,7 @@
       <class name="com.beust.jcommander.DefaultProviderTest" />
       <class name="com.beust.jcommander.DefaultValueTest" />
       <class name="com.beust.jcommander.JCommanderTest" />
+      <class name="com.beust.jcommander.JCommanderWithAbbreviationsTest" />
       <class name="com.beust.jcommander.ParametersDelegateTest" />
       <class name="com.beust.jcommander.dynamic.DynamicParameterTest" />
       <class name="com.beust.jcommander.VariableArityTest" />


### PR DESCRIPTION
This code allows users to enter the shortest unambiguous prefix of a parameter name.  For example, given parameters --alpha --beta, and --barium, users need only type --a, --bet, and --bar on the command line.

Last November, we discussed implementing this as a "wrapper" to JCommander.  However, that solution does not work well when commands are used.  For example, JCommander allows the parameters for different commands to have different prefixes.  It would be very difficult to implement the abbreviations as a wrapper and support similar behavior.

Instead, I made a few small changes right in JCommander. In particular I added an AbbreviationMap instance variable. This object maps abbreviated parameters to the appropriate ParameterDescription (if the abbreviation is unambiguous).

I then added this code at JCommander line 642 in parseValues:

 ParameterDescription pd;
            if (allowAbbreviations) {
               pd = m_abbrevMap.get(a);
            } else {
               pd = m_descriptions.get(a);
            }

I got AbbreviationMap from Paul Hosler's JOptSimple package.  It uses the MIT license.

I added these two methods:

 /**
    \* Parse and validate the command line parameters allowing abbreviated parameters.
    */
   public void parseWithAbbreviations(String... args) {
      parseWithAbbreviations(true, args);
   }

   /**
    \* Parse the command line parameters allowing abbreviated parameters.
    _/
   public void parseWithAbbreviations(boolean validate, String... args) {
      parse(validate, true /_ allow abbreviations */, args);
   }

Perhaps instead of parse, parseWithoutValidation, and two versions of parseWithAbbreviations, we want to simply make this method public:

   private void parse(boolean validate, boolean allowAbbreviations, String... args) {

Let me know what you think.
