### PR TITLE
Do not display help default value #305

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Changelog
 
 ### Current
+
+2016-12-27
+* Fixed: Default value for `@Parameter(help=true)` parameter is not displayed in output of `JCommander.usage()`, #305 (@jeremysolarz) 
+
 2016-12-16
 * Fixed: When providing two names in `@Parameter` always first name is given to `IValueValidator`, #309 (@jeremysolarz) 
 

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1041,7 +1041,7 @@ public class JCommander {
                 + "key" + parameter.getAssignment()
                 + "value");
       }
-      if (def != null) {
+      if (def != null && !pd.isHelp()) {
         String displayedDef = Strings.isStringEmpty(def.toString())
             ? "<empty string>"
             : def.toString();

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -994,6 +994,23 @@ public class JCommanderTest {
     jc.parse("-help");
   }
 
+  @Test
+  public void doNotDisplayHelpDefaultValue(){
+    class Arg {
+      @Parameter(names = "--help", help = true)
+      public boolean help = false;
+    }
+    Arg arg = new Arg();
+    String[] argv = { "--help" };
+    JCommander jc = new JCommander(arg, argv);
+
+    StringBuilder sb = new StringBuilder();
+
+    jc.usage(sb);
+
+    Assert.assertFalse(sb.toString().contains("Default"));
+  }
+
   @Test(enabled = false, description = "Should only be enable once multiple parameters are allowed")
   public void duplicateParameterNames() {
     class ArgBase {


### PR DESCRIPTION
When `@Parameter(help=true)` is set the default value is printed when `new JCommand().usage()` is called. 

After a discussion in #305 it was decided that default values shouldn't be displayed here.

The default value isn't displayed for `@Parameter` marked with `help=true`.