### PR TITLE
Updated doc's maven version to 1.48

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -857,7 +857,7 @@ You can download JCommander from the following locations:
 <dependency>
   &lt;groupId&gt;com.beust&lt;/groupId&gt;
   &lt;artifactId&gt;jcommander&lt;/artifactId&gt;
-  &lt;version&gt;1.30&lt;/version&gt;
+  &lt;version&gt;1.48&lt;/version&gt;
 </dependency>
   </pre>
 


### PR DESCRIPTION
The documentation's example Maven `<dependency>` declaration says to use version 1.30, but according to GitHub's "Releases" tab, it looks like v1.48 has been released.