### PR TITLE
Add support for combined passing of short parameters

### DIFF
--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -732,6 +732,7 @@ You can configure how options are looked up in a few different ways:
 
 - `JCommander#setCaseSensitiveOptions(boolean)`: specify whether options are case sensitive. If you call this method with `false`, then `"-param"` and `"-PARAM"` are considered equal.
 - `JCommander#setAllowAbbreviatedOptions(boolean)`: specify whether users can pass abbreviated options. If you call this method with `true` then users can pass `"-par"` to specify an option called `-param`. JCommander will throw a `ParameterException` if the abbreviated name is ambiguous.
+- `JCommander#setAllowCombinedShortOptions(boolean)`: specify whether users can combine single-character options (i.e. options with names of the form `-x`). If you call this method with `true`, users can pass `"-abc"` to specify boolean options called `-a`, `-b`, and `-c`. The final option may have a non-zero arity. In this configuration, parameters with longer names should use the double-dash prefix (e.g. `--name`).
 
 == Required and optional parameters
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.5">
+<meta name="generator" content="Asciidoctor 1.5.4">
 <meta name="author" content="Cédric Beust">
 <title>JCommander</title>
 <style>
@@ -1638,6 +1638,9 @@ $ java Main --outputDirectory /tmp</code></pre>
 <li>
 <p><code>JCommander#setAllowAbbreviatedOptions(boolean)</code>: specify whether users can pass abbreviated options. If you call this method with <code>true</code> then users can pass <code>"-par"</code> to specify an option called <code>-param</code>. JCommander will throw a <code>ParameterException</code> if the abbreviated name is ambiguous.</p>
 </li>
+<li>
+<p><code>JCommander#setAllowCombinedShortOptions(boolean)</code>: specify whether users can combine single-character options (i.e. options with names of the form <code>-x</code>). If you call this method with <code>true</code>, users can pass <code>"-abc"</code> to specify boolean options called <code>-a</code>, <code>-b</code>, and <code>-c</code>. The final option may have a non-zero arity. In this configuration, parameters with longer names should use the double-dash prefix (e.g. <code>--name</code>).</p>
+</li>
 </ul>
 </div>
 </div>
@@ -2075,7 +2078,7 @@ new Args().with {
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-15 11:58:52 PDT
+Last updated 2017-09-04 11:29:07 BST
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/prettify.min.css">

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -460,7 +460,28 @@ public class JCommander {
             }
         }
 
+        //
+        // Expand combined options
+        //
+        if (options.allowCombinedShortOptions) {
+            vResult2 = expandCombinedShortOptions(vResult2);
+        }
+
         return vResult2.toArray(new String[vResult2.size()]);
