### PR TITLE
Fixed encoding problem in test and another test that was failing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id "com.jfrog.bintray" version "1.2"
 }
 
-version = '1.58'
+version = '1.72'
 
 apply plugin: 'java'
 apply plugin: 'eclipse'
@@ -41,4 +41,8 @@ artifacts {
 test {
     // enable TestNG support (default is JUnit)
     useTestNG()
+}
+
+tasks.withType(JavaCompile) {
+  options.encoding = "UTF-8"
 }

--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -32,7 +32,7 @@ val jcommander = project {
     }
 
     javaCompiler {
-        args("-target", "1.7", "-source", "1.7", "-g")
+        args("-target", "1.7", "-source", "1.7", "-g", "-encoding", "utf-8")
     }
 
     osgi {}

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -700,10 +700,12 @@ public class JCommanderTest {
         final Args1 args1 = new Args1();
         final JCommander jc = new JCommander(args1);
         try {
-            jc.parse("@" + f.getAbsolutePath());
+            jc.parse("@__this_file_does_not_exists_then_we_should_get_some_exception_telling_us_so");
             throw new IllegalStateException("Expected exception to be thrown");
         } catch (ParameterException expected) {
-            Assert.assertTrue(expected.getMessage().startsWith("Could not read file"));
+          if (!expected.getMessage().startsWith("Could not read file")) {
+            Assert.fail("Invalid exception message", expected);
+          }
         }
         jc.setAtFileCharset(utf32);
         jc.parse("@" + f.getAbsolutePath());


### PR DESCRIPTION
The test were build dependent due to encoding (I'm actually working on a French Windows 7 and default JVM encoding is Windows Cp1252). 
I also fixed a problem in a test expectation.