### PR TITLE
Remove String.join (Java 7 compliance)

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -336,22 +336,13 @@ public class JCommander {
 
     private void parse(boolean validate, String... args) {
         StringBuilder sb = new StringBuilder("Parsing \"");
-        sb.append(join(args).append("\"\n  with:").append(join(objects.toArray())));
+        sb.append(Strings.join(" ", args)).append("\"\n  with:").append(Strings.join(" ", objects.toArray()));
         p(sb.toString());
 
         if (descriptions == null) createDescriptions();
         initializeDefaultValues();
         parseValues(expandArgs(args), validate);
         if (validate) validateOptions();
-    }
-
-    private StringBuilder join(Object[] args) {
-        StringBuilder result = new StringBuilder();
-        for (int i = 0; i < args.length; i++) {
-            if (i > 0) result.append(" ");
-            result.append(args[i]);
-        }
-        return result;
     }
 
     private void initializeDefaultValues() {
@@ -378,9 +369,9 @@ public class JCommander {
         if (!requiredFields.isEmpty()) {
             List<String> missingFields = new ArrayList<>();
             for (ParameterDescription pd : requiredFields.values()) {
-                missingFields.add("[" + String.join(" | ", pd.getParameter().names()) + "]");
+                missingFields.add("[" + Strings.join(" | ", pd.getParameter().names()) + "]");
             }
-            String message = String.join(", ", missingFields);
+            String message = Strings.join(", ", missingFields);
             throw new ParameterException("The following "
                     + pluralize(requiredFields.size(), "option is required: ", "options are required: ")
                     + message);

--- a/src/main/java/com/beust/jcommander/Strings.java
+++ b/src/main/java/com/beust/jcommander/Strings.java
@@ -1,5 +1,7 @@
 package com.beust.jcommander;
 
+import java.util.List;
+
 public class Strings {
 
     public static boolean isStringEmpty(String s) {
@@ -12,5 +14,29 @@ public class Strings {
         else {
             return s.toLowerCase().startsWith(with.toLowerCase());
         }
+    }
+
+    public static String join(String delimiter, List<String> args) {
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < args.size(); i++) {
+            builder.append(args.get(i));
+
+            if (i + 1 < args.size())
+                builder.append(delimiter);
+        }
+        return builder.toString();
+    }
+
+    public static String join(String delimiter, Object[] args) {
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < args.length; i++) {
+            builder.append(args[i]);
+
+            if (i + 1 < args.length)
+                builder.append(delimiter);
+        }
+        return builder.toString();
     }
 }

--- a/src/test/java/com/beust/jcommander/StringsTest.java
+++ b/src/test/java/com/beust/jcommander/StringsTest.java
@@ -1,0 +1,31 @@
+package com.beust.jcommander;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+@Test
+public class StringsTest {
+
+    @Test
+    public void testListJoin() {
+        String expected = "A, B, C  c";
+        String actual = Strings.join(", ", Arrays.asList("A", "B", "C  c"));
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testArrayJoinSpaceDelimiter() {
+        String expected = "A B C  c";
+        String actual = Strings.join(" ", new String[] { "A", "B", "C  c" });
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testArrayJoinEmptyDelimiter() {
+        String expected = "ABC  c";
+        String actual = Strings.join("", new Object[] { "A", "B", "C  c" });
+        Assert.assertEquals(expected, actual);
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -17,6 +17,7 @@
       <class name="com.beust.jcommander.PositiveIntegerTest" />
       <class name="com.beust.jcommander.FinderTest" />
       <class name="com.beust.jcommander.CmdTest" />
+      <class name="com.beust.jcommander.StringsTest" />
     </classes>
   </test>
 


### PR DESCRIPTION
I think it is worth restoring Java 7 compliance for the following reasons:
* We only use `String.join` twice
* We already had a `join` method

A mixture of the aforementioned creates inconsistency, we should remove one or the other. In this case if we remove `String.join` we remove the inconsistency and restore Java 7 compliance.

This would resolve #394 #391 #381 