### PR TITLE
Allow generics of type List<? extends X> and List<? super Y> in parameters

### DIFF
--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -4,12 +4,7 @@ import com.beust.jcommander.internal.Lists;
 import com.beust.jcommander.internal.Sets;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
+import java.lang.reflect.*;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -77,7 +72,7 @@ public class Parameterized {
    * Given an object return the set of classes that it extends
    * or implements.
    *
-   * @param arg object to describe
+   * @param inputClass object to describe
    * @return set of classes that are implemented or extended by that object
    */
   private static Set<Class<?>> describeClassTree(Class<?> inputClass) {
@@ -314,6 +309,14 @@ public class Parameterized {
         Type cls = p.getActualTypeArguments()[0];
         if (cls instanceof Class) {
           return cls;
+        } else if ( cls instanceof WildcardType) {
+          WildcardType wildcardType = (WildcardType)cls;
+          if (wildcardType.getLowerBounds().length > 0) {
+            return wildcardType.getLowerBounds()[0];
+          }
+          if (wildcardType.getUpperBounds().length > 0) {
+            return wildcardType.getUpperBounds()[0];
+          }
         }
       }
     }

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -335,7 +335,9 @@ public class JCommanderTest {
         JCommander.newBuilder().addObject(args).build().parse("-file", "/tmp/" + fileName,
                 "-listStrings", "Tuesday,Thursday",
                 "-listInts", "-1,8",
-                "-listBigDecimals", "-11.52,100.12");
+                "-listBigDecimals", "-11.52,100.12",
+                "-listBigDecimalsWildcardUpper", "-11.52,100.12",
+                "-listBigDecimalsWildcardLower", "-11.52,100.12");
         Assert.assertEquals(args.file.getName(), fileName);
         Assert.assertEquals(args.listStrings.size(), 2);
         Assert.assertEquals(args.listStrings.get(0), "Tuesday");
@@ -346,6 +348,12 @@ public class JCommanderTest {
         Assert.assertEquals(args.listBigDecimals.size(), 2);
         Assert.assertEquals(args.listBigDecimals.get(0), new BigDecimal("-11.52"));
         Assert.assertEquals(args.listBigDecimals.get(1), new BigDecimal("100.12"));
+        Assert.assertEquals(args.listBigDecimalsWildcardUpper.size(), 2);
+        Assert.assertEquals(args.listBigDecimalsWildcardUpper.get(0), new BigDecimal("-11.52"));
+        Assert.assertEquals(args.listBigDecimalsWildcardUpper.get(1), new BigDecimal("100.12"));
+        Assert.assertEquals(args.listBigDecimalsWildcardLower.size(), 2);
+        Assert.assertEquals(args.listBigDecimalsWildcardLower.get(0), new BigDecimal("-11.52"));
+        Assert.assertEquals(args.listBigDecimalsWildcardLower.get(1), new BigDecimal("100.12"));
     }
 
     public void hiddenConverter() {

--- a/src/test/java/com/beust/jcommander/args/ArgsConverter.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsConverter.java
@@ -53,5 +53,11 @@ public class ArgsConverter {
 
   @Parameter(names = "-listBigDecimals")
   public List<BigDecimal> listBigDecimals;
+
+  @Parameter(names = "-listBigDecimalsWildcardUpper")
+  public List<? extends BigDecimal> listBigDecimalsWildcardUpper;
+
+  @Parameter(names = "-listBigDecimalsWildcardLower")
+  public List<? super BigDecimal> listBigDecimalsWildcardLower;
   
 }


### PR DESCRIPTION
Especially useful with Kotlin when using custom types with lists. 

E.g. When creating a class like this in Kotlin
```
class ExampleParameters  {
    @Parameter(names = arrayOf("-test"))
    var users: List<ExampleCustomClass> = emptyList()
}
```
Kotlin actually creates a Java class that looks something like this:

```
public class ExampleParameters {
    @Parameter(names = "-test")
    private List<? extends ExampleCustomClass> users = Collections.emptyList();
}
```

This allows jCommander to understand the generic `List<? extends ExampleCustomClass>` (and .e.g.
`List<? super ExampleCustomClass>`.)