### PR TITLE
Fix NPE when there was a parameter with only a listConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -50,6 +50,7 @@ import com.beust.jcommander.internal.Lists;
 import com.beust.jcommander.internal.Maps;
 import com.beust.jcommander.internal.Nullable;
 
+
 /**
  * The main class for JCommander. It's responsible for parsing the object that contains
  * all the annotated fields, parse the command line and assign the fields with the correct
@@ -1248,7 +1249,7 @@ public class JCommander {
       }
     }
 
-    IStringConverter<?> converter;
+    IStringConverter<?> converter = null;
     Object result = null;
     try {
       String[] names = annotation.names();
@@ -1264,7 +1265,9 @@ public class JCommander {
                                        EnumSet.allOf((Class<? extends Enum>) converterClass));
         }
       } else {
-        converter = instantiateConverter(optionName, converterClass);
+        if (converterClass != null) {
+          converter = instantiateConverter(optionName, converterClass);
+        }
         if (type.isAssignableFrom(List.class)
               && parameterized.getGenericType() instanceof ParameterizedType) {
 

--- a/src/test/java/com/beust/jcommander/HostPortListConverter.java
+++ b/src/test/java/com/beust/jcommander/HostPortListConverter.java
@@ -1,0 +1,25 @@
+package com.beust.jcommander;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Scott Stark
+ * @version $Revision:$
+ */
+public class HostPortListConverter implements IStringConverter<List<HostPort>> {
+   @Override
+   public List<HostPort> convert(String value) {
+      ArrayList<HostPort> hps = new ArrayList<HostPort>();
+      // First split on ; to find host/port pairs
+      String[] pairs = value.split(";");
+      for (String pair : pairs) {
+         String[] s = pair.split(":");
+         HostPort result = new HostPort();
+         result.host = s[0];
+         result.port = Integer.parseInt(s[1]);
+         hps.add(result);
+      }
+      return hps;
+   }
+}

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -585,7 +585,7 @@ public class JCommanderTest {
     ArgsList al = new ArgsList();
     JCommander j = new JCommander(al);
     j.parse("-groups", "a,b", "-ints", "41,42", "-hp", "localhost:1000;example.com:1001",
-        "-hp2", "localhost:1000,example.com:1001", "-uppercase", "ab,cd");
+        "-hp2", "localhost:1000,example.com:1001", "-hps", "localhost:1000;example.com:1001", "-uppercase", "ab,cd");
     Assert.assertEquals(al.groups.get(0), "a");
     Assert.assertEquals(al.groups.get(1), "b");
     Assert.assertEquals(al.ints.get(0).intValue(), 41);
@@ -596,6 +596,10 @@ public class JCommanderTest {
     Assert.assertEquals(al.hostPorts.get(1).port.intValue(), 1001);
     Assert.assertEquals(al.hp2.get(1).host, "example.com");
     Assert.assertEquals(al.hp2.get(1).port.intValue(), 1001);
+    Assert.assertEquals(al.hps.get(0).host, "localhost");
+    Assert.assertEquals(al.hps.get(0).port.intValue(), 1000);
+    Assert.assertEquals(al.hps.get(1).host, "example.com");
+    Assert.assertEquals(al.hps.get(1).port.intValue(), 1001);
     Assert.assertEquals(al.uppercase.get(0), "AB");
     Assert.assertEquals(al.uppercase.get(1), "CD");
   }

--- a/src/test/java/com/beust/jcommander/args/ArgsList.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsList.java
@@ -2,6 +2,7 @@ package com.beust.jcommander.args;
 
 import com.beust.jcommander.HostPort;
 import com.beust.jcommander.HostPortConverter;
+import com.beust.jcommander.HostPortListConverter;
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.converters.IParameterSplitter;
@@ -23,6 +24,9 @@ public class ArgsList {
 
   @Parameter(names = "-hp2", converter = HostPortConverter.class)
   public List<HostPort> hp2;
+
+  @Parameter(names = "-hps", listConverter = HostPortListConverter.class)
+  public List<HostPort> hps;
 
   @Parameter(names = "-uppercase", listConverter = UppercaseConverter.class)
   public List<String> uppercase;


### PR DESCRIPTION
I was seeing the following NPE when there was a parameter with only a listConverter as seen in the updated JCommanderTest.testListAndSplitters. This pull request fixes that.

java.lang.NullPointerException at com.beust.jcommander.JCommander.instantiateConverter(JCommander.java:1320)
 at com.beust.jcommander.JCommander.convertValue(JCommander.java:1268) 
at com.beust.jcommander.JCommander.convertValue(JCommander.java:1212) 
at com.beust.jcommander.ParameterDescription.addValue(ParameterDescription.java:242) 
at com.beust.jcommander.ParameterDescription.addValue(ParameterDescription.java:210)
 at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:868) 
at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:850) 
at com.beust.jcommander.JCommander.parseValues(JCommander.java:722)
 at com.beust.jcommander.JCommander.parse(JCommander.java:282)
 at com.beust.jcommander.JCommander.parse(JCommander.java:265)
 at com.beust.jcommander.JCommanderTest.testListAndSplitters(JCommanderTest.java:587)