### PR TITLE
Added default converters for Path, URI and URL

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1113,6 +1113,11 @@ public class JCommander {
         out.append("\n" + s(indentCount + 1))
             .append("Default: " + (parameter.password()?"********" : displayedDef));
       }
+      Class<?> type =  pd.getParameterized().getType();
+      if(type.isEnum()){
+          out.append("\n" + s(indentCount + 1))
+          .append("Possible Values: " + EnumSet.allOf((Class<? extends Enum>) type));
+      }
       out.append("\n");
     }
 

--- a/src/main/java/com/beust/jcommander/internal/DefaultConverterFactory.java
+++ b/src/main/java/com/beust/jcommander/internal/DefaultConverterFactory.java
@@ -29,10 +29,16 @@ import com.beust.jcommander.converters.ISO8601DateConverter;
 import com.beust.jcommander.converters.IntegerConverter;
 import com.beust.jcommander.converters.LongConverter;
 import com.beust.jcommander.converters.StringConverter;
+import com.beust.jcommander.converters.PathConverter;
+import com.beust.jcommander.converters.URIConverter;
+import com.beust.jcommander.converters.URLConverter;
 
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.Date;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
 import java.util.Map;
 
 public class DefaultConverterFactory implements IStringConverterFactory {
@@ -57,6 +63,9 @@ public class DefaultConverterFactory implements IStringConverterFactory {
     m_classConverters.put(File.class, FileConverter.class);
     m_classConverters.put(BigDecimal.class, BigDecimalConverter.class);
     m_classConverters.put(Date.class, ISO8601DateConverter.class);
+    m_classConverters.put(Path.class, PathConverter.class);
+    m_classConverters.put(URI.class, URIConverter.class);
+    m_classConverters.put(URL.class, URLConverter.class);
   }
 
   public Class<? extends IStringConverter<?>> getConverter(Class forType) {


### PR DESCRIPTION
As you requested in https://github.com/cbeust/jcommander/pull/189#issuecomment-78516232

I created a new Pull request for adding default converters for Path, URI and URL

EDIT: Sorry, I am new to git and pushed another change to my fork, but wanted to do a new Pull request for that. So now there are two commits in this Pull request (and the one does not belong to the title).
The other commit adds enum constants to the usage output.

Will you just merge both of them or what to do?