### PR TITLE
Support ability to disable ampersat (@) parsing

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -156,6 +156,8 @@ public class JCommander {
   private boolean m_acceptUnknownOptions = false;
   
   private static Console m_console;
+  
+  private boolean expandAmpersat = true;
 
   /**
    * The factories used to look up string converters.
@@ -207,6 +209,10 @@ public class JCommander {
   public JCommander(Object object, String... args) {
     addObject(object);
     parse(args);
+  }
+
+  public void setExpandAmpersat(boolean expandAmpersat){
+    this.expandAmpersat = expandAmpersat;
   }
   
   public static Console getConsole() {
@@ -351,7 +357,7 @@ public class JCommander {
     //
     for (String arg : originalArgv) {
 
-      if (arg.startsWith("@")) {
+      if (arg.startsWith("@") && expandAmpersat) {
         String fileName = arg.substring(1);
         vResult1.addAll(readFile(fileName));
       }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -157,7 +157,7 @@ public class JCommander {
   
   private static Console m_console;
   
-  private boolean expandAmpersat = true;
+  private boolean expandAtSign = true;
 
   /**
    * The factories used to look up string converters.
@@ -211,8 +211,8 @@ public class JCommander {
     parse(args);
   }
 
-  public void setExpandAmpersat(boolean expandAmpersat){
-    this.expandAmpersat = expandAmpersat;
+  public void setExpandAtSign(boolean expandAtSign){
+    this.expandAtSign = expandAtSign;
   }
   
   public static Console getConsole() {
@@ -357,7 +357,7 @@ public class JCommander {
     //
     for (String arg : originalArgv) {
 
-      if (arg.startsWith("@") && expandAmpersat) {
+      if (arg.startsWith("@") && expandAtSign) {
         String fileName = arg.substring(1);
         vResult1.addAll(readFile(fileName));
       }

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -839,6 +839,36 @@ public class JCommanderTest {
     Assert.assertEquals(arg2.host, "foo");
   }
 
+  @Test(enabled = true, description = "Disable top-level @/ampersand file expansion")
+  public void disabledAtSignExpansionTest() {
+    class Params {
+      @Parameter(names = { "-username" })
+      protected String username;
+    }
+
+    Params params = new Params();
+
+    JCommander jc = new JCommander(params);
+    jc.setExpandAtSign(false);
+    jc.parse(new String[] { "-username", "@tzellman" });
+    Assert.assertEquals(params.username, "@tzellman");
+  }
+
+  @Test(enabled = true, description = "Enable top-level @/ampersand file expansion, which should throw in this case",
+          expectedExceptions = ParameterException.class)
+  public void enabledAtSignExpansionTest() {
+    class Params {
+      @Parameter(names = { "-username" })
+      protected String username;
+    }
+
+    Params params = new Params();
+
+    JCommander jc = new JCommander(params);
+    jc.parse(new String[] { "-username", "@tzellman" });
+    Assert.assertEquals(params.username, "@tzellman");
+  }
+
   public void parameterWithOneDoubleQuote() {
     @Parameters(separators = "=")
     class Arg {


### PR DESCRIPTION
Support a flag to disable ampersat/file parse support; required when options actually begin with an ampersat symbol and you don't intend for it to be a file.

e.g.

```java
            String[] args = new String[]{"--name", "@tzellman"};
            Params params = new Params();
            JCommander jc = new JCommander(params);
            jc.setExpandAmpersat(false);
            jc.parse(args);
```