### PR TITLE
Use commandDescription if no commandDescriptionKey

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -944,7 +944,10 @@ public class JCommander {
             }
 
             if (bundle != null) {
-                result = getI18nString(bundle, p.commandDescriptionKey(), p.commandDescription());
+                String descriptionKey = p.commandDescriptionKey();
+                if (!"".equals(descriptionKey)) {
+                    result = getI18nString(bundle, descriptionKey, p.commandDescription());
+                }
             }
         }
 

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -269,6 +269,17 @@ public class JCommanderTest {
     i18n2(new ArgsI18N2New());
   }
 
+  public void i18MissingKeyForCommand() {
+    ResourceBundle bundle = ResourceBundle.getBundle("MessageBundle", new Locale("en", "US"));
+    JCommander jc = new JCommander(new ArgsHelp(), bundle);
+    jc.addCommand(new ArgsLongCommandDescription());
+    StringBuilder sb = new StringBuilder();
+    jc.usage(sb);
+    jc.usage();
+    String usage = sb.toString();
+    Assert.assertTrue(usage.contains("text"));
+  }
+
   public void noParseConstructor() {
     JCommander jCommander = new JCommander(new ArgsMainParameter1());
     jCommander.usage(new StringBuilder());


### PR DESCRIPTION
When obtaining the description of a command, if a resourcebundle is
configured, but commandDescriptionKey is missing, use the provided
commandDescription instead of failing with MissingResourceException.

It should be easy to add a test for this similar to the one using ArgI18N, but with a missing descriptionKey. I' m looking at this, but having a hard time replaying without failures all tests under windows. Apparently, java compiles sources as if they were latin1 encoded instead of UTF-8