### PR TITLE
Fix param name error in validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### Current
+2016-12-16
+* Fixed: When providing two names in `@Parameter` always first name is given to `IValueValidator`, #309 (@jeremysolarz) 
 
 ### 1.58
 2016-09-29

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -813,7 +813,8 @@ public class JCommander {
 
       if (index + arity < args.length) {
         for (int j = 1; j <= arity; j++) {
-          pd.addValue(trim(args[index + j + offset]), false, validate);
+          String value = trim(args[index + j + offset]);
+          pd.addValue(arg, value, false, validate);
           m_requiredFields.remove(pd.getParameterized());
         }
         index += arity + offset;

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -223,13 +223,15 @@ public class ParameterDescription {
    * converter, and if we can't find any, throw an exception.
    */
   public void addValue(String value, boolean isDefault) {
-    addValue(value, isDefault, true);
+    addValue(null, value, isDefault, true);
   }
 
-  void addValue(String value, boolean isDefault, boolean validate) {
+  void addValue(String name, String value, boolean isDefault, boolean validate) {
     p("Adding " + (isDefault ? "default " : "") + "value:" + value
         + " to parameter:" + m_parameterized.getName());
-    String name = m_wrappedParameter.names()[0];
+    if(name == null) {
+      name = m_wrappedParameter.names()[0];
+    }
     if (m_assigned && ! isMultiOption() && !m_jCommander.isParameterOverwritingAllowed() || isNonOverwritableForced()) {
       throw new ParameterException("Can only specify option " + name + " once.");
     }

--- a/src/test/java/com/beust/jcommander/ArgMultiNameValidator.java
+++ b/src/test/java/com/beust/jcommander/ArgMultiNameValidator.java
@@ -1,0 +1,19 @@
+package com.beust.jcommander;
+
+/**
+ * Created by jeremysolarz on 12/15/16.
+ */
+public class ArgMultiNameValidator {
+
+    public static class MultiNameValidator implements IValueValidator<String> {
+
+        public static String parsedName;
+
+        public void validate(String name, String value) throws ParameterException {
+            parsedName = name;
+        }
+    }
+
+    @Parameter(names = { "-name1", "-name2" }, description = "Names of parameter", validateValueWith = MultiNameValidator.class, required = true)
+    private String parameter;
+}

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -635,6 +635,15 @@ public class JCommanderTest {
     jc.parse("-age", "-2 ");
   }
 
+  @Test
+  public void validationShouldReceiveRightParameterName() {
+    ArgMultiNameValidator validator = new ArgMultiNameValidator();
+    JCommander jc = new JCommander(validator);
+    String paramName = "-name2";
+    jc.parse(paramName, "param1");
+    Assert.assertEquals(ArgMultiNameValidator.MultiNameValidator.parsedName, paramName);
+  }
+
   public void atFileCanContainEmptyLines() throws IOException {
     File f = File.createTempFile("JCommander", null);
     f.deleteOnExit();


### PR DESCRIPTION
When IValueValidator is called it always get's the first name as
defined in @Parameter. JCommander should call the validator with
the parameter given on the command line. See #242 