### PR TITLE
Issue 247 getter for program name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Changelog
 
 ### Current
-2017-01-14
+2017-03-04
 
+* Added: Add `getProgramName` to `JCommander`, #247
 * Added: Documentation for `listConverter` and `splitter`, #253, (@jeremysolarz)
 * Fixed: Return right parameter name in exception, #227, (@jeremysolarz)
 * Fixed: `JCommander#getParameters` returning nothing, #315, (@simon04)

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -888,6 +888,13 @@ public class JCommander {
     }
 
     /**
+     * Get the program name (used only in the usage).
+     */
+    public String getProgramName(){
+        return programName == null ? null : programName.getName();
+    }
+
+    /**
      * Set the program name
      *
      * @param name    program name
@@ -993,7 +1000,7 @@ public class JCommander {
          * Adds the provided arg object to the set of objects that this commander
          * will parse arguments into.
          *
-         * @param object The arg object expected to contain {@link Parameter}
+         * @param o The arg object expected to contain {@link Parameter}
          * annotations. If <code>object</code> is an array or is {@link Iterable},
          * the child objects will be added instead.
          */
@@ -1050,7 +1057,7 @@ public class JCommander {
 
         /**
          * Adds a factory to lookup string converters. The added factory is used prior to previously added factories.
-         * @param converterFactory the factory determining string converters
+         * @param factory the factory determining string converters
          */
         public Builder addConverterFactory(IStringConverterFactory factory) {
             jCommander.addConverterFactory(factory);

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -1415,6 +1415,17 @@ public class JCommanderTest {
         Assert.assertEquals(args.mvParameters.to, "to");
     }
 
+  public void programName() {
+    JCommander jcommander = new JCommander();
+    String programName = "main";
+    jcommander.setProgramName(programName);
+    StringBuilder sb = new StringBuilder();
+    jcommander.usage(sb);
+
+    Assert.assertTrue(sb.toString().contains(programName));
+    Assert.assertEquals(jcommander.getProgramName(), programName);
+  }
+
     public void dontShowOptionUsageIfThereAreNoOptions() {
         class CommandTemplate {
             @Parameter


### PR DESCRIPTION
As requested in issue #247 there is no method in `JCommander` that allows to get the program name.

The PR fixes this.