### PR TITLE
Allow an array of Classes in `validateWith` and `validateValueWith` 

### DIFF
--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -483,6 +483,15 @@ private Integer age;
 
 Attempting to pass a negative integer to this option will cause a ParameterException to be thrown.
 
+Multiple validators may be specified:
+
+[source,java]
+----
+@Parameter(names = "-count", validateWith = { PositiveInteger.class, CustomOddNumberValidator.class })
+private Integer value;
+----
+
+
 === Global parameter validation
 
 After parsing your parameters with JCommander, you might want to perform additional validation across these parameters, such as making sure that two mutually exclusive parameters are not both specified. Because of all the potential combinations involved in such validation, JCommander does not provide any annotation-based solution to perform this validation because such an approach would necessarily be very limited by the very nature of Java annotations. Instead, you should simply perform this validation in Java on all the arguments that JCommander just parsed.

--- a/src/main/java/com/beust/jcommander/DynamicParameter.java
+++ b/src/main/java/com/beust/jcommander/DynamicParameter.java
@@ -37,14 +37,14 @@ public @interface DynamicParameter {
   boolean hidden() default false;
 
   /**
-   * The validation class to use.
+   * The validation classes to use.
    */
-  Class<? extends IParameterValidator> validateWith() default NoValidator.class;
+  Class<? extends IParameterValidator>[] validateWith() default NoValidator.class;
 
   /**
    * The character(s) used to assign the values.
    */
   String assignment() default "=";
 
-  Class<? extends IValueValidator> validateValueWith() default NoValueValidator.class;
+  Class<? extends IValueValidator>[] validateValueWith() default NoValueValidator.class;
 }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -727,10 +727,12 @@ public class JCommander {
                             convertedValue = convertValue(mainParameter, (Class) cls, null, value);
                         }
                     }
