### PR TITLE
Allow @Parameters to be used with cglib proxies 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
           <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.13</version>
+            <version>1.31-SNAPSHOT</version>
 <!--
             <version>${project.version}</version>
 -->

--- a/src/main/java/com/beust/jcommander/Parameters.java
+++ b/src/main/java/com/beust/jcommander/Parameters.java
@@ -18,10 +18,11 @@
 
 package com.beust.jcommander;
 
-import static java.lang.annotation.ElementType.TYPE;
-
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
 
 /**
  * An annotation used to specify settings for parameter parsing.
@@ -30,6 +31,7 @@ import java.lang.annotation.Target;
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ TYPE })
+@Inherited
 public @interface Parameters {
 
   public static final String DEFAULT_OPTION_PREFIXES = "-";


### PR DESCRIPTION
We now have the ability to use @Parameters with cglib proxies (such as those created by Spring).
Before the change, JCommander couldn't find the @Parameters annotation on the proxy, since the annotation wasn't set to @Inherited, this change rectifies that.
