### PR TITLE
Add automatic module name to manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,13 @@ dependencies {
     testCompile 'org.testng:testng:6.9.13'
 }
 
+jar {
+  manifest {
+    attributes(
+      "Automatic-Module-Name": "com.beust.jcommander")
+  }
+}
+
 task sourceJar(type: Jar) {
     group 'Build'
     description 'An archive of the source code'


### PR DESCRIPTION
As the `module-info.java` file requires a lot more setup, here is the simpler approach.  It just adds an entry to the MANIFEST.MF file. This should be removed when the project is properly modularized using `module-info.java`. I've run gradle locally and the jar file has the manifest entry in, so I believe it works.

Thanks