### PR TITLE
Allow selective usage()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,13 @@
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>3</version>
+    <version>9</version>
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
   <build>
@@ -88,10 +88,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>3.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -145,19 +145,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.10</version>
         <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-            <version>1.30</version>
-<!--
-            <version>${project.version}</version>
--->
-           </dependency>
-        </dependencies>
-      </plugin>
+       </configuration>
+       </plugin>
 
       <!-- Generating Javadoc -->
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
     <version>3</version>
   </parent>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
   <build>
     <plugins>
 

--- a/src/main/java/com/beust/jcommander/UsageOptions.java
+++ b/src/main/java/com/beust/jcommander/UsageOptions.java
@@ -1,0 +1,24 @@
+package com.beust.jcommander;
+
+public enum UsageOptions {
+  /**
+   * Display non-command parameters.
+   */
+  DISPLAY_PARAMETERS, 
+  
+  /**
+   * Display "syntax" line.
+   */
+  DISPLAY_SYNTAX_LINE, 
+  
+  /**
+   * Display commands.
+   */
+  DISPLAY_COMMANDS,
+  
+  /**
+   * Displays options for each command, if commands are present and {@link #DISPLAY_COMMANDS}
+   * is also passed as an option.
+   */
+  DISPLAY_OPTIONS_FOR_EACH_COMMAND;
+}


### PR DESCRIPTION
If one has a number of commands the default usage() tends to be too verbose. We'd rather like git-like behavior which displays just commands and their descriptions at the "top level".

This patch introduces an enumeration which allows selective picks of the default usage() block. This is just for consideration, perhaps other options are viable (like exposing internals that allow formatting of options, for example).

I also removed an odd circular dependency to an older project version in surefire and updated the required java compatibility level to 1.6 (Override on interfaces).