### PR TITLE
Return right parameter name in exception #227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Current
 
+2017-01-14
+* Fixed: Return right parameter name in exception, #227, (@jeremysolarz)
+
 2017-01-13
 * Fixed: `JCommander#getParameters` returning nothing, #315, (@simon04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
 ## Changelog
 
 ### Current
-
 2017-01-14
+
 * Fixed: Return right parameter name in exception, #227, (@jeremysolarz)
-
-2017-01-13
 * Fixed: `JCommander#getParameters` returning nothing, #315, (@simon04)
-
-2016-12-27
 * Fixed: Allow empty string (e.g. `java -jar jcommander-program.jar param1 ""`) as part of main parameter, #306 (@jeremysolarz)
 * Fixed: Default value for `@Parameter(help=true)` parameter is not displayed in output of `JCommander.usage()`, #305 (@jeremysolarz) 
 

--- a/src/main/java/com/beust/jcommander/IStringConverterInstanceFactory.java
+++ b/src/main/java/com/beust/jcommander/IStringConverterInstanceFactory.java
@@ -13,7 +13,8 @@ public interface IStringConverterInstanceFactory {
      * Obtain a converter instance for parsing {@code parameter} as type {@code forType}
      * @param parameter the parameter to parse
      * @param forType the type class
+     * @param optionName the name of the option used on the command line
      * @return a converter instance
      */
-    IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType);
+    IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType, String optionName);
 }

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -242,7 +242,7 @@ public class ParameterDescription {
 
     Class<?> type = m_parameterized.getType();
 
-    Object convertedValue = m_jCommander.convertValue(getParameterized(), getParameterized().getType(), value);
+    Object convertedValue = m_jCommander.convertValue(getParameterized(), getParameterized().getType(), name, value);
     if (validate) {
       validateValueParameter(name, convertedValue);
     }

--- a/src/test/java/com/beust/jcommander/ConverterFactoryTest.java
+++ b/src/test/java/com/beust/jcommander/ConverterFactoryTest.java
@@ -92,7 +92,7 @@ public class ConverterFactoryTest {
   public void mainWithInstanceFactory() {
     mainWithHostPortParameters(null, new IStringConverterInstanceFactory() {
       @Override
-      public IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType) {
+      public IStringConverter<?> getConverterInstance(Parameter parameter, Class<?> forType, String optionName) {
         return HostPort.class.equals(forType) ? new HostPortConverter() : null;
       }
     }, new ArgsMainParameter1());

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -933,6 +933,15 @@ public class JCommanderTest {
     new JCommander(new A()).parse("");
   }
 
+  @Test(expectedExceptions = ParameterException.class, expectedExceptionsMessageRegExp = "\"--b\": couldn't convert \"ThisIsATest\" to an integer")
+  public void multipleParameterNames() {
+    class MultipleParameterNames {
+      @Parameter(names = {"-b", "--b"})
+      public Integer b;
+    }
+    new JCommander(new MultipleParameterNames()).parse("--b", "ThisIsATest");
+  }
+
   public void unknownOptionWithDifferentPrefix() {
     @Parameters(optionPrefixes = "/")
     class SlashSeparator {


### PR DESCRIPTION
As shown in issue #227 when an exception is thrown during parameter parsing the wrong parameter name is included.

The PR fixes this.