### PR TITLE
Fixing: squid:ModifiersOrderCheck and squid:S2444

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -210,7 +210,7 @@ public class JCommander {
     parse(args);
   }
   
-  public static Console getConsole() {
+  public static synchronized Console getConsole() {
     if (m_console == null) {
       try {
         Method consoleMethod = System.class.getDeclaredMethod("console", new Class<?>[0]);

--- a/src/main/java/com/beust/jcommander/converters/BaseConverter.java
+++ b/src/main/java/com/beust/jcommander/converters/BaseConverter.java
@@ -25,7 +25,7 @@ import com.beust.jcommander.IStringConverter;
  * 
  * @author cbeust
  */
-abstract public class BaseConverter<T> implements IStringConverter<T> {
+public abstract class BaseConverter<T> implements IStringConverter<T> {
 
   private String m_optionName;
 

--- a/src/main/java/com/beust/jcommander/converters/ISO8601DateConverter.java
+++ b/src/main/java/com/beust/jcommander/converters/ISO8601DateConverter.java
@@ -32,7 +32,7 @@ import java.util.Date;
  */
 public class ISO8601DateConverter extends BaseConverter<Date> {
 
-  private final static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+  private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
   public ISO8601DateConverter(String optionName) {
     super(optionName);

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -972,7 +972,7 @@ public class JCommanderTest {
   }
 
   static class V2 implements IParameterValidator2 {
-    final static List<String> names =  Lists.newArrayList();
+    static final List<String> names =  Lists.newArrayList();
     static boolean validateCalled = false;
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:ModifiersOrderCheck (Modifiers should be declared in the correct order) and squid:S2444 (Lazy initialization of "static" fields should be "synchronized")

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:ModifiersOrderCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2444

Please let me know if you have any questions.

Kirill Vlasov
