### PR TITLE
Fixes changes introduced by #369 and version 1.71

### DIFF
--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -393,7 +393,7 @@ public class JCommanderTest {
         JCommander.newBuilder()
                 .addObject(args)
                 .build().parse("--f");
-        Assert.assertEquals(args.f, null);
+        Assert.assertEquals(args.f, Boolean.TRUE);
     }
 
 


### PR DESCRIPTION
Fixes changes introduced by #369 and commit 4435722a0b45be660b1b58834d4f5326fc78c9ad

  The changes was introducing a regression when the @Parameter was set on a Boolean
  whose default value was `null`: irrelevant of the parameter being set, the option
  would always be left to `null` instead of `true`.

  This breaks change with version 1.69 where the parameter was set to true even if
  null.
