### PR TITLE
Allow users to create ParameterException with description and cause

### DIFF
--- a/src/main/java/com/beust/jcommander/ParameterException.java
+++ b/src/main/java/com/beust/jcommander/ParameterException.java
@@ -34,5 +34,9 @@ public class ParameterException extends RuntimeException {
   public ParameterException(String string) {
     super(string);
   }
+  
+  public ParameterException(String string, Throwable t) {
+      super(string, t);
+  }   
 
 }


### PR DESCRIPTION
This is useful in custom validators: it may want to provide both description
and exception caused it. E.g. in case of file operations