### PR TITLE
DefaultVariableArity implementation

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -802,7 +802,7 @@ public class JCommander {
     @Override
     public int processVariableArity(String optionName, String[] options) {
         int i = 0;
-        while (i < options.length && !isOption(options, options[i])) {
+        while (i < options.length && findParameterDescription(options[i]) == null) {
           i++;
         }
         return i;


### PR DESCRIPTION
The following parameter is supposed to get many parameters to pass to an
external software.

```
// JS Parameters
@Parameter(names = "-J", description = "Parameters to be passed to Google Closure Compiler", variableArity = true)
public List<String> closureOpts = new ArrayList<String>();
```

So my app will be called like this

```
foo -J --compilation_level WHITESPACE_ONLY --language_in=ECMASCRIPT5 -bar baz -faz -J --more-options
```

Judging by the documentation:

> You can specify that a parameter can receive an indefinite number of
> parameters, up to the next option. For example:

I was expecting to get

```
{ "--compilation_level", "WHITESPACE_ONLY", "--language_in=ECMASCRIPT5", "--more-options" }
```

Instead I've received

ParameterException for "Unknown options".

If I set AcceptUnknownOptions to true, it still does not work as I've
expected and the list is not populated at all.

I believe correct behaviour should be to interpret all of the parameters
after a VariableArity parameter until next VALID parameter as raw values
and add them to the list.

This patch does that and gives the result I expected.

The expected result could also be achived by deriving our  MyOptions
class from IVariableArity (see JCommander.java:824) but I believe our
options class is not the appropriate place to change this behaviour.
