### PR TITLE
fix NPE if you attempt to call JCommander#usage when you have not specified the @Parameters annotation

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1126,7 +1126,7 @@ public class JCommander {
       for (Map.Entry<ProgramName, JCommander> commands : m_commands.entrySet()) {
         Object arg = commands.getValue().getObjects().get(0);
         Parameters p = arg.getClass().getAnnotation(Parameters.class);
-        if (!p.hidden()) {
+        if (p == null || !p.hidden()) {
           ProgramName progName = commands.getKey();
           String dispName = progName.getDisplayName();
           out.append(indent).append("    " + dispName); // + s(spaceCount) + getCommandDescription(progName.name) + "\n");

--- a/src/test/java/com/beust/jcommander/command/CommandNoParametersAnnotation.java
+++ b/src/test/java/com/beust/jcommander/command/CommandNoParametersAnnotation.java
@@ -1,0 +1,9 @@
+package com.beust.jcommander.command;
+
+import com.beust.jcommander.Parameter;
+import java.util.List;
+
+public class CommandNoParametersAnnotation {
+  @Parameter(description = "Patterns of files to be added")
+  public List<String> patterns;
+}

--- a/src/test/java/com/beust/jcommander/command/CommandTest.java
+++ b/src/test/java/com/beust/jcommander/command/CommandTest.java
@@ -109,6 +109,20 @@ public class CommandTest {
         Assert.assertFalse(out.toString().contains("hidden      Hidden command to add file contents to the index"));
     }
 
+  @Test
+  public void noParametersAnnotationOnCommandTest() {
+    CommandMain cm = new CommandMain();
+    JCommander jc = new JCommander(cm);
+    CommandNoParametersAnnotation noParametersAnnotation = new CommandNoParametersAnnotation();
+    jc.addCommand("no-annotation", noParametersAnnotation);
+
+    jc.setProgramName("TestCommander");
+    StringBuilder out = new StringBuilder();
+    jc.usage(out);
+
+    Assert.assertTrue(out.toString().contains("no-annotation"));
+  }
+
   public static void main(String[] args) {
     new CommandTest().shouldComplainIfNoAnnotations();
   }


### PR DESCRIPTION
[The change to allow hidden commands](https://github.com/cbeust/jcommander/commit/44ef916dcf74e46adbf7c2ae99643bd0e97c16e6)  causes a NullPointerException if you try to call JCommander#usage for a class that has not been annotated with @Parameters