### PR TITLE
Keep the parent's JCommander bundle when creating child JCommander objec...

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1358,7 +1358,7 @@ public class JCommander {
    * Add a command object and its aliases.
    */
   public void addCommand(String name, Object object, String... aliases) {
-    JCommander jc = new JCommander(object);
+    JCommander jc = new JCommander(object, m_bundle);
     jc.setProgramName(name, aliases);
     jc.setDefaultProvider(m_defaultProvider);
     ProgramName progName = jc.m_programName;


### PR DESCRIPTION
...ts for commands

This commit should fix a bug in which commands added to the JCommander object do not have a resource bundle associated with them and thus appear to not have descriptions if their descriptions are provided using a bundle key and not directly in the annotation. Unfortunately, the parameter descriptions are created in the constructor and later change in the bundle does not affect them.