### PR TITLE
Usage no longer has a trailing space at the end of the line.

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1192,8 +1192,12 @@ public class JCommander {
     while (i < words.length) {
       String word = words[i];
       if (word.length() > max || current + 1 + word.length() <= max) {
-        out.append(word).append(" ");
-        current += word.length() + 1;
+        out.append(word);
+        current += word.length();
+        if(i != words.length -1) {
+          out.append(" ");
+          current++;
+        }
       } else {
         out.append("\n").append(s(indent)).append(word).append(" ");
         current = indent + 1 + word.length();

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -1086,7 +1086,7 @@ public class JCommanderTest {
     
     StringBuilder sb = new StringBuilder();
     c.usage(sb);
-    Assert.assertTrue(sb.toString().contains("[command options] \n  Commands:"));
+    Assert.assertTrue(sb.toString().contains("[command options]\n  Commands:"));
   }
 
   public void usageWithEmpytLine() {
@@ -1111,7 +1111,7 @@ public class JCommanderTest {
     
     StringBuilder sb = new StringBuilder();
     c.usage(sb);
-    Assert.assertTrue(sb.toString().contains("command a parameters \n\n    b"));
+    Assert.assertTrue(sb.toString().contains("command a parameters\n\n    b"));
   }
 
   public void partialValidation() {

--- a/src/test/java/com/beust/jcommander/command/CommandTest.java
+++ b/src/test/java/com/beust/jcommander/command/CommandTest.java
@@ -123,6 +123,21 @@ public class CommandTest {
     Assert.assertTrue(out.toString().contains("no-annotation"));
   }
 
+  @Test
+  public void noTrailingSpaceInUsageTest() {
+    CommandMain cm = new CommandMain();
+    JCommander jc = new JCommander(cm);
+    CommandAdd add = new CommandAdd();
+    jc.addCommand("add", add);
+    CommandCommit commit = new CommandCommit();
+    jc.addCommand("commit", commit);
+    jc.parse("-v", "commit", "--amend", "--author=cbeust", "A.java", "B.java");
+    StringBuilder out = new StringBuilder();
+    jc.usage(out);
+    String firstLine = out.toString().split("\n")[0];
+    Assert.assertFalse(firstLine.endsWith(" "), "Usage should not have trailing spaces");
+  }
+
   public static void main(String[] args) {
     new CommandTest().shouldComplainIfNoAnnotations();
   }


### PR DESCRIPTION
The CLI usage printout no longer has a trailing space at the end of the line.