### PR TITLE
Do not close System.in when using DefaultConsole

### DIFF
--- a/src/main/java/com/beust/jcommander/internal/DefaultConsole.java
+++ b/src/main/java/com/beust/jcommander/internal/DefaultConsole.java
@@ -18,11 +18,10 @@ public class DefaultConsole implements Console {
 
   public char[] readPassword(boolean echoInput) {
     try {
+      // Do not close the readers since System.in should not be closed
       InputStreamReader isr = new InputStreamReader(System.in);
       BufferedReader in = new BufferedReader(isr);
       String result = in.readLine();
-      in.close();
-      isr.close();
       return result.toCharArray();
     }
     catch (IOException e) {

--- a/src/test/java/com/beust/jcommander/internal/DefaultConsoleTest.java
+++ b/src/test/java/com/beust/jcommander/internal/DefaultConsoleTest.java
@@ -1,0 +1,64 @@
+package com.beust.jcommander.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class DefaultConsoleTest {
+  public void readPasswordCanBeCalledMultipleTimes() {
+    final InputStream inBackup = System.in;
+    try {
+      final StringInputStream in = new StringInputStream();
+      System.setIn(in);
+      final Console console = new DefaultConsole();
+
+      in.setData("password1\n");
+      char[] password = console.readPassword(false);
+      Assert.assertEquals(password, "password1".toCharArray());
+      Assert.assertFalse(in.isClosedCalled(), "System.in stream shouldn't be closed");
+
+      in.setData("password2\n");
+      password = console.readPassword(false);
+      Assert.assertEquals(password, "password2".toCharArray());
+      Assert.assertFalse(in.isClosedCalled(), "System.in stream shouldn't be closed");
+    } finally {
+      System.setIn(inBackup);
+    }
+  }
+
+  private static class StringInputStream extends InputStream {
+    private byte[] data = new byte[0];
+    private int offset = 0;
+    private boolean closedCalled;
+
+    StringInputStream() {
+      super();
+    }
+
+    void setData(final String strData) {
+      data = strData.getBytes();
+      offset = 0;
+    }
+
+    boolean isClosedCalled() {
+      return closedCalled;
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (offset >= data.length) {
+        return -1;
+      }
+      return 0xFFFF & data[offset++];
+    }
+
+    @Override
+    public void close() throws IOException {
+      closedCalled = true;
+      super.close();
+    }
+  }
+}


### PR DESCRIPTION
When running inside an environment that does not provide an implementation for System.console() (see [Eclipse issue 122429](https://bugs.eclipse.org/bugs/show_bug.cgi?id=122429), DefaultConsole is used.

DefaultConsole closes the System.in stream, which means that:
- two different passwords cannot be requested for a single command.
- if the application then requires a user input, it will fail since the stream has already been closed.
