### PR TITLE
@ParameterFile support

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="/home/sjr/git/jcommander/lib/testng-6.5.2/testng-6.5.2.jar"/>
+	<classpathentry kind="src" path="testResources"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 target
-.classpath
-.project
-.settings
 test-output

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>JCom</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -175,9 +175,16 @@ public class JCommander {
   private Map<Field, String> m_parameterFileNames = Maps.newHashMap();
   
   /**
-   * Stores a set of Fields that are 
+   * Stores a set of Fields that are allowed to not exist
    */
   private Set<Field> m_parameterFilesThatCanNotExist = new HashSet<Field>();
+  
+  private Set<String> m_parameterFilesToRead = new HashSet<String>();
+  
+  public Set<String> getParameterFilesToRead()
+  {
+	  return Collections.unmodifiableSet(this.m_parameterFilesToRead);
+  }
   
   /**
    * The factories used to look up string converters.
@@ -203,7 +210,9 @@ public class JCommander {
   }
   
   
-  private final boolean forceBooleanOneArity; 
+  private final boolean forceBooleanOneArity;
+
+
   /**
    * @param object The arg object expected to contain {@link Parameter} annotations.
    */
@@ -337,6 +346,11 @@ public class JCommander {
 	       				{
 	       					this.m_parameterFilesThatCanNotExist.add(field);
 	       				}
+	       				
+	       				if(field.get(obj) != null)
+	       				{
+	       					this.m_parameterFilesToRead.add(field.get(obj) + "");
+	       				}
 	    			   }
 	    			   
 	    			}
