### PR TITLE
Fix usage to add missing new lines

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1032,10 +1032,10 @@ public class JCommander {
     String programName = m_programName != null ? m_programName.getDisplayName() : "<main class>";
     out.append(indent).append("Usage: " + programName + " [options]");
     if (hasCommands) out.append(indent).append(" [command] [command options]");
-//    out.append("\n");
     if (m_mainParameterDescription != null) {
       out.append(" " + m_mainParameterDescription.getDescription());
     }
+    out.append("\n");
 
     //
     // Align the descriptions at the "longestName" column
@@ -1062,7 +1062,7 @@ public class JCommander {
     // Display all the names and descriptions
     //
     int descriptionIndent = 6;
-    if (sorted.size() > 0) out.append(indent).append("\n").append(indent).append("  Options:\n");
+    if (sorted.size() > 0) out.append(indent).append("  Options:\n");
     for (ParameterDescription pd : sorted) {
       WrappedParameter parameter = pd.getParameter();
       out.append(indent).append("  "

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -895,6 +895,56 @@ public class JCommanderTest {
     Assert.assertEquals(V2.names, Arrays.asList(new String[] { "-h", "--host" }));
     Assert.assertTrue(V2.validateCalled);
   }
+  
+  public void usageCommandsUnderUsage() {
+    class Arg {
+    }
+    @Parameters(commandDescription = "command a")
+    class ArgCommandA {
+      @Parameter(description = "command a parameters")
+      List<String> parameters;
+    }
+    @Parameters(commandDescription = "command b")
+    class ArgCommandB {
+      @Parameter(description = "command b parameters")
+      List<String> parameters;
+    }
+    
+    Arg a = new Arg();
+    
+    JCommander c = new JCommander(a);
+    c.addCommand("a", new ArgCommandA());
+    c.addCommand("b", new ArgCommandB());
+    
+    StringBuilder sb = new StringBuilder();
+    c.usage(sb);
+    Assert.assertTrue(sb.toString().contains("[command options]\n  Commands:"));
+  }
+
+  public void usageWithEmpytLine() {
+    class Arg {
+    }
+    @Parameters(commandDescription = "command a")
+    class ArgCommandA {
+      @Parameter(description = "command a parameters")
+      List<String> parameters;
+    }
+    @Parameters(commandDescription = "command b")
+    class ArgCommandB {
+      @Parameter(description = "command b parameters")
+      List<String> parameters;
+    }
+    
+    Arg a = new Arg();
+    
+    JCommander c = new JCommander(a);
+    c.addCommand("a", new ArgCommandA());
+    c.addCommand("b", new ArgCommandB());
+    
+    StringBuilder sb = new StringBuilder();
+    c.usage(sb);
+    Assert.assertTrue(sb.toString().contains("command a parameters\n\n    b"));
+  }
 
   @Test(enabled = false)
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The change affects the result of usage() when:
- there are commands and no main parameters
- there are commands without parameters

For example, the output before the fix:

```
Usage: <main class> [options] [command] [command options]  Commands:
    a      command a
      Usage: a [options] command a parameters
    b      command b
      Usage: b [options] command b parameters
```

After the fix:

```
Usage: <main class> [options] [command] [command options]
  Commands:
    a      command a
      Usage: a [options] command a parameters

    b      command b
      Usage: b [options] command b parameters
```
