### PR TITLE
Improve @file possibilities

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -154,6 +154,7 @@ public class JCommander {
 
   private List<String> m_unknownArgs = Lists.newArrayList();
   private boolean m_acceptUnknownOptions = false;
+  private boolean m_allowParameterOverwriting = false;
   
   private static Console m_console;
 
@@ -1567,7 +1568,13 @@ public class JCommander {
   public List<String> getUnknownOptions() {
     return m_unknownArgs;
   }
+  public void setAllowParameterOverwriting(boolean b) {
+    m_allowParameterOverwriting = b;
+  }
 
+  public boolean isParameterOverwritingAllowed() {
+    return m_allowParameterOverwriting;
+  }
 //  public void setCaseSensitiveCommands(boolean b) {
 //    m_caseSensitiveCommands = b;
 //  }

--- a/src/main/java/com/beust/jcommander/Parameter.java
+++ b/src/main/java/com/beust/jcommander/Parameter.java
@@ -119,4 +119,12 @@ public @interface Parameter {
    * required parameters are no longer checked for their presence.
    */
   boolean help() default false;
+  
+  /**
+   * If true, this parameter can be overwritten through a file or another appearance of the parameter
+   * @return 
+   */
+  boolean forceNonOverwritable() default false;
+
+  
 }

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -231,7 +231,7 @@ public class ParameterDescription {
     p("Adding " + (isDefault ? "default " : "") + "value:" + value
         + " to parameter:" + m_parameterized.getName());
     String name = m_wrappedParameter.names()[0];
-    if (m_assigned && ! isMultiOption()) {
+    if (m_assigned && ! isMultiOption() && !m_jCommander.isParameterOverwritingAllowed() || isNonOverwritableForced()) {
       throw new ParameterException("Can only specify option " + name + " once.");
     }
 
@@ -357,5 +357,9 @@ public class ParameterDescription {
 
   public boolean isHelp() {
     return m_wrappedParameter.isHelp();
+  }
+  
+  public boolean isNonOverwritableForced() {
+    return m_wrappedParameter.isNonOverwritableForced();
   }
 }

--- a/src/main/java/com/beust/jcommander/WrappedParameter.java
+++ b/src/main/java/com/beust/jcommander/WrappedParameter.java
@@ -109,4 +109,7 @@ public class WrappedParameter {
     return m_parameter != null && m_parameter.help();
   }
 
+  public boolean isNonOverwritableForced() {
+      return m_parameter != null && m_parameter.forceNonOverwritable();
+  }
 }


### PR DESCRIPTION
1st commit:
### add the possibility to have # comments in a @file

When using the @file possibilities of jcommander it would be useful to have the ability to comment certain lines.

with this pull request this is possible:

(use `@Parameters(separators = "=")`to have nicer config files ;-) )

and how you use it:

``` properties
#Specifiy the port
-port = 42
#Specify another param
--mod1Param = file1
```