@@ -366,6 +380,7 @@ public class JCommander {
 	 */
 	public void getAllDelegates(Object objectToScan)
 			throws IllegalAccessException {
+		m_parameterObjectForFiles.add(objectToScan);
 		if(objectToScan.getClass().isArray())
 		{
 			for(int i=0; i < Array.getLength(objectToScan); i++)
@@ -378,7 +393,6 @@ public class JCommander {
 		
 			for (Field field : objectToScan.getClass().getFields()) {
 				if (field.isAnnotationPresent(ParametersDelegate.class)) {
-					m_parameterObjectForFiles.add(field.get(objectToScan));
 					getAllDelegates(field.get(objectToScan));
 				}
 			}
@@ -400,6 +414,7 @@ public class JCommander {
    */
   public void parse(String... args) {
     parse(true /* validate */, args);
+
   }
 
   /**

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -974,12 +974,12 @@ public class JCommander {
 	    	if(!parameterFile.exists())
 	    	{
 	    		if(this.m_parameterFilesThatCanNotExist.contains(field)) continue;
-	    		throw new ParameterException("Parameter File does not exist: " + parameterFile.getName());
+	    		throw new ParameterException("Option File (JCommander @ParameterFile) does not exist: " + parameterFile.getName());
 	    	}
 	    	
 			if(!parameterFile.canRead())
 			{
-				throw new ParameterException("Parameter File is not readable: " + parameterFile.getName());
+				throw new ParameterException("Option File (JCommander @ParameterFile) file is not readable: " + parameterFile.getName());
 			}
 	    	
 			String[] paramFileContents = parseParameterFile(parameterFile);

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -83,6 +84,7 @@ public class JCommander {
    */
   private List<Object> m_objects = Lists.newArrayList();
 
+  
   /**
    * This field/method will contain whatever command line parameter is not an option.
    * It is expected to be a List<String>.
@@ -171,6 +173,12 @@ public class JCommander {
    * Stores a mapping from Field to names
    */
   private Map<Field, String> m_parameterFileNames = Maps.newHashMap();
+  
+  /**
+   * Stores a set of Fields that are 
+   */
+  private Set<Field> m_parameterFilesThatCanNotExist = new HashSet<Field>();
+  
   /**
    * The factories used to look up string converters.
    */
@@ -323,6 +331,12 @@ public class JCommander {
 	    				   p("Adding ParameterFile Field " + name);
 	       				this.m_parameterFileOptions.put(field,  obj);
 	       				this.m_parameterFileNames.put(field, name);
+	       				
+	       				ParameterFile parameterFile = field.getAnnotation(ParameterFile.class);
+	       				if(parameterFile.ignoreFileNotExists())
+	       				{
+	       					this.m_parameterFilesThatCanNotExist.add(field);
+	       				}
 	    			   }
 	    			   
 	    			}
@@ -931,6 +945,7 @@ public class JCommander {
 	    	
 	    	if(!parameterFile.exists())
 	    	{
+	    		if(this.m_parameterFilesThatCanNotExist.contains(field)) continue;
 	    		throw new ParameterException("Parameter File does not exist: " + parameterFile.getName());
 	    	}
 	    	

--- a/src/main/java/com/beust/jcommander/ParameterFile.java
+++ b/src/main/java/com/beust/jcommander/ParameterFile.java
@@ -13,5 +13,6 @@ import java.lang.annotation.*;
 @Target(ElementType.FIELD)
 public @interface ParameterFile {
 
+	boolean ignoreFileNotExists() default false;
 	
 }

--- a/src/main/java/com/beust/jcommander/ParameterFile.java
+++ b/src/main/java/com/beust/jcommander/ParameterFile.java
@@ -1,0 +1,17 @@
+package com.beust.jcommander;
+
+
+import java.lang.annotation.*;
+
+/**
+ * Mark a @Parameter as a @ParameterFile if the File referenced by it should be parsed as a property file,
+ * and modify the Options Object in which it is referenced (for instance a scenario file modifies the Scenario options)
+ *
+ * @author sramage 
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ParameterFile {
+
+	
+}

--- a/src/test/java/com/beust/jcommander/ParameterFileTest.java
+++ b/src/test/java/com/beust/jcommander/ParameterFileTest.java
@@ -1,7 +1,5 @@
 package com.beust.jcommander;
 
-import java.net.URL;
-
 import junit.framework.Assert;
 
 import org.junit.Test;

--- a/src/test/java/com/beust/jcommander/ParameterFileTest.java
+++ b/src/test/java/com/beust/jcommander/ParameterFileTest.java
@@ -1,0 +1,136 @@
+package com.beust.jcommander;
+
+import java.net.URL;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.beust.jcommander.args.ParameterFileTestObject;
+
+public class ParameterFileTest {
+
+	
+	public String getFile(String name)
+	{
+		return ClassLoader.getSystemClassLoader().getResource(name).getFile();
+		
+	}
+	@Test
+	public void testFileLoad()
+	{
+		ParameterFileTestObject tobj = new ParameterFileTestObject();
+		
+		JCommander jcom = new JCommander(tobj);
+		
+		
+		/**System.out.println(System.getProperty("java.class.path"));
+		System.out.println(u);
+		*/
+		
+		
+		String file = getFile("validOptionFile.txt");
+		System.out.println(file);
+		String[] args = {"--file",file};
+		
+		jcom.parse(args);
+		
+		Assert.assertEquals(tobj.intValue,3);
+		Assert.assertEquals(tobj.strValue,"Hello");
+		Assert.assertEquals(tobj.simpleBooleanTrue, true);
+		Assert.assertEquals(tobj.simpleBooleanFalse, false);
+	}
+	
+	
+	@Test(expected=ParameterException.class)
+	public void missingFileError()
+	{
+		ParameterFileTest tobj = new ParameterFileTest();
+		
+		JCommander jcom = new JCommander(tobj);
+		String[] args = {"--file", "/hello"};
+		
+		jcom.parse(args);
+	}
+	
+	
+	@Test
+	public void testRequiredParameters()
+	{
+		ParameterFileTestObject tobj = new ParameterFileTestObject();
+		
+		JCommander jcom = new JCommander(tobj);
+		String[] args = {"--file", getFile("validOptionFile.txt"), "--simpleBooleanTrue"};
+		
+		jcom.parse(args);
+		
+		Assert.assertEquals(tobj.intValue,3);
+		Assert.assertEquals(tobj.strValue,"Hello");
+		Assert.assertEquals(tobj.simpleBooleanTrue, true);
+		Assert.assertEquals(tobj.simpleBooleanFalse, false);
+	}
+	
+	@Test(expected=ParameterException.class)
+	public void testRequiredParameterMissing(){
+		ParameterFileTestObject tobj = new ParameterFileTestObject();
+		
+		JCommander jcom = new JCommander(tobj);
+		String[] args = {"--file", getFile("validButMissingRequired.txt")};
+		
+		jcom.parse(args);
+		
+	}
+	
+	@Test
+	public void testCommandLineOverride()
+	{
+		ParameterFileTestObject tobj = new ParameterFileTestObject();
+		
+		JCommander jcom = new JCommander(tobj);
+		
+		
+		/**System.out.println(System.getProperty("java.class.path"));
+		System.out.println(u);
+		*/
+		
+		
+		String file = getFile("validOptionFile.txt");
+		System.out.println(file);
+		String[] args = {"--file",file,"--intValue","42"};
+		
+		jcom.parse(args);
+		
+		Assert.assertEquals(tobj.intValue,42);
+		Assert.assertEquals(tobj.strValue,"Hello");
+		Assert.assertEquals(tobj.simpleBooleanTrue, true);
+		Assert.assertEquals(tobj.simpleBooleanFalse, false);
+	}
+	
+	
+	
+	@Test
+	public void variableArity()
+	{
+		ParameterFileTestObject tobj = new ParameterFileTestObject();
+		
+		JCommander jcom = new JCommander(tobj);
+		
+		
+		/**System.out.println(System.getProperty("java.class.path"));
+		System.out.println(u);
+		*/
+		
+		
+		String file = getFile("validTwoArityIncluded.txt");
+		System.out.println(file);
+		String[] args = {"--file",file,"--intValue","42"};
+		
+		jcom.parse(args);
+		
+		Assert.assertEquals(tobj.intValue,42);
+		Assert.assertEquals(tobj.strValue,"Hello");
+		Assert.assertEquals(tobj.simpleBooleanTrue, true);
+		Assert.assertEquals(tobj.varArity.get(0), "Hello");
+		Assert.assertEquals(tobj.varArity.get(1),"There");
+	}
+}

--- a/src/test/java/com/beust/jcommander/args/ParameterFileTestObject.java
+++ b/src/test/java/com/beust/jcommander/args/ParameterFileTestObject.java
@@ -1,0 +1,34 @@
+package com.beust.jcommander.args;
+
+import java.io.File;
+import java.util.List;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterFile;
+
+public class ParameterFileTestObject {
+
+	@Parameter(names="--intValue")
+	public int intValue;
+	
+	@Parameter(names="--strValue")
+	public String strValue;
+	
+	@Parameter(names="--simpleBooleanTrue", required=true)
+	public boolean simpleBooleanTrue;
+	
+	@Parameter(names="--simpleBooleanFalse")
+	public boolean simpleBooleanFalse;
+	
+	@ParameterFile
+	@Parameter(names="--file")
+	public File optionsFile;
+	
+	@Parameter(names="--stringTwoArity", arity=2)
+	public List<String> arityTwo;
+	
+	@Parameter(names="--stringVarArity", variableArity = true)
+	public List<String> varArity;
+	
+	
+}

--- a/testResources/InvalidTypeFile.txt
+++ b/testResources/InvalidTypeFile.txt
@@ -1,0 +1,4 @@
+intValue = There
+strValue = Hello 
+simpleBooleanTrue = true
+simpleBooleanFalse = false

--- a/testResources/TwoAritySpecifiedAsThreeArity.txt
+++ b/testResources/TwoAritySpecifiedAsThreeArity.txt
@@ -1,0 +1,3 @@
+stringTwoArity = hello
+stringTwoArity = there
+stringTwoArity = honey

--- a/testResources/validButMissingRequired.txt
+++ b/testResources/validButMissingRequired.txt
@@ -1,0 +1,3 @@
+intValue = 3
+strValue = Hello 
+simpleBooleanFalse = false

--- a/testResources/validOptionFile.txt
+++ b/testResources/validOptionFile.txt
@@ -1,0 +1,4 @@
+intValue = 3
+strValue = Hello 
+simpleBooleanTrue = true
+simpleBooleanFalse = false

--- a/testResources/validTwoArityIncluded.txt
+++ b/testResources/validTwoArityIncluded.txt
@@ -1,0 +1,6 @@
+intValue = 3
+strValue = Hello 
+simpleBooleanTrue = true
+simpleBooleanFalse = false
+stringTwoArity = hello
+stringTwoArity = there

--- a/testResources/varArityTest.txt
+++ b/testResources/varArityTest.txt
@@ -1,0 +1,6 @@
+intValue = 3
+strValue = Hello 
+simpleBooleanTrue = true
+simpleBooleanFalse = false
+stringVarArity = hello
+stringVarArity = there


### PR DESCRIPTION
Hello as per this thread (https://groups.google.com/forum/?fromgroups#!topic/jcommander/dE6UyojYiVE) I have implemented support for configuration files. This does not support variable arguments currently, as the method I use to read configuration files is via a Properties object, and it didn't occur to me that I can't have multiple keys.

In short you specify things as

@ParameterFile
@Parameter(names="--conf")
File configurationFile;

I did add a Test class, originally I tried with TestNG but because of a few problems A) I couldn't run TestNG in debug mode in Eclipse it would just lock up, and B) It seemed like I had to do something with Maven to actually get the updated files to be tested against, and I didn't know how to do this.

There is still more work to do be done (multiple arity arguments, and a few more tests), but I wanted to get some feedback in the interim. 
