### PR TITLE
Suppress ParameterException if a default value is provided to a required parameter

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -796,6 +796,14 @@ public class JCommander {
       if (parameterDescription.isAssigned()) {
         m_fields.get(parameterDescription.getParameterized()).setAssigned(true);
       }
+      
+      // if the parameter has a default value (not the one assigned by DefaultProvider
+      // but the one assigned on the variable initialization), make it as assigned and
+      // remove it from the list of parameters to be required
+      if (parameterDescription.getDefault() != null) {
+          m_fields.get(parameterDescription.getParameterized()).setAssigned(true);
+          m_requiredFields.remove(parameterDescription.getParameterized());
+      }
     }
 
   }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -663,6 +663,8 @@ public class JCommander {
       if (def != null) {
         p("Initializing " + optionName + " with default value:" + def);
         pd.addValue(def, true /* default */);
+        // remove the parameter from the list of fields to be required
+        m_requiredFields.remove(pd.getParameterized());
         return;
       }
     }

--- a/src/test/java/com/beust/jcommander/DefaultProviderTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultProviderTest.java
@@ -18,11 +18,15 @@
 
 package com.beust.jcommander;
 
+import java.util.List;
+
+import com.beust.jcommander.DefaultValueTest.MyRequiredOptsWithDefaultValues;
 import com.beust.jcommander.args.ArgsDefault;
 import com.beust.jcommander.defaultprovider.PropertyFileDefaultProvider;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.collections.Lists;
 
 public class DefaultProviderTest {
   private static final IDefaultProvider DEFAULT_PROVIDER = new IDefaultProvider() {
@@ -117,4 +121,25 @@ public class DefaultProviderTest {
     Assert.assertEquals(a.log.intValue(), 19);
   }
 
+
+  @Test
+  public void missingRequiredParameterWithDefaultValueProviderShouldNotRaiseParameterException() {
+    class ArgsRequired {
+      @Parameter(names = "-log", description = "Level of verbosity", required = true)
+      public Integer log;
+    };
+    
+    IDefaultProvider defaultProvider = new IDefaultProvider() {
+      public String getDefaultValueFor(String optionName) {
+        return "-log".equals(optionName) ? "1" : "";
+      }
+    };
+    
+    ArgsRequired a = new ArgsRequired();
+    JCommander jc = new JCommander(a);
+    jc.setDefaultProvider(defaultProvider);
+    jc.parse(new String[]{});
+    
+    Assert.assertEquals(a.log.intValue(), 1);
+  }
 }

--- a/src/test/java/com/beust/jcommander/DefaultValueTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultValueTest.java
@@ -110,4 +110,17 @@ public class DefaultValueTest {
     set.add(value);
     return set;
   }
+  
+
+  @Test
+  public void missingRequiredParameterWithDefaultValueShouldNotRaiseParameterException() {
+    MyRequiredOptsWithDefaultValues opts = new MyRequiredOptsWithDefaultValues();
+    JCommander cmd = new JCommander(opts);
+    cmd.parse(new String[]{});
+  }
+
+  public static class MyRequiredOptsWithDefaultValues {
+    @Parameter(names = "-a", required = true)
+    public List<String> list = singletonList("defaultValue");
+  }
 }

--- a/src/test/java/com/beust/jcommander/args/Args1.java
+++ b/src/test/java/com/beust/jcommander/args/Args1.java
@@ -31,7 +31,7 @@ public class Args1 {
   public List<String> parameters = Lists.newArrayList();
 
   @Parameter(names = { "-log", "-verbose" }, description = "Level of verbosity", required = true)
-  public Integer verbose = 1;
+  public Integer verbose;
 
   @Parameter(names = "-groups", description = "Comma-separated list of group names to be run")
   public String groups;


### PR DESCRIPTION
Suppress ParameterException on the following two cases.
- No value is given to a required parameter but the default value is provided by a DefaultProvider
- No value is given to a required parameter but the default value is assigned on the initialization

They are implemented in different commits. And  69acd2e resolves cbeust/jcommander#95.
