### PR TITLE
Issue 147: Allow null value for dynamic parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
-          <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
 
@@ -87,9 +86,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <version>2.4.1</version>
-        <configuration>
-          <encoding>UTF-8</encoding>
-        </configuration>
       </plugin>
 
       <!-- OSGi manifest creation -->
@@ -130,19 +126,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.10</version>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-            <version>1.31-SNAPSHOT</version>
-<!--
-            <version>${project.version}</version>
--->
-           </dependency>
-        </dependencies>
       </plugin>
 
       <!-- Generating Javadoc -->
@@ -158,23 +141,22 @@
   </build>
 
   <dependencies>
-  	<dependency>
-  		<groupId>org.testng</groupId>
-  		<artifactId>testng</artifactId>
-  		<version>6.1.1</version>
-  		<type>jar</type>
-  		<scope>test</scope>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.1.1</version>
+      <scope>test</scope>
         <exclusions>
             <exclusion>
                 <artifactId>jcommander</artifactId>
                 <groupId>com.beust</groupId>
             </exclusion>
         </exclusions>
-  	</dependency>
+    </dependency>
   </dependencies>
 
   <profiles>
-    
+
     <!--
         Do a license check by running       : mvn -P license license:check
         UPdate the license check by running : mvn -P license license:format

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -142,7 +142,6 @@ public class JCommander {
 
   private Comparator<? super ParameterDescription> m_parameterDescriptionComparator
       = new Comparator<ParameterDescription>() {
-        @Override
         public int compare(ParameterDescription p0, ParameterDescription p1) {
           return p0.getLongestName().compareTo(p1.getLongestName());
         }
@@ -154,7 +153,7 @@ public class JCommander {
 
   private List<String> m_unknownArgs = Lists.newArrayList();
   private boolean m_acceptUnknownOptions = false;
-  
+
   private static Console m_console;
 
   /**
@@ -208,7 +207,7 @@ public class JCommander {
     addObject(object);
     parse(args);
   }
-  
+
   public static Console getConsole() {
     if (m_console == null) {
       try {
@@ -581,7 +580,7 @@ public class JCommander {
               new ParameterDescription(object, dp, parameterized, m_bundle, this);
           m_fields.put(parameterized, pd);
           m_descriptions.put(new StringKey(name), pd);
-    
+
           if (dp.required()) m_requiredFields.put(parameterized, pd);
         }
       }
@@ -775,7 +774,7 @@ public class JCommander {
             } else if (jc != null){
                 m_parsedCommand = jc.m_programName.m_name;
                 m_parsedAlias = arg; //preserve the original form
-    
+
                 // Found a valid command, ask it to parse the remainder of the arguments.
                 // Setting the boolean commandParsed to true will force the current
                 // loop to end.
@@ -799,7 +798,6 @@ public class JCommander {
 
   private class DefaultVariableArity implements IVariableArity {
 
-    @Override
     public int processVariableArity(String optionName, String[] options) {
         int i = 0;
         while (i < options.length && !isOption(options, options[i])) {
@@ -1485,7 +1483,6 @@ public class JCommander {
       m_aliases = aliases;
     }
 
-    @Override
     public String getName() {
       return m_name;
     }
@@ -1506,7 +1503,7 @@ public class JCommander {
       }
       return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
       final int prime = 31;
@@ -1539,7 +1536,7 @@ public class JCommander {
     @Override
     public String toString() {
       return getDisplayName();
-      
+
     }
   }
 

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -130,7 +130,7 @@ public class ParameterDescription {
     if (m_parameterAnnotation != null) {
       String description;
       if (Enum.class.isAssignableFrom(parameterized.getType())
-          && m_parameterAnnotation.description().isEmpty()) {
+          && m_parameterAnnotation.description().length() == 0) {
         description = "Options: " + EnumSet.allOf((Class<? extends Enum>) parameterized.getType());
       }else {
         description = m_parameterAnnotation.description();

--- a/src/main/java/com/beust/jcommander/StringKey.java
+++ b/src/main/java/com/beust/jcommander/StringKey.java
@@ -10,7 +10,6 @@ public class StringKey implements IKey {
     m_name = name;
   }
 
-  @Override
   public String getName() {
     return m_name;
   }

--- a/src/main/java/com/beust/jcommander/WrappedParameter.java
+++ b/src/main/java/com/beust/jcommander/WrappedParameter.java
@@ -61,7 +61,7 @@ public class WrappedParameter {
   }
 
   public boolean echoInput() {
-	  return m_parameter != null ? m_parameter.echoInput() : false;
+    return m_parameter != null ? m_parameter.echoInput() : false;
   }
 
   public void addValue(Parameterized parameterized, Object object, Object value) {
@@ -73,11 +73,11 @@ public class WrappedParameter {
 
       int aInd = sv.indexOf(a);
       if (aInd == -1) {
-        throw new ParameterException(
-            "Dynamic parameter expected a value of the form a" + a + "b"
-                + " but got:" + sv);
+        callPut(object, parameterized, sv, null);
       }
-      callPut(object, parameterized, sv.substring(0, aInd), sv.substring(aInd + 1));
+      else {
+        callPut(object, parameterized, sv.substring(0, aInd), sv.substring(aInd + 1));
+      }
     }
   }
 
@@ -88,9 +88,9 @@ public class WrappedParameter {
       m.invoke(parameterized.get(object), key, value);
     } catch (SecurityException e) {
       e.printStackTrace();
-    } catch(IllegalAccessException e) {
+    } catch (IllegalAccessException e) {
       e.printStackTrace();
-    } catch(InvocationTargetException e) {
+    } catch (InvocationTargetException e) {
       e.printStackTrace();
     } catch (NoSuchMethodException e) {
       e.printStackTrace();

--- a/src/test/java/com/beust/jcommander/DefaultValueTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultValueTest.java
@@ -73,9 +73,8 @@ public class DefaultValueTest {
     Assert.assertEquals(opts.list.get(0), "anotherValue");
     Assert.assertEquals(opts.list.get(1), "anotherValue2");
     Assert.assertEquals(opts.set.size(), 2);
-    Iterator<String> arg2it = opts.set.iterator();
-    Assert.assertEquals(arg2it.next(), "anotherValue3");
-    Assert.assertEquals(arg2it.next(), "anotherValue4");
+    Assert.assertTrue(opts.set.contains("anotherValue3"));
+    Assert.assertTrue(opts.set.contains("anotherValue4"));
   }
 
   public static class MyOpts {

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -266,7 +266,7 @@ public class JCommanderTest {
   public void converterArgs() {
     ArgsConverter args = new ArgsConverter();
     String fileName = "a";
-    new JCommander(args, "-file", "/tmp/" + fileName, 
+    new JCommander(args, "-file", "/tmp/" + fileName,
       "-listStrings", "Tuesday,Thursday",
       "-listInts", "-1,8",
       "-listBigDecimals", "-11.52,100.12");
@@ -566,12 +566,12 @@ public class JCommanderTest {
     JCommander jc = new JCommander(args, argv);
 
     Assert.assertEquals(args.choice, ArgsEnum.ChoiceType.ONE);
-    
+
     List<ChoiceType> expected = Arrays.asList(ChoiceType.ONE, ChoiceType.Two);
     Assert.assertEquals(expected, args.choices);
     Assert.assertEquals(jc.getParameters().get(0).getDescription(),
         "Options: " + EnumSet.allOf((Class<? extends Enum>) ArgsEnum.ChoiceType.class));
-    
+
   }
 
   @Test(expectedExceptions = ParameterException.class)
@@ -614,7 +614,6 @@ public class JCommanderTest {
   public void mainParameterShouldBeValidate() {
     class V implements IParameterValidator {
 
-      @Override
       public void validate(String name, String value) throws ParameterException {
         Assert.assertEquals("a", value);
       }
@@ -654,8 +653,8 @@ public class JCommanderTest {
   @Test(enabled = false,
       description = "For some reason, this test still asks the password on stdin")
   public void askedRequiredPassword() {
-    class A {     
-        @Parameter(names = { "--password", "-p" }, description = "Private key password", 
+    class A {
+        @Parameter(names = { "--password", "-p" }, description = "Private key password",
             password = true, required = true)
         public String password;
 
@@ -666,7 +665,7 @@ public class JCommanderTest {
     A a = new A();
     InputStream stdin = System.in;
     try {
-      System.setIn(new ByteArrayInputStream("password".getBytes()));      
+      System.setIn(new ByteArrayInputStream("password".getBytes()));
       new JCommander(a,new String[]{"--port", "7","--password"});
       Assert.assertEquals(a.port, 7);
       Assert.assertEquals(a.password, "password");
@@ -730,7 +729,7 @@ public class JCommanderTest {
     @Parameters(resourceBundle = "MessageBundle", commandDescriptionKey = "command")
     class Args {
       @Parameter(names="-myoption", descriptionKey="myoption")
-      private boolean option; 
+      private boolean option;
     }
     JCommander j = new JCommander();
     Args a = new Args();
@@ -874,12 +873,10 @@ public class JCommanderTest {
     final static List<String> names =  Lists.newArrayList();
     static boolean validateCalled = false;
 
-    @Override
     public void validate(String name, String value) throws ParameterException {
       validateCalled = true;
     }
 
-    @Override
     public void validate(String name, String value, ParameterDescription pd)
         throws ParameterException {
       names.addAll(Arrays.asList(pd.getParameter().names()));
@@ -899,7 +896,7 @@ public class JCommanderTest {
     Assert.assertEquals(V2.names, Arrays.asList(new String[] { "-h", "--host" }));
     Assert.assertTrue(V2.validateCalled);
   }
-  
+
   public void usageCommandsUnderUsage() {
     class Arg {
     }
@@ -913,13 +910,13 @@ public class JCommanderTest {
       @Parameter(description = "command b parameters")
       List<String> parameters;
     }
-    
+
     Arg a = new Arg();
-    
+
     JCommander c = new JCommander(a);
     c.addCommand("a", new ArgCommandA());
     c.addCommand("b", new ArgCommandB());
-    
+
     StringBuilder sb = new StringBuilder();
     c.usage(sb);
     Assert.assertTrue(sb.toString().contains("[command options]\n  Commands:"));
@@ -938,13 +935,13 @@ public class JCommanderTest {
       @Parameter(description = "command b parameters")
       List<String> parameters;
     }
-    
+
     Arg a = new Arg();
-    
+
     JCommander c = new JCommander(a);
     c.addCommand("a", new ArgCommandA());
     c.addCommand("b", new ArgCommandB());
-    
+
     StringBuilder sb = new StringBuilder();
     c.usage(sb);
     Assert.assertTrue(sb.toString().contains("command a parameters\n\n    b"));
@@ -981,13 +978,13 @@ public class JCommanderTest {
     class Arguments {
         @Parameter(names = { "-help", "-h" }, arity = 0, description = "Show this help message")
         public Boolean help = false;
-        
+
         @Parameter(names = { "-verbose", "-v" }, arity = 0, description = "Verbose output mode")
         public Boolean verbose = false;
-        
+
         @Parameter(names = { "-target" }, arity = 1, description = "Target directory", required = true)
         public File target;
-        
+
         @Parameter(names = { "-input" }, variableArity = true, description = "Input paths", required = true)
         public List<String> paths;
     }

--- a/src/test/java/com/beust/jcommander/MyClass.java
+++ b/src/test/java/com/beust/jcommander/MyClass.java
@@ -15,7 +15,6 @@ public class MyClass {
   }
 
   public static class MyValidator implements IParameterValidator {
-    @Override
     public void validate(String name, String value) throws ParameterException {
       Assert.assertEquals(value, "\"");
     }

--- a/src/test/java/com/beust/jcommander/dynamic/DynamicParameterTest.java
+++ b/src/test/java/com/beust/jcommander/dynamic/DynamicParameterTest.java
@@ -3,7 +3,6 @@ package com.beust.jcommander.dynamic;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.internal.Maps;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,10 +14,11 @@ public class DynamicParameterTest {
     new JCommander(new DSimpleBad()).parse("-D", "a=b", "-D", "c=d");
   }
 
-  @Test(expectedExceptions = ParameterException.class)
-  public void wrongSeparatorShouldThrow() {
+  @Test
+  public void paramWithoutValue() {
     DSimple ds = new DSimple();
-    new JCommander(ds).parse("-D", "a:b", "-D", "c=d");
+    new JCommander(ds).parse("-D", "a", "-D", "c=d");
+    Assert.assertEquals(ds.params, Maps.newHashMap("a", null, "c", "d"));
   }
 
   private void simple(String... parameters) {
@@ -51,10 +51,9 @@ public class DynamicParameterTest {
   public static void main(String[] args) {
     DynamicParameterTest dpt = new DynamicParameterTest();
     dpt.simpleWithSpaces();
-//    dpt.nonMapShouldThrow();
-//    dpt.wrongSeparatorShouldThrow();
-//    dpt.differentAssignment();
-//    dpt.arity0();
-//    dpt.usage();
+    // dpt.nonMapShouldThrow();
+    // dpt.differentAssignment();
+    // dpt.arity0();
+    // dpt.usage();
   }
 }


### PR DESCRIPTION
As a side effect of my fix for issue 147 then there is no more exception because of invalid separator for dynamic parameters. Instead it will be considered as a parameter without value.

I also took the opportunity to cleanup the pom.xml and restore Java 1.5 compatibility.
