### PR TITLE
Use HTML codes for angle brackets in javadoc

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -52,7 +52,7 @@
   </tr>
   <tr>
     <td align="right">
-      Last updated: January 14th, 2015
+      Last updated: February 5th, 2015
     </td>
   </tr>
   <tr><td align="right"><a href="mailto:cedric@beust.com">C&eacute;dric Beust</a></td></tr>
@@ -857,7 +857,7 @@ You can download JCommander from the following locations:
 <dependency>
   &lt;groupId&gt;com.beust&lt;/groupId&gt;
   &lt;artifactId&gt;jcommander&lt;/artifactId&gt;
-  &lt;version&gt;1.30&lt;/version&gt;
+  &lt;version&gt;1.47&lt;/version&gt;
 </dependency>
   </pre>
 

--- a/src/main/java/com/beust/jcommander/IParameterValidator.java
+++ b/src/main/java/com/beust/jcommander/IParameterValidator.java
@@ -21,7 +21,7 @@ package com.beust.jcommander;
 /**
  * The class used to validate parameters.
  *
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 public interface IParameterValidator {
 

--- a/src/main/java/com/beust/jcommander/IStringConverter.java
+++ b/src/main/java/com/beust/jcommander/IStringConverter.java
@@ -33,7 +33,7 @@ package com.beust.jcommander;
  */
 public interface IStringConverter<T> {
   /**
-   * @return an object of type <T> created from the parameter value.
+   * @return an object of type &lt;T&gt; created from the parameter value.
    */
   T convert(String value);
 }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -60,7 +60,7 @@ import com.beust.jcommander.internal.Nullable;
  * or an instance of Iterable. In the case of an array or Iterable, JCommander will collect
  * the \@Parameter annotations from all the objects passed in parameter.
  *
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 public class JCommander {
   public static final String DEBUG_PROPERTY = "jcommander.debug";

--- a/src/main/java/com/beust/jcommander/MissingCommandException.java
+++ b/src/main/java/com/beust/jcommander/MissingCommandException.java
@@ -21,7 +21,7 @@ package com.beust.jcommander;
 /**
  * Thrown when a command was expected.
  *
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 @SuppressWarnings("serial")
 public class MissingCommandException extends ParameterException {

--- a/src/main/java/com/beust/jcommander/ParameterException.java
+++ b/src/main/java/com/beust/jcommander/ParameterException.java
@@ -22,7 +22,7 @@ package com.beust.jcommander;
  * The main exception that JCommand will throw when something goes wrong while
  * parsing parameters.
  *
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 @SuppressWarnings("serial")
 public class ParameterException extends RuntimeException {

--- a/src/main/java/com/beust/jcommander/ResourceBundle.java
+++ b/src/main/java/com/beust/jcommander/ResourceBundle.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 /**
  * @deprecated use @Parameters
  * 
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ TYPE })

--- a/src/main/java/com/beust/jcommander/validators/NoValidator.java
+++ b/src/main/java/com/beust/jcommander/validators/NoValidator.java
@@ -24,7 +24,7 @@ import com.beust.jcommander.ParameterException;
 /**
  * This is the default value of the validateWith attribute.
  *
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 public class NoValidator implements IParameterValidator {
 

--- a/src/main/java/com/beust/jcommander/validators/NoValueValidator.java
+++ b/src/main/java/com/beust/jcommander/validators/NoValueValidator.java
@@ -24,7 +24,7 @@ import com.beust.jcommander.ParameterException;
 /**
  * This is the default value of the validateValueWith attribute.
  *
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 public class NoValueValidator<T> implements IValueValidator<T> {
 

--- a/src/main/java/com/beust/jcommander/validators/PositiveInteger.java
+++ b/src/main/java/com/beust/jcommander/validators/PositiveInteger.java
@@ -24,7 +24,7 @@ import com.beust.jcommander.ParameterException;
 /**
  * A validator that makes sure the value of the parameter is a positive integer.
  *
- * @author Cedric Beust <cedric@beust.com>
+ * @author Cedric Beust &lt;cedric@beust.com&gt;
  */
 public class PositiveInteger implements IParameterValidator {
 


### PR DESCRIPTION
Use HTML codes instead of < and >.
Update main docs to point to a recent release in example pom snippet.
