### PR TITLE
Return right parameter name in exception #227

### DIFF
--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -195,11 +195,19 @@ public class ArgsPassword {
 }
 ----
 
-== Custom types
+== Custom types (converters and splitters)
 
-=== By annotation
+To bind parameters to custom types or change the way how JCommander splits parameters (default is to split via comma) JCommander provides two
+interfaces `IStringConverter` and `IParameterSplitter`.
 
-By default, JCommander parses the command line into basic types only (strings, booleans, integers and longs). Very often, your application actually needs more complex types, such as files, host names, lists, etc... To achieve this, you can write a type converter by implementing the following interface:
+[[single-value]]
+=== Single value
+
+Use either the `converter=` attribute of the `@Parameter` or implement `IStringConverterFactory`.
+
+==== By annotation
+
+By default, JCommander parses the command line into basic types only (strings, booleans, integers and longs). Very often, your application actually needs more complex types (such as files, host names, lists, etc.). To achieve this, you can write a type converter by implementing the following interface:
 
 [source,java]
 ----
@@ -228,9 +236,32 @@ Then, all you need to do is declare your field with the correct type and specify
 File file;
 ----
 
-JCommander ships with a few common converters (e.g. one that turns a comma separated list into a List<String>).
+JCommander ships with a few common converters (for more info please see the implementations of `IStringConverter`).
 
-=== By factory
+===== Note
+
+If a converter is used for a List field, JCommander tries to use this converter on the value provided.
+
+For example, suppose you provide a string representing a list of files:
+
+[source,bash]
+----
+$ java App -files file1,file2,file3
+----
+
+And you declared your field as List and specified the converter as an attribute:
+
+[source,java]
+----
+@Parameter(names = "-files", converter = FileConverter.class)
+List<File> files;
+----
+
+JCommander will split the string `file1,file2,file3` into `file1`, `file2`, `file3` and feed it one by one to the converter.
+
+For an alternative solution to parse a list of values see <<list-value>>.
+
+==== By factory
 
 If the custom types you use appear multiple times in your application, having to specify the converter in each annotation can become tedious. To address this, you can use an `IStringConverterFactory`:
 
@@ -311,6 +342,91 @@ Assert.assertEquals(a.hostPort.port.intValue(), 8080);
 ----
 
 Another advantage of using string converter factories is that your factories can come from a dependency injection framework.
+
+[[list-value]]
+=== List value
+
+Use the `listConverter=` attribute of the `@Parameter` annotation and assign a custom `IStringConverter` implementation to convert a `String` into a `List` of values
+
+==== By annotation
+
+If your application needs a list of complex types write a list type converter by implementing the same interface as before:
+
+[source,java]
+----
+public interface IStringConverter<T> {
+  T convert(String value);
+}
+----
+where `T` is a `List`.
+
+
+For example, here is a list converter that turns a string into a `List<File>`:
+
+[source,java]
+----
+public class FileListConverter implements IStringConverter<List<File>> {
+  @Override
+  public File convert(String files) {
+    String [] paths = files.split(",");
+    List<File> files = new ArrayList<>();
+    for(String path : paths){
+        files.add(new File(path));
+    }
+    return files;
+  }
+}
+----
+
+Then, all you need to do is declare your field with the correct type and specify the list converter as an attribute:
+
+[source,java]
+----
+@Parameter(names = "-files", listConverter = FileListConverter.class)
+List<File> file;
+----
+
+JCommander ships with a default converter for `String` values.
+
+
+=== Splitting
+
+Use the `splitter=` attribute of the `@Parameter` annotation and assign a custom `IParameterSplitter` implementation to handle how parameters are split in sub-parts
+
+==== By annotation
+
+As already mentioned in <<single-value>>, by default, JCommander tries to split parameters for List field types on comma.
+
+To split parameters on other characters, you can write a custom splitter by implementing the following interface:
+
+[source,java]
+----
+public interface IParameterSplitter {
+  List<String> split(String value);
+}
+----
+
+For example, here is a splitter that splits a string on semicolon:
+
+[source,java]
+----
+public static class SemiColonSplitter implements IParameterSplitter {
+    public List<String> split(String value) {
+      return Arrays.asList(value.split(";"));
+    }
+}
+----
+
+Then, all you need to do is declare your field with the correct type and specify the splitter as an attribute:
+
+[source,java]
+----
+@Parameter(names = "-files", converter = FileConverter.class, splitter = SemiColonSplitter.class)
+List<File> files;
+----
+
+JCommander will split the string `file1;file2;file3` into `file1`, `file2`, `file3` and feed it one by one to the converter.
+
 
 == Parameter validation
 