+    }
+
+    private List<String> expandCombinedShortOptions(List<String> args) {
+        List<String> vResult = Lists.newArrayList();
+        for (String arg : args) {
+            if (arg.length() > 1 && arg.charAt(0) == '-' && arg.charAt(1) != '-') {
+                for (int i = 1; i < arg.length(); i++) {
+                    vResult.add("-" + arg.charAt(i));
+                }
+            } else {
+                vResult.add(arg);
+            }
+        }
+        return vResult;
     }
 
     private List<String> expandDynamicArg(String arg) {

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -187,6 +187,7 @@ public class JCommander {
         private int verbose = 0;
         private boolean caseSensitiveOptions = true;
         private boolean allowAbbreviatedOptions = false;
+        private boolean allowCombinedShortOptions = false;
         /**
          * The factories used to look up string converters.
          */
@@ -1180,6 +1181,11 @@ public class JCommander {
             return this;
         }
 
+        public Builder allowCombinedShortOptions(boolean b) {
+            jCommander.setAllowCombinedShortOptions(b);
+            return this;
+        }
+
         public Builder acceptUnknownOptions(boolean b) {
             jCommander.setAcceptUnknownOptions(b);
             return this;
@@ -1734,6 +1740,10 @@ public class JCommander {
 
     public void setAllowAbbreviatedOptions(boolean b) {
         options.allowAbbreviatedOptions = b;
+    }
+
+    public void setAllowCombinedShortOptions(boolean b) {
+        options.allowCombinedShortOptions = b;
     }
 
     public void setAcceptUnknownOptions(boolean b) {

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -474,8 +474,8 @@ public class JCommander {
         List<String> vResult = Lists.newArrayList();
         for (String arg : args) {
             if (arg.length() > 1 && arg.charAt(0) == '-' && arg.charAt(1) != '-') {
-                for (int i = 1; i < arg.length(); i++) {
-                    vResult.add("-" + arg.charAt(i));
+                for (char ch : arg.substring(1).toCharArray()) {
+                    vResult.add("-" + ch);
                 }
             } else {
                 vResult.add(arg);

--- a/src/test/java/com/beust/jcommander/CombinedShortOptionsTest.java
+++ b/src/test/java/com/beust/jcommander/CombinedShortOptionsTest.java
@@ -1,0 +1,62 @@
+package com.beust.jcommander;
+
+import com.beust.jcommander.args.Args1;
+import com.beust.jcommander.args.ArgsShort;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class CombinedShortOptionsTest {
+
+    @Test(expectedExceptions = ParameterException.class)
+    public void testCombinedShortOptionsDisabled() {
+        ArgsShort args = new ArgsShort();
+        String[] argv = {"-abc"};
+        JCommander.newBuilder().addObject(args).build().parse(argv);
+    }
+
+    @Test
+    public void testSingleBooleanOption() {
+        ArgsShort args = new ArgsShort();
+        String[] argv = {"-b"};
+        JCommander.newBuilder().addObject(args).allowCombinedShortOptions(true).build().parse(argv);
+
+        Assert.assertFalse(args.a);
+        Assert.assertTrue(args.b);
+        Assert.assertFalse(args.c);
+    }
+
+    @Test
+    public void testMultipleBooleanOptions() {
+        ArgsShort args = new ArgsShort();
+        String[] argv = {"-abc"};
+        JCommander.newBuilder().addObject(args).allowCombinedShortOptions(true).build().parse(argv);
+
+        Assert.assertTrue(args.a);
+        Assert.assertTrue(args.b);
+        Assert.assertTrue(args.c);
+    }
+
+    @Test
+    public void testStringArgument() {
+        ArgsShort args = new ArgsShort();
+        String[] argv = {"-acs", "str"};
+        JCommander.newBuilder().addObject(args).allowCombinedShortOptions(true).build().parse(argv);
+
+        Assert.assertTrue(args.a);
+        Assert.assertFalse(args.b);
+        Assert.assertTrue(args.c);
+        Assert.assertEquals(args.s, "str");
+    }
+
+    @Test
+    public void testLongOptionName() {
+        ArgsShort args = new ArgsShort();
+        String[] argv = {"--longname"};
+        JCommander.newBuilder().addObject(args).allowCombinedShortOptions(true).build().parse(argv);
+
+        Assert.assertTrue(args.a);
+        Assert.assertFalse(args.b);
+        Assert.assertFalse(args.c);
+    }
+}

--- a/src/test/java/com/beust/jcommander/CombinedShortOptionsTest.java
+++ b/src/test/java/com/beust/jcommander/CombinedShortOptionsTest.java
@@ -1,6 +1,5 @@
 package com.beust.jcommander;
 
-import com.beust.jcommander.args.Args1;
 import com.beust.jcommander.args.ArgsShort;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -58,5 +57,17 @@ public class CombinedShortOptionsTest {
         Assert.assertTrue(args.a);
         Assert.assertFalse(args.b);
         Assert.assertFalse(args.c);
+    }
+
+    @Test
+    public void testShortOptionsWithDynamicParameters() {
+        ArgsShort args = new ArgsShort();
+        String[] argv = {"-ab", "-Dparam=str"};
+        JCommander.newBuilder().addObject(args).allowCombinedShortOptions(true).build().parse(argv);
+
+        Assert.assertTrue(args.a);
+        Assert.assertTrue(args.b);
+        Assert.assertFalse(args.c);
+        Assert.assertEquals(args.params.get("param"), "str");
     }
 }

--- a/src/test/java/com/beust/jcommander/args/ArgsShort.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsShort.java
@@ -1,0 +1,25 @@
+package com.beust.jcommander.args;
+
+import com.beust.jcommander.Parameter;
+
+import java.util.List;
+
+/**
+ * Test combined short arguments.
+ *
+ * @author rddunphy
+ */
+public class ArgsShort {
+    @Parameter(names = {"-a", "--longname"}, description = "Boolean A")
+    public boolean a;
+
+    @Parameter(names = "-b", description = "Boolean B")
+    public boolean b;
+
+    @Parameter(names = "-c", description = "Boolean C")
+    public boolean c;
+
+    @Parameter(names = "-s", description = "String")
+    public String s;
+
+}

--- a/src/test/java/com/beust/jcommander/args/ArgsShort.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsShort.java
@@ -1,8 +1,10 @@
 package com.beust.jcommander.args;
 
+import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Test combined short arguments.
@@ -21,5 +23,8 @@ public class ArgsShort {
 
     @Parameter(names = "-s", description = "String")
     public String s;
+
+    @DynamicParameter(names = "-D", description = "Dynamic parameters")
+    public Map<String, String> params = new HashMap<>();
 
 }


### PR DESCRIPTION
Hello, 

Thanks for creating JCommander; it's a great tool. I've had a go at adding support for combining UN*X-style short parameters into single arguments.

- `JCommander.Options` now has a field `allowCombinedShortOptions`, `false` by default. 
- If set to `true`, parameters starting with a single dash will be expanded and treated as if multiple short parameters had been entered. (E.g. `Main -laX` will be parsed as `Main -l -a -X`.)
- Dynamic parameters are still parsed as normal and won't be expanded in this way.
- `JCommander.Builder` has a method `allowCombinedShortOptions(boolean)` which calls `JCommander.setAllowCombinedShortOptions(boolean)`.
- I've added a bullet point to the documentation explaining this usage.

### Usage example
```java
public class Main {

    @Parameter(names = "-a")
    private boolean a = false;

    @Parameter(names = "-b")
    private boolean b = false;

    @Parameter(names = "-c")
    private boolean c = false;

    public static void main(String[] args) {
        Main main = new Main();
        JCommander.newBuilder().addObject(main).allowCombinedShortOptions(true)
                        .build().parse(args);
        main.run();
    }

    public void run() {
        System.out.println("a = " + a + ", b = " + b + ", c = " + c);
    }

}
```
The user can then enter the following: 
```
$ ./Main -abc
a = true, b = true, c = true
```