-
-                    ParameterDescription.validateParameter(mainParameterDescription,
-                            mainParameterAnnotation.validateWith(),
+                    
+                    for(final Class<? extends IParameterValidator> validator : mainParameterAnnotation.validateWith() ) {
+                        ParameterDescription.validateParameter(mainParameterDescription,
+                        	validator,
                             "Default", value);
+                    }
 
                     mainParameterDescription.setAssigned(true);
                     mp.add(convertedValue);

--- a/src/main/java/com/beust/jcommander/Parameter.java
+++ b/src/main/java/com/beust/jcommander/Parameter.java
@@ -90,12 +90,12 @@ public @interface Parameter {
   /**
    * Validate the parameter found on the command line.
    */
-  Class<? extends IParameterValidator> validateWith() default NoValidator.class;
+  Class<? extends IParameterValidator>[] validateWith() default NoValidator.class;
 
   /**
    * Validate the value for this parameter.
    */
-  Class<? extends IValueValidator> validateValueWith() default NoValueValidator.class;
+  Class<? extends IValueValidator>[] validateValueWith() default NoValueValidator.class;
 
   /**
    * @return true if this parameter has a variable arity. See @{IVariableArity}

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -327,16 +327,20 @@ public class ParameterDescription {
   }
 
   private void validateParameter(String name, String value) {
-    Class<? extends IParameterValidator> validator = wrappedParameter.validateWith();
-    if (validator != null) {
-      validateParameter(this, validator, name, value);
+    Class<? extends IParameterValidator> validators[] = wrappedParameter.validateWith();
+    if (validators != null && validators.length>0) {
+        for(final Class<? extends IParameterValidator> validator: validators) {
+           validateParameter(this, validator, name, value);
+        }
     }
   }
 
   void validateValueParameter(String name, Object value) {
-    Class<? extends IValueValidator> validator = wrappedParameter.validateValueWith();
-    if (validator != null) {
-      validateValueParameter(validator, name, value);
+    Class<? extends IValueValidator> validators[] = wrappedParameter.validateValueWith();
+    if (validators != null && validators.length>0) {
+      for(final Class<? extends IValueValidator> validator: validators) {
+        validateValueParameter(validator, name, value);
+      }
     }
   }
 
@@ -356,6 +360,7 @@ public class ParameterDescription {
       Class<? extends IParameterValidator> validator,
       String name, String value) {
     try {
+    	
       if (validator != NoValidator.class) {
         p("Validating parameter:" + name + " value:" + value + " validator:" + validator);
       }

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -327,17 +327,17 @@ public class ParameterDescription {
   }
 
   private void validateParameter(String name, String value) {
-    Class<? extends IParameterValidator> validators[] = wrappedParameter.validateWith();
-    if (validators != null && validators.length>0) {
+    final Class<? extends IParameterValidator> validators[] = wrappedParameter.validateWith();
+    if (validators != null && validators.length > 0) {
         for(final Class<? extends IParameterValidator> validator: validators) {
-           validateParameter(this, validator, name, value);
+          validateParameter(this, validator, name, value);
         }
     }
   }
 
   void validateValueParameter(String name, Object value) {
-    Class<? extends IValueValidator> validators[] = wrappedParameter.validateValueWith();
-    if (validators != null && validators.length>0) {
+    final Class<? extends IValueValidator> validators[] = wrappedParameter.validateValueWith();
+    if (validators != null && validators.length > 0) {
       for(final Class<? extends IValueValidator> validator: validators) {
         validateValueParameter(validator, name, value);
       }

--- a/src/main/java/com/beust/jcommander/WrappedParameter.java
+++ b/src/main/java/com/beust/jcommander/WrappedParameter.java
@@ -51,11 +51,11 @@ public class WrappedParameter {
     return parameter != null ? parameter.variableArity() : false;
   }
 
-  public Class<? extends IParameterValidator> validateWith() {
+  public Class<? extends IParameterValidator>[] validateWith() {
     return parameter != null ? parameter.validateWith() : dynamicParameter.validateWith();
   }
 
-  public Class<? extends IValueValidator> validateValueWith() {
+  public Class<? extends IValueValidator>[] validateValueWith() {
     return parameter != null
         ? parameter.validateValueWith()
         : dynamicParameter.validateValueWith();

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -593,31 +593,31 @@ public class JCommanderTest {
     
     @Test
     public void multipleValidators() {
-    	for(int i=1;i< 100;i+=2) {
-    	  ArgsMultiValidate a = new ArgsMultiValidate();
-          JCommander jc = new JCommander(a);
-          jc.parse("-age", String.valueOf(i));
-    	}
+    	  for(int i=1;i< 100;i+=2) {
+    	    ArgsMultiValidate a = new ArgsMultiValidate();
+            JCommander jc = new JCommander(a);
+            jc.parse("-age", String.valueOf(i));
+    	  }
     }
     @Test(expectedExceptions=ParameterException.class)
     public void multipleValidatorsFails1()
     {
-  	  ArgsMultiValidate a = new ArgsMultiValidate();
-      JCommander jc = new JCommander(a);
-      jc.parse("-age", "131");
+        ArgsMultiValidate a = new ArgsMultiValidate();
+        JCommander jc = new JCommander(a);
+        jc.parse("-age", "131");
     }
     
     @Test(expectedExceptions=ParameterException.class)
     public void multipleValidatorsFails2()
     {
-  	  ArgsMultiValidate a = new ArgsMultiValidate();
-      JCommander jc = new JCommander(a);
-      jc.parse("-age", "0");
+        ArgsMultiValidate a = new ArgsMultiValidate();
+        JCommander jc = new JCommander(a);
+        jc.parse("-age", "0");
     }
 
     @Test(expectedExceptions = ParameterException.class)
     public void validationShouldWork2() {
-        ArgsValidate1 a = new ArgsValidate1();
+    	  ArgsValidate1 a = new ArgsValidate1();
         JCommander jc = new JCommander(a);
         jc.parse("-age", "-2 ");
     }

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -590,6 +590,30 @@ public class JCommanderTest {
         ArgsValidate2 a = new ArgsValidate2();
         new JCommander(a).usage();
     }
+    
+    @Test
+    public void multipleValidators() {
+    	for(int i=1;i< 100;i+=2) {
+    	  ArgsMultiValidate a = new ArgsMultiValidate();
+          JCommander jc = new JCommander(a);
+          jc.parse("-age", String.valueOf(i));
+    	}
+    }
+    @Test(expectedExceptions=ParameterException.class)
+    public void multipleValidatorsFails1()
+    {
+  	  ArgsMultiValidate a = new ArgsMultiValidate();
+      JCommander jc = new JCommander(a);
+      jc.parse("-age", "131");
+    }
+    
+    @Test(expectedExceptions=ParameterException.class)
+    public void multipleValidatorsFails2()
+    {
+  	  ArgsMultiValidate a = new ArgsMultiValidate();
+      JCommander jc = new JCommander(a);
+      jc.parse("-age", "0");
+    }
 
     @Test(expectedExceptions = ParameterException.class)
     public void validationShouldWork2() {

--- a/src/test/java/com/beust/jcommander/args/ArgsMultiValidate.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsMultiValidate.java
@@ -14,23 +14,22 @@ public class ArgsMultiValidate {
 	}
   }
 
-  public static class LowerThan100VvalueValidator implements IValueValidator<Integer> {
+  public static class LowerThan100ValueValidator implements IValueValidator<Integer> {
 	 @Override
 	public void validate(String name, Integer value) throws ParameterException {
 			if(value>=100) throw new ParameterException("param "+name+"="+value+" is greater than 100");
 	 }
   } 
   
-  public static class GreaterTha0VvalueValidator implements IValueValidator<Integer> {
+  public static class GreaterTha0ValueValidator implements IValueValidator<Integer> {
 		 @Override
 		public void validate(String name, Integer value) throws ParameterException {
-			 System.err.println(name+"="+value+"######################");
 			 if(value<=0) throw new ParameterException("param "+name+"="+value+" is lower than 1");
 		 }
 	  }
   
   @Parameter(names = "-age",
 		  validateWith = {PositiveInteger.class,OddIntegerParameterValidator.class},
-		  validateValueWith={GreaterTha0VvalueValidator.class,LowerThan100VvalueValidator.class})
+		  validateValueWith={GreaterTha0ValueValidator.class,LowerThan100ValueValidator.class})
   public int age=29;
 }

--- a/src/test/java/com/beust/jcommander/args/ArgsMultiValidate.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsMultiValidate.java
@@ -1,0 +1,36 @@
+package com.beust.jcommander.args;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.IValueValidator;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.validators.PositiveInteger;
+
+public class ArgsMultiValidate {
+  public static class OddIntegerParameterValidator implements IParameterValidator {
+	  @Override
+	public void validate(String name, String value) throws ParameterException {
+		if(Integer.parseInt(value)%2!=1) throw new ParameterException("param "+name+"="+value+" is not odd");
+	}
+  }
+
+  public static class LowerThan100VvalueValidator implements IValueValidator<Integer> {
+	 @Override
+	public void validate(String name, Integer value) throws ParameterException {
+			if(value>=100) throw new ParameterException("param "+name+"="+value+" is greater than 100");
+	 }
+  } 
+  
+  public static class GreaterTha0VvalueValidator implements IValueValidator<Integer> {
+		 @Override
+		public void validate(String name, Integer value) throws ParameterException {
+			 System.err.println(name+"="+value+"######################");
+			 if(value<=0) throw new ParameterException("param "+name+"="+value+" is lower than 1");
+		 }
+	  }
+  
+  @Parameter(names = "-age",
+		  validateWith = {PositiveInteger.class,OddIntegerParameterValidator.class},
+		  validateValueWith={GreaterTha0VvalueValidator.class,LowerThan100VvalueValidator.class})
+  public int age=29;
+}

--- a/src/test/java/com/beust/jcommander/args/ArgsMultiValidate.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsMultiValidate.java
@@ -7,29 +7,30 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.validators.PositiveInteger;
 
 public class ArgsMultiValidate {
-  public static class OddIntegerParameterValidator implements IParameterValidator {
-	  @Override
-	public void validate(String name, String value) throws ParameterException {
-		if(Integer.parseInt(value)%2!=1) throw new ParameterException("param "+name+"="+value+" is not odd");
-	}
-  }
-
-  public static class LowerThan100ValueValidator implements IValueValidator<Integer> {
-	 @Override
-	public void validate(String name, Integer value) throws ParameterException {
-			if(value>=100) throw new ParameterException("param "+name+"="+value+" is greater than 100");
-	 }
-  } 
-  
-  public static class GreaterTha0ValueValidator implements IValueValidator<Integer> {
-		 @Override
-		public void validate(String name, Integer value) throws ParameterException {
-			 if(value<=0) throw new ParameterException("param "+name+"="+value+" is lower than 1");
-		 }
-	  }
-  
-  @Parameter(names = "-age",
-		  validateWith = {PositiveInteger.class,OddIntegerParameterValidator.class},
-		  validateValueWith={GreaterTha0ValueValidator.class,LowerThan100ValueValidator.class})
-  public int age=29;
+	
+		public static class OddIntegerParameterValidator implements IParameterValidator {
+				@Override
+				public void validate(String name, String value) throws ParameterException {
+					if(Integer.parseInt(value) %2 != 1) throw new ParameterException("param "+name+"="+value+" is not odd");
+				}
+		}
+	
+		public static class LowerThan100ValueValidator implements IValueValidator<Integer> {
+				@Override
+				public void validate(String name, Integer value) throws ParameterException {
+					if(value >= 100) throw new ParameterException("param "+name+"="+value+" is greater than 100");
+				}
+		} 
+	
+		public static class GreaterTha0ValueValidator implements IValueValidator<Integer> {
+				@Override
+				public void validate(String name, Integer value) throws ParameterException {
+					if(value <= 0) throw new ParameterException("param "+name+"="+value+" is lower than 1");
+				}
+		}
+	
+		@Parameter(names = "-age",
+				validateWith = {PositiveInteger.class,OddIntegerParameterValidator.class},
+				validateValueWith={GreaterTha0ValueValidator.class,LowerThan100ValueValidator.class})
+		public int age=29;
 }


### PR DESCRIPTION
Here is a PR where I've changed the definition of Parameter and DynamicParameter from:

```java
  Class<? extends IParameterValidator> validateWith() default NoValidator.class;
  Class<? extends IValueValidator> validateValueWith() default NoValueValidator.class;
```

to

```java
  Class<? extends IParameterValidator>[] validateWith() default NoValidator.class;
  Class<? extends IValueValidator>[] validateValueWith() default NoValueValidator.class;
```

this allow to specifiy multiple validator without creating a new class:

```java
  @Parameter(names = "-age",
		  validateWith = {PositiveInteger.class,OddIntegerParameterValidator.class},
		  validateValueWith={GreaterTha0ValueValidator.class,LowerThan100ValueValidator.class})
  public int age=29;
```
I've added a test and a paragraph in the documentation

