### PR TITLE
Fix issue where JCommander could not access private fields/methods

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1309,6 +1309,8 @@ public class JCommander {
       throw new ParameterException(e);
     } catch (InvocationTargetException e) {
       throw new ParameterException(e);
+    } catch (NoSuchMethodException e) {
+      throw new ParameterException(e);
     }
 
     return result;
@@ -1320,8 +1322,11 @@ public class JCommander {
    */
   private Object convertToList(String value, IStringConverter<?> converter,
       Class<? extends IParameterSplitter> splitterClass)
-          throws InstantiationException, IllegalAccessException {
-    IParameterSplitter splitter = splitterClass.newInstance();
+      throws InstantiationException, IllegalAccessException, NoSuchMethodException,
+      InvocationTargetException {
+    Constructor<? extends IParameterSplitter> constructor = splitterClass.getConstructor(new Class[0]);
+    constructor.setAccessible(true);
+    IParameterSplitter splitter = constructor.newInstance();
     List<Object> result = Lists.newArrayList();
     for (String param : splitter.split(value)) {
       result.add(converter.convert(param));
@@ -1331,13 +1336,14 @@ public class JCommander {
 
   private IStringConverter<?> instantiateConverter(String optionName,
       Class<? extends IStringConverter<?>> converterClass)
-      throws IllegalArgumentException, InstantiationException, IllegalAccessException,
+      throws InstantiationException, IllegalAccessException,
       InvocationTargetException {
     Constructor<IStringConverter<?>> ctor = null;
     Constructor<IStringConverter<?>> stringCtor = null;
     Constructor<IStringConverter<?>>[] ctors
         = (Constructor<IStringConverter<?>>[]) converterClass.getDeclaredConstructors();
     for (Constructor<IStringConverter<?>> c : ctors) {
+      c.setAccessible(true);
       Class<?>[] types = c.getParameterTypes();
       if (types.length == 1 && types[0].equals(String.class)) {
         stringCtor = c;

--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -41,6 +41,7 @@ public class Parameterized {
     Class<? extends Object> cls = arg.getClass();
     while (!Object.class.equals(cls)) {
       for (Field f : cls.getDeclaredFields()) {
+        f.setAccessible(true);
         Annotation annotation = f.getAnnotation(Parameter.class);
         Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
         Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
@@ -62,6 +63,7 @@ public class Parameterized {
     cls = arg.getClass();
     while (!Object.class.equals(cls)) {
       for (Method m : cls.getDeclaredMethods()) {
+        m.setAccessible(true);
         Annotation annotation = m.getAnnotation(Parameter.class);
         Annotation delegateAnnotation = m.getAnnotation(ParametersDelegate.class);
         Annotation dynamicParameter = m.getAnnotation(DynamicParameter.class);

--- a/src/test/java/com/beust/jcommander/HiddenConverter.java
+++ b/src/test/java/com/beust/jcommander/HiddenConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.beust.jcommander;
+
+public class HiddenConverter implements IStringConverter<String> {
+  private HiddenConverter() {
+  }
+
+  @Override
+  public String convert(String value) {
+    return value;
+  }
+}

--- a/src/test/java/com/beust/jcommander/HiddenParameterSplitter.java
+++ b/src/test/java/com/beust/jcommander/HiddenParameterSplitter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.beust.jcommander;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.beust.jcommander.converters.IParameterSplitter;
+
+public class HiddenParameterSplitter implements IParameterSplitter {
+  private HiddenParameterSplitter() {
+  }
+
+  @Override
+  public List<String> split(String value) {
+    return Arrays.asList(value.split(";"));
+  }
+}

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -1063,34 +1063,8 @@ public class JCommanderTest {
         bar = value;
       }
     }
-    try {
-      Arguments a = new Arguments();
-      new JCommander(a, new String[] { "-bar", "1" });
-    } catch(ParameterException ex) {
-      Assert.assertTrue(ex.getMessage().contains("invoke"));
-    }
-  }
-
-  @Test(enabled = false)
-  public static void main(String[] args) throws Exception {
-    new JCommanderTest().access();
-//    class A {
-//      @Parameter(names = "-short", required = true)
-//      List<String> parameters;
-//
-//      @Parameter(names = "-long", required = true)
-//      public long l;
-//    }
-//    A a = new A();
-//    new JCommander(a).parse();
-//    System.out.println(a.l);
-//    System.out.println(a.parameters);
-//    ArgsList al = new ArgsList();
-//    JCommander j = new JCommander(al);
-//    j.setColumnSize(40);
-//    j.usage();
-//    new JCommanderTest().testListAndSplitters();
-//    new JCommanderTest().converterArgs();
+    Arguments a = new Arguments();
+    new JCommander(a, new String[] { "-bar", "1" });
   }
 
   // Tests:

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -68,6 +68,7 @@ import com.beust.jcommander.args.ArgsSlaveBogus;
 import com.beust.jcommander.args.ArgsValidate1;
 import com.beust.jcommander.args.ArgsWithSet;
 import com.beust.jcommander.args.Arity1;
+import com.beust.jcommander.args.HiddenArgs;
 import com.beust.jcommander.args.SeparatorColon;
 import com.beust.jcommander.args.SeparatorEqual;
 import com.beust.jcommander.args.SeparatorMixed;
@@ -310,6 +311,30 @@ public class JCommanderTest {
     Assert.assertEquals(args.listBigDecimals.size(), 2);
     Assert.assertEquals(args.listBigDecimals.get(0), new BigDecimal("-11.52"));
     Assert.assertEquals(args.listBigDecimals.get(1), new BigDecimal("100.12"));
+  }
+
+  public void hiddenConverter() {
+    class Args {
+      @Parameter(names = "--path", converter = HiddenConverter.class)
+      public String path;
+    }
+
+    new JCommander(new Args(), "--path", "/tmp/a");
+  }
+
+  public void hiddenArgs() {
+    new JCommander(new HiddenArgs(), "--input", "/tmp/a", "--output", "/tmp/b");
+  }
+
+  public void hiddenSplitter() {
+    class Args {
+      @Parameter(names = "--extensions", splitter = HiddenParameterSplitter.class)
+      public List<String> extensions;
+    }
+
+    Args args = new Args();
+    new JCommander(args, "--extensions", ".txt;.md");
+    Assert.assertEquals(Arrays.asList(".txt", ".md"), args.extensions);
   }
 
   private void argsBoolean1(String[] params, Boolean expected) {

--- a/src/test/java/com/beust/jcommander/args/HiddenArgs.java
+++ b/src/test/java/com/beust/jcommander/args/HiddenArgs.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2010 the original author or authors.
+ * See the notice.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.beust.jcommander.args;
+
+import com.beust.jcommander.Parameter;
+
+public class HiddenArgs {
+  public HiddenArgs() {
+  }
+
+  @Parameter(names = "--input")
+  private String input;
+
+  private String output;
+
+  @Parameter(names = "--output")
+  private void setOutput(String output) {
+    this.output = output;
+  }
+}


### PR DESCRIPTION
This pull request adds calls to `setAccessible(true)` after a method/field/constructor has been retrieved, which permits JCommander to access private fields, and fields in package-private classes. The only implication I can see of this change is that a `SecurityManager` implementation may deny requests to call `setAccessible`; but this is probably not too much of a problem, as such restricted environments most likely won't use reflection at all.

Fixes #232.