### PR TITLE
Issue 339: allow using stderr instead of stdout

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -147,7 +147,7 @@ public class JCommander {
 
     private List<String> unknownArgs = Lists.newArrayList();
 
-    private static Console console;
+    private Console console;
 
     private final Options options;
 
@@ -265,12 +265,14 @@ public class JCommander {
         options.expandAtSign = expandAtSign;
     }
 
-    public static synchronized Console getConsole() {
+    public void setConsole(Console console) { this.console = console; }
+
+    public synchronized Console getConsole() {
         if (console == null) {
             try {
                 Method consoleMethod = System.class.getDeclaredMethod("console");
                 Object console = consoleMethod.invoke(null);
-                JCommander.console = new JDK6Console(console);
+                this.console = new JDK6Console(console);
             } catch (Throwable t) {
                 console = new DefaultConsole();
             }
@@ -762,8 +764,7 @@ public class JCommander {
 
                     for(final Class<? extends IParameterValidator> validator : mainParameter.annotation.validateWith()
                             ) {
-                        ParameterDescription.validateParameter(mainParameter.description,
-                        	validator,
+                        mainParameter.description.validateParameter(validator,
                             "Default", value);
                     }
 
@@ -1113,6 +1114,11 @@ public class JCommander {
 
         public Builder args(String[] args) {
             this.args = args;
+            return this;
+        }
+
+        public Builder console(Console console) {
+            jCommander.setConsole(console);
             return this;
         }
 

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -330,7 +330,7 @@ public class ParameterDescription {
     final Class<? extends IParameterValidator> validators[] = wrappedParameter.validateWith();
     if (validators != null && validators.length > 0) {
         for(final Class<? extends IParameterValidator> validator: validators) {
-          validateParameter(this, validator, name, value);
+          validateParameter(validator, name, value);
         }
     }
   }
@@ -344,7 +344,7 @@ public class ParameterDescription {
     }
   }
 
-  public static void validateValueParameter(Class<? extends IValueValidator> validator,
+  public void validateValueParameter(Class<? extends IValueValidator> validator,
       String name, Object value) {
     try {
       if (validator != NoValueValidator.class) {
@@ -356,8 +356,7 @@ public class ParameterDescription {
     }
   }
 
-  public static void validateParameter(ParameterDescription pd,
-      Class<? extends IParameterValidator> validator,
+  public void validateParameter(Class<? extends IParameterValidator> validator,
       String name, String value) {
     try {
     	
@@ -367,7 +366,7 @@ public class ParameterDescription {
       validator.newInstance().validate(name, value);
       if (IParameterValidator2.class.isAssignableFrom(validator)) {
         IParameterValidator2 instance = (IParameterValidator2) validator.newInstance();
-        instance.validate(name, value, pd);
+        instance.validate(name, value, this);
       }
     } catch (InstantiationException | IllegalAccessException e) {
       throw new ParameterException("Can't instantiate validator:" + e);
@@ -404,9 +403,9 @@ public class ParameterDescription {
     return (!isDefault && !assigned);
   }
 
-  private static void p(String string) {
+  private void p(String string) {
     if (System.getProperty(JCommander.DEBUG_PROPERTY) != null) {
-      JCommander.getConsole().println("[ParameterDescription] " + string);
+      jCommander.getConsole().println("[ParameterDescription] " + string);
     }
   }
 

--- a/src/main/java/com/beust/jcommander/internal/DefaultConsole.java
+++ b/src/main/java/com/beust/jcommander/internal/DefaultConsole.java
@@ -5,15 +5,25 @@ import com.beust.jcommander.ParameterException;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.PrintStream;
 
 public class DefaultConsole implements Console {
+  private final PrintStream target;
+
+  public DefaultConsole(PrintStream target) {
+    this.target = target;
+  }
+
+  public DefaultConsole() {
+    this.target = System.out;
+  }
 
   public void print(String msg) {
-    System.out.print(msg);
+    target.print(msg);
   }
 
   public void println(String msg) {
-    System.out.println(msg);
+    target.println(msg);
   }
 
   public char[] readPassword(boolean echoInput) {


### PR DESCRIPTION
at the moment instance of `Console` used by `JCommander` is initialized in `JCommander.getConsole()` and can not be changed. this situation results in issue #339 

by making `JCommander.console` configurable developers can decide on what implementation of `Console` they are going to use.
using `JCommander.Builder` like this would resolve issue #339 :

```
JCommander.newBuilder()
    .args(args)
    .console(new DefaultConsole(System.err))
    .build();
```