### PR TITLE
Use of value.toUpperCase() with enums fails if the enum constants uses mix case constants.

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1264,7 +1264,7 @@ public class JCommander {
       String optionName = names.length > 0 ? names[0] : "[Main class]";
       if (converterClass != null && converterClass.isEnum()) {
         try {
-          result = Enum.valueOf((Class<? extends Enum>) converterClass, value.toUpperCase());
+          result = Enum.valueOf((Class<? extends Enum>) converterClass, value);
         } catch (Exception e) {
           throw new ParameterException("Invalid value for " + optionName + " parameter. Allowed values:" +
                                        EnumSet.allOf((Class<? extends Enum>) converterClass));


### PR DESCRIPTION
If an enum constant uses mixed case as the example below, JCommander fails to parse this because it calls value.toUpperCase() on the string value in the call to Enum.valueOf(). This pull request simply drops the toUpperCase.

``` java
   public static enum MixedCaseEnum {
      EnumOne,
      ENUM_TWO,
      Enum_Three,
      EnumFour,
      ENUMFIVE
   };
```
