### PR TITLE
Fix description line wrapping

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1172,7 +1172,7 @@ public class JCommander {
         current += word.length() + 1;
       } else {
         out.append("\n").append(s(indent + 1)).append(word);
-        current = indent;
+        current = indent + 1 + word.length();
       }
       i++;
     }

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.TreeSet;
 
+import com.beust.jcommander.args.ArgsLongDescription;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -81,6 +82,22 @@ import com.beust.jcommander.internal.Maps;
 
 @Test
 public class JCommanderTest {
+
+  @Test
+  public void testDescriptionWrappingLongWord() {
+    //setup
+    StringBuilder sb = new StringBuilder();
+    final JCommander jc = new JCommander(new ArgsLongDescription());
+
+    //action
+    jc.usage(sb);
+
+    //verify
+    for (String line: sb.toString().split("\n")) {
+      Assert.assertTrue(line.length() <=  jc.getColumnSize(), "line length < column size");
+    }
+  }
+
   public void simpleArgs() throws ParseException {
     Args1 args = new Args1();
     String[] argv = { "-debug", "-log", "2", "-float", "1.2", "-double", "1.3", "-bigdecimal", "1.4",


### PR DESCRIPTION
The first word of the description was not counted towards the line length so
a long first word would result in a very long line written to the terminal.
Added proper line length accounting and a unit test.