### PR TITLE
Share options with subcommands

### DIFF
--- a/src/test/java/com/beust/jcommander/CmdTest.java
+++ b/src/test/java/com/beust/jcommander/CmdTest.java
@@ -88,4 +88,20 @@ public class CmdTest {
         Assert.assertEquals(parseArgs(true, args), expected);
     }
 
+    @Test
+    public void testIssue244() throws Exception {
+        class P1 {}
+        class P2 {
+            @Parameter(names = "--hello")
+            private int test;
+        }
+        P1 p1 = new P1();
+        P2 p2 = new P2();
+        JCommander j = new JCommander(p1);
+        j.addCommand("wonderful", p2);
+        j.setAllowAbbreviatedOptions(true);
+        j.parse("wond", "--he", "47");
+        Assert.assertEquals("wonderful", j.getParsedCommand());
+        Assert.assertEquals(47, p2.test);
+    }
 }

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -352,7 +352,7 @@ public class JCommanderTest {
     Object args = new Object() {
       @Parameter(names = "-foo") final int _foo = 0;
     };
-    new JCommander(args);
+    new JCommander(args).usage();
   }
 
   public void converterArgs() {
@@ -623,7 +623,7 @@ public class JCommanderTest {
   @Test(expectedExceptions = ParameterException.class)
   public void validationShouldWorkWithDefaultValues() {
     ArgsValidate2 a = new ArgsValidate2();
-    new JCommander(a);
+    new JCommander(a).usage();
   }
 
   @Test(expectedExceptions = ParameterException.class)


### PR DESCRIPTION
This fixes #244, #261. However, since `JCommander#getCommands` exposes subcommand `JCommander` objects, allowing to set custom settings on subcommands, this might break some very specific use-cases.