--- a/src/main/java/com/beust/jcommander/IStringConverterInstanceFactory.java
+++ b/src/main/java/com/beust/jcommander/IStringConverterInstanceFactory.java
@@ -13,7 +13,8 @@ public interface IStringConverterInstanceFactory {
      * Obtain a converter instance for parsing {@code parameter} as type {@code forType}
      * @param parameter the parameter to parse
      * @param forType the type class
+     * @param optionName the name of the option used on the command line
      * @return a converter instance
      */
-    IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType);
+    IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType, String optionName);
 }

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -242,7 +242,7 @@ public class ParameterDescription {
 
     Class<?> type = m_parameterized.getType();
 
-    Object convertedValue = m_jCommander.convertValue(getParameterized(), getParameterized().getType(), value);
+    Object convertedValue = m_jCommander.convertValue(getParameterized(), getParameterized().getType(), name, value);
     if (validate) {
       validateValueParameter(name, convertedValue);
     }

--- a/src/test/java/com/beust/jcommander/ConverterFactoryTest.java
+++ b/src/test/java/com/beust/jcommander/ConverterFactoryTest.java
@@ -92,7 +92,7 @@ public class ConverterFactoryTest {
   public void mainWithInstanceFactory() {
     mainWithHostPortParameters(null, new IStringConverterInstanceFactory() {
       @Override
-      public IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType) {
+      public IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType, String optionName) {
         return HostPort.class.equals(forType) ? new HostPortConverter() : null;
       }
     }, new ArgsMainParameter1());

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -961,6 +961,15 @@ public class JCommanderTest {
     new JCommander(new A()).parse("");
   }
 
+  @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "\"--b\": couldn't convert \"ThisIsATest\" to an integer")
+  public void multipleParameterNames() {
+    class MultipleParameterNames {
+      @Parameter(names = {"-b", "--b"})
+      public Integer b;
+    }
+    new JCommander(new MultipleParameterNames()).parse("--b", "ThisIsATest");
+  }
+
   public void unknownOptionWithDifferentPrefix() {
     @Parameters(optionPrefixes = "/")
     class SlashSeparator {

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -767,21 +767,49 @@ public class JCommanderTest {
     new JCommander(args, argv);
   }
 
-  public void testListAndSplitters() {
+  @Test
+  public void testDefaultListConverterForString() {
     ArgsList al = new ArgsList();
     JCommander j = new JCommander(al);
-    j.parse("-groups", "a,b", "-ints", "41,42", "-hp", "localhost:1000;example.com:1001",
-        "-hp2", "localhost:1000,example.com:1001", "-uppercase", "ab,cd");
+    j.parse("-groups", "a,b");
     Assert.assertEquals(al.groups.get(0), "a");
     Assert.assertEquals(al.groups.get(1), "b");
+  }
+
+  @Test
+  public void testDefaultListConverterForStandardType() {
+    ArgsList al = new ArgsList();
+    JCommander j = new JCommander(al);
+    j.parse("-ints", "41,42");
     Assert.assertEquals(al.ints.get(0).intValue(), 41);
     Assert.assertEquals(al.ints.get(1).intValue(), 42);
+  }
+
+  @Test
+  public void testDefaultListConverterWithCustomConverterAndSplitter() {
+    ArgsList al = new ArgsList();
+    JCommander j = new JCommander(al);
+    j.parse("-hp", "localhost:1000;example.com:1001");
     Assert.assertEquals(al.hostPorts.get(0).host, "localhost");
     Assert.assertEquals(al.hostPorts.get(0).port.intValue(), 1000);
     Assert.assertEquals(al.hostPorts.get(1).host, "example.com");
     Assert.assertEquals(al.hostPorts.get(1).port.intValue(), 1001);
+  }
+
+  @Test
+  public void testDefaultListConverterWithCustomConverterAndDefaultSplitter() {
+    ArgsList al = new ArgsList();
+    JCommander j = new JCommander(al);
+    j.parse("-hp2", "localhost:1000,example.com:1001");
     Assert.assertEquals(al.hp2.get(1).host, "example.com");
     Assert.assertEquals(al.hp2.get(1).port.intValue(), 1001);
+  }
+
+  @Test
+  public void testCustomListConverter() {
+    ArgsList al = new ArgsList();
+    JCommander j = new JCommander(al);
+    j.parse("-uppercase", "ab,cd");
     Assert.assertEquals(al.uppercase.get(0), "AB");
     Assert.assertEquals(al.uppercase.get(1), "CD");
   }


### PR DESCRIPTION
As shown in issue #227 when an exception is thrown during parameter parsing the wrong parameter name is included.

The PR fixes this. 