### PR TITLE
Make getParameters() work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Current
 
+2017-01-13
+* Fixed: `JCommander#getParameters` returning nothing, #315, (@simon04)
+
 2016-12-27
 * Fixed: Allow empty string (e.g. `java -jar jcommander-program.jar param1 ""`) as part of main parameter, #306 (@jeremysolarz)
 * Fixed: Default value for `@Parameter(help=true)` parameter is not displayed in output of `JCommander.usage()`, #305 (@jeremysolarz) 

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -197,8 +197,7 @@ public class JCommander {
      * @param object The arg object expected to contain {@link Parameter} annotations.
      */
     public JCommander(Object object) {
-        this();
-        addObject(object);
+        this(object, (ResourceBundle) null);
     }
 
     /**
@@ -206,8 +205,7 @@ public class JCommander {
      * @param bundle The bundle to use for the descriptions. Can be null.
      */
     public JCommander(Object object, @Nullable ResourceBundle bundle) {
-        this(object);
-        setDescriptionsBundle(bundle);
+        this(object, bundle, (String[]) null);
     }
 
     /**
@@ -215,9 +213,16 @@ public class JCommander {
      * @param bundle The bundle to use for the descriptions. Can be null.
      * @param args The arguments to parse (optional).
      */
-    public JCommander(Object object, ResourceBundle bundle, String... args) {
-        this(object, bundle);
-        parse(args);
+    public JCommander(Object object, @Nullable  ResourceBundle bundle, String... args) {
+        this();
+        addObject(object);
+        if (bundle != null) {
+            setDescriptionsBundle(bundle);
+        }
+        createDescriptions();
+        if (args != null) {
+            parse(args);
+        }
     }
 
     /**

--- a/src/test/java/com/beust/jcommander/ParametersNotEmptyTest.java
+++ b/src/test/java/com/beust/jcommander/ParametersNotEmptyTest.java
@@ -1,0 +1,30 @@
+package com.beust.jcommander;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Test
+public class ParametersNotEmptyTest {
+
+    public class Args1 {
+        @Parameter(names = "-debug", description = "Debug mode")
+        public boolean debug = false;
+
+        @Parameter(names = "-date", description = "An ISO 8601 formatted date.")
+        public Date date;
+    }
+
+    @Test
+    public void testParameters() throws Exception {
+        final JCommander jc = new JCommander(new Args1());
+        final String parameterNames = jc.getParameters().stream()
+                .map(ParameterDescription::getNames)
+                .sorted()
+                .collect(Collectors.joining(", "));
+        Assert.assertEquals(parameterNames,"-date, -debug",
+                "getParameters returns the @Parameters");
+    }
+}


### PR DESCRIPTION
Regression from c4532fde79808d231e7b8c6fe330655c7d91638f.
`createDescriptions` needs to be called.