### PR TITLE
Remove the generic in IStringConverterFactory

### DIFF
--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -32,7 +32,7 @@ val jcommander = project {
     }
 
     javaCompiler {
-        args("-target", "1.7", "-source", "1.7")
+        args("-target", "1.7", "-source", "1.7", "-g")
     }
 
     osgi {}

--- a/src/main/java/com/beust/jcommander/IStringConverterFactory.java
+++ b/src/main/java/com/beust/jcommander/IStringConverterFactory.java
@@ -22,10 +22,10 @@ package com.beust.jcommander;
  * A factory for IStringConverter. This interface lets you specify your
  * converters in one place instead of having them repeated all over
  * your argument classes.
- * 
+ *
  * @author cbeust
  * @see IStringConverterInstanceFactory
  */
 public interface IStringConverterFactory {
-  <T> Class<? extends IStringConverter<T>> getConverter(Class<T> forType);
+  Class<? extends IStringConverter<?>> getConverter(Class<?> forType);
 }


### PR DESCRIPTION
  The generic is producing JDK warnings in maven builds:

```
[WARNING] <file>:<line> getConverter(java.lang.Class) in <class> implements <T>getConverter(java.lang.Class<T>) in com.beust.jcommander.IStringConverterFactory
  return type requires unchecked conversion from java.lang.Class<? extends com.beust.jcommander.IStringConverter> to java.lang.Class<? extends com.beust.jcommander.IStringConverter<T>>
```

  With the following implementation:

```
public class ConverterFactory implements IStringConverterFactory {

  @SuppressWarnings({ "unchecked", "rawtypes" })
  @Override
  public Class<? extends IStringConverter> getConverter(final Class forType) {
    if (Path.class.isAssignableFrom(forType)) {// nio Path
      return StringToPath.class; 
    }
    if (Period.class.isAssignableFrom(forType)) { // javatime Period
      return StringToPeriod.class; // 
    }
    return null;
  }
}

````

  The `T` was unneeded here (because it would only help the interface' caller,
  and because if the converter is used to build TypeA and TypeB, then there is
  no common ancestor to be used as a "T" beside Object).

Beside, not related to the fix, but I can't do a full check because Kobalt (or even gradle for what is worth) is not doing well:

``` 
***** ERROR Error: java.lang.IllegalArgumentException: Illegal character in opaque part at index 11: jar:file:E:\git\external\github\jcommander\.\kobaltBuild\libs\jcommander-1.72.jar
*****
``` 
