### PR TITLE
Allow user to retrieve unknown command

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -778,7 +778,7 @@ public class JCommander {
             // Command parsing
             //
             if (jc == null && validate) {
-                throw new MissingCommandException(arg, "Expected a command, got " + arg);
+                throw new MissingCommandException("Expected a command, got " + arg, arg);
             } else if (jc != null){
                 m_parsedCommand = jc.m_programName.m_name;
                 m_parsedAlias = arg; //preserve the original form

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -778,7 +778,7 @@ public class JCommander {
             // Command parsing
             //
             if (jc == null && validate) {
-                throw new MissingCommandException("Expected a command, got " + arg);
+                throw new MissingCommandException(arg, "Expected a command, got " + arg);
             } else if (jc != null){
                 m_parsedCommand = jc.m_programName.m_name;
                 m_parsedAlias = arg; //preserve the original form

--- a/src/main/java/com/beust/jcommander/MissingCommandException.java
+++ b/src/main/java/com/beust/jcommander/MissingCommandException.java
@@ -26,11 +26,20 @@ package com.beust.jcommander;
 @SuppressWarnings("serial")
 public class MissingCommandException extends ParameterException {
 
-  public MissingCommandException(String string) {
-    super(string);
+  private final String unknownCommand;
+
+  public MissingCommandException(String message) {
+    super(message);
+    this.unknownCommand = null;
   }
 
-  public MissingCommandException(Throwable t) {
-    super(t);
+  public MissingCommandException(String command, String message) {
+    super(message);
+    this.unknownCommand = command;
   }
+
+  public String getUnknownCommand() {
+    return unknownCommand;
+  }
+
 }

--- a/src/main/java/com/beust/jcommander/MissingCommandException.java
+++ b/src/main/java/com/beust/jcommander/MissingCommandException.java
@@ -32,8 +32,7 @@ public class MissingCommandException extends ParameterException {
   private final String unknownCommand;
 
   public MissingCommandException(String message) {
-    super(message);
-    this.unknownCommand = null;
+    this(message, null);
   }
 
   public MissingCommandException(String message, String command) {

--- a/src/main/java/com/beust/jcommander/MissingCommandException.java
+++ b/src/main/java/com/beust/jcommander/MissingCommandException.java
@@ -36,7 +36,7 @@ public class MissingCommandException extends ParameterException {
     this.unknownCommand = null;
   }
 
-  public MissingCommandException(String command, String message) {
+  public MissingCommandException(String message, String command) {
     super(message);
     this.unknownCommand = command;
   }

--- a/src/test/java/com/beust/jcommander/CmdTest.java
+++ b/src/test/java/com/beust/jcommander/CmdTest.java
@@ -70,7 +70,12 @@ public class CmdTest {
     public void testArgsWithoutDefaultCmdFail(String expected,
             boolean requireDefault, String[] args) {
         if (requireDefault) {
-            parseArgs(false, args);
+            try {
+                parseArgs(false, args);
+            } catch (MissingCommandException e) {
+                Assert.assertEquals(e.getUnknownCommand(), args[0]);
+                throw e;
+            }
         } else {
             throw new MissingCommandException("irrelevant test case");
         }


### PR DESCRIPTION
When an unknown command is parsed, the MissingCommandException is
raised. However, there is no way for the library user to access the
erroneous command (except parsing either the arguments or the error
message).
Such access is helpfull, for instance to provide a better error message,
hinting to close commands as git does (try "git pulll").