### PR TITLE
Issue #171, Issue #127: Methods w/o output parameters for parse and usag...

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -208,7 +208,56 @@ public class JCommander {
     addObject(object);
     parse(args);
   }
-  
+
+  /**
+   * Convenience method for parsing arguments in a functional manner - i.e. without using an output parameter.
+   *
+   * @param argumentsDescriptor The arg class expected to contain {@link Parameter} annotations.
+   * @param args The arguments to parse
+   * @return The args parsed into an instance of parameterDescriptorClass
+   */
+  public static <T> T parse(Class<T> parameterDescriptorClass, String[] args) {
+
+    T parameterCarrier = instantiateArgumentsCarrier(parameterDescriptorClass);
+
+    new JCommander(parameterCarrier, args);
+
+    return parameterCarrier;
+  }
+
+  private static <T> T instantiateArgumentsCarrier(final Class<T> parameterDescriptorClass) {
+
+    try {
+      return parameterDescriptorClass.newInstance();
+    } catch (InstantiationException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Convenience method for getting the usage text in a functional manner - i.e. without using an output parameter.
+   *
+   * @param argumentsDescriptor The arg class expected to contain {@link Parameter} annotations.
+   * @param args The name of the program
+   * @return The usage description
+   */
+  public static <T> String usage(Class<T> parameterDescriptorClass, String programName) {
+
+    T parameterCarrier = instantiateArgumentsCarrier(parameterDescriptorClass);
+
+    JCommander parser = new JCommander(parameterCarrier);
+
+    parser.setProgramName(programName);
+
+    StringBuilder builder = new StringBuilder();
+
+    parser.usage(builder);
+
+    return builder.toString();
+  }
+
   public static Console getConsole() {
     if (m_console == null) {
       try {


### PR DESCRIPTION
...e description.

This pull request suggests to add static convenience methods for parsing lists of arguments and getting the usage text for a "Parameter descriptor" object (i.e. an object with Parameter annotations) _without_ using Output parameters. It relies, instead, on reflection.

This will make the API slightly easier to use in a functional manner and, in my opinion, just generally easier to understand and use:

```
Params myParams = JCommander.parse(Params.class, myArgs);
String usage = JCommander.usage(Params.class, myProgramName);
```

This pull request is intended to resolve Issue https://github.com/cbeust/jcommander/issues/171   but it also kind of addresses Issue https://github.com/cbeust/jcommander/issues/127
