### PR TITLE
fix bug in usage line wrapping method

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1158,7 +1158,7 @@ public class JCommander {
         current += word.length() + 1;
       } else {
         out.append("\n").append(s(indent + 1)).append(word);
-        current = indent;
+        current = indent + word.length() + 1;
       }
       i++;
     }

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -57,6 +57,7 @@ import com.beust.jcommander.args.ArgsI18N2;
 import com.beust.jcommander.args.ArgsI18N2New;
 import com.beust.jcommander.args.ArgsInherited;
 import com.beust.jcommander.args.ArgsList;
+import com.beust.jcommander.args.ArgsLongDescription;
 import com.beust.jcommander.args.ArgsMainParameter1;
 import com.beust.jcommander.args.ArgsMaster;
 import com.beust.jcommander.args.ArgsMultipleUnparsed;
@@ -430,6 +431,16 @@ public class JCommanderTest {
     jc.usage(sb);
     String actual = sb.toString();
     Assert.assertEquals(actual, expected);
+  }
+
+  public void usageLongDescription() {
+    JCommander jc = new JCommander(new ArgsLongDescription(), new String[]{"-c", "foo"});
+    StringBuilder sb = new StringBuilder();
+    jc.usage(sb);
+    String expected = sb.toString();
+    for (String line : expected.split("\n")) {
+      Assert.assertTrue(line.length() <= jc.getColumnSize(), line);
+    }
   }
 
   private void verifyCommandOrdering(String[] commandNames, Object[] commands) {

--- a/src/test/java/com/beust/jcommander/args/ArgsLongDescription.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsLongDescription.java
@@ -5,7 +5,8 @@ import com.beust.jcommander.Parameter;
 public class ArgsLongDescription {
 
   @Parameter(names = "--classpath", description = "The classpath. This is a very long "
-      + "description in order to test the line wrapping. Let's see how this works."
+      + "description in order to test the line wrapping. Let's see how this works. "
+      + "Thisisareallylongwordtotestwhetherthecodeworkswithlongwords. "
       + "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor"
       + " incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis "
       + "nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.")


### PR DESCRIPTION
I created this commit because there seemed to be a bug in your code that wraps lines in the usage descriptions. I thought you would be interested, so I am passing it back upstream to you.

By the way: you are aware that your test suite is both disabled and failing right now, right? Something about JCommanderTest.enumArgsFail?
