### PR TITLE
Issue 367 Fix NPE when Boolean default is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Current
 2017-03-05
 
+* Fixed: Fix NullPointerException for Boolean null values, #367
 * Fixed: '--' handling, #296
 * Added: Add `getProgramName` to `JCommander`, #247
 * Added: Documentation for `listConverter` and `splitter`, #253, (@jeremysolarz)

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -717,7 +717,9 @@ public class JCommander {
                                     && pd.getParameter().arity() == -1) {
                                 // Flip the value this boolean was initialized with
                                 Boolean value = (Boolean) pd.getParameterized().get(pd.getObject());
-                                pd.addValue(value ? "false" : "true");
+                                if(value != null) {
+                                    pd.addValue(value ? "false" : "true");
+                                }
                                 requiredFields.remove(pd.getParameterized());
                             } else {
                                 increment = processFixedArity(args, i, pd, validate, fieldType);

--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -169,15 +169,7 @@ public class Parameterized {
     try {
       if (method != null) {
         if (getter == null) {
-          String methodName;
-          if(Boolean.class.getSimpleName().toLowerCase().equals(getType().getName())){
-            methodName = "is" + method.getName().substring(3);
-          } else {
-            methodName = "g" + method.getName().substring(1);
-          }
-
-          getter = object.getClass()
-                  .getMethod(methodName);
+          setGetter(object);
         }
         return getter.invoke(object);
       } else {
@@ -201,6 +193,22 @@ public class Parameterized {
       }
       return result;
     }
+  }
+
+  private void setGetter(Object object) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    if(Boolean.class.getSimpleName().toLowerCase().equals(getType().getName())){
+      // try is<fieldname> notation
+      try {
+        getter = object.getClass()
+                .getMethod("is" + method.getName().substring(3));
+        // we have found a is<fieldname> getter we can return
+        return;
+      } catch (NoSuchMethodException n){
+        // if not found ignore exception and try with default get<fieldname> below
+      }
+    }
+    getter = object.getClass()
+            .getMethod("g" + method.getName().substring(1));
   }
 
   @Override

--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -169,8 +169,15 @@ public class Parameterized {
     try {
       if (method != null) {
         if (getter == null) {
-            getter = method.getDeclaringClass()
-                .getMethod("g" + method.getName().substring(1));
+          String methodName;
+          if(Boolean.class.getSimpleName().toLowerCase().equals(getType().getName())){
+            methodName = "is" + method.getName().substring(3);
+          } else {
+            methodName = "g" + method.getName().substring(1);
+          }
+
+          getter = object.getClass()
+                  .getMethod(methodName);
         }
         return getter.invoke(object);
       } else {

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -375,6 +375,34 @@ public class JCommanderTest {
         Assert.assertEquals(Arrays.asList(".txt", ".md"), args.extensions);
     }
 
+    @Test
+    public void booleanNoDefault() {
+        class Args {
+            @Parameter(names = {"--f"}, description = "Just a simple flag")
+            private Boolean f;
+        }
+        Args args = new Args();
+        JCommander.newBuilder()
+                .addObject(args)
+                .build().parse("--f");
+        Assert.assertEquals(args.f, null);
+    }
+
+
+    @Test
+    public void invertedBoolean() {
+        class Args {
+            @Parameter(names = {"--f"})
+            private boolean f = true;
+        }
+        Args args = new Args();
+        JCommander.newBuilder()
+                .addObject(args)
+                .args(new String[]{"--f"})
+                .build();
+        Assert.assertEquals(args.f, false);
+    }
+
     private void argsBoolean1(String[] argv, Boolean expected) {
         ArgsBooleanArity args = new ArgsBooleanArity();
         JCommander.newBuilder().addObject(args).build().parse(argv);
@@ -1556,20 +1584,6 @@ public class JCommanderTest {
                 .args(new String[]{"--generate", "--config", "foo.txt"})
                 .build();
         Assert.assertEquals(generateOption.configFile.getName(), "foo.txt");
-    }
-
-    @Test
-    public void invertedBoolean() {
-        class Args {
-            @Parameter(names = {"--f"})
-            private boolean f = true;
-        }
-        Args args = new Args();
-        JCommander.newBuilder()
-                .addObject(args)
-                .args(new String[]{"--f"})
-                .build();
-        Assert.assertEquals(args.f, false);
     }
 
     @Test


### PR DESCRIPTION
The PR fixes the error as described in #367 and also fixes an error in `TypeHierarchyTest`.

The necessary fix for #367 was done in `JCommander#parseValues`.
The fix to get `TypeHierarchyTest` passing again was done in `Parameterized#get`.

The get method tried to get the getter method from the interface `Visitor` before (which only implements the setter). With the getter is accessed directly from the given object.

@cbeust hope that fix makes sense.

Best,

JS