### PR TITLE
Support for whitespace between arguments on the same line in @ argument files

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -473,7 +473,7 @@ public class JCommander {
       // Read through file one line at time. Print line # and line
       while ((line = bufRead.readLine()) != null) {
         // Allow empty lines in these at files
-        if (line.length() > 0) result.add(line);
+        if (line.length() > 0) result.addAll(Arrays.asList(line.split("\\s+")));
       }
 
       bufRead.close();


### PR DESCRIPTION
This change allows spaces between arguments on the same line in @ argument files.  Consider the content of the args file

args:
-arg build

Without the change, this results in an unknown argument exception.
java -Djcommander.debug -cp build/:../jcommander/build Main @args
[JCommander] Adding description for -arg
[JCommander] Parsing "@args"
  with:Options@27d9e895
[JCommander] Parsing arg: -arg build
Error: Unknown option: -arg build

With the change, it works as expected.
java -Djcommander.debug -cp build/:../jcommander/build Main \@args
[JCommander] Adding description for -arg
[JCommander] Parsing "@args"
  with:Options@24a1a602
[JCommander] Parsing arg: -arg
[ParameterDescription] Adding value:build to parameter:arg
