### PR TITLE
Fix error message when failing to convert a Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed: Do not add a DefaultConverterFactory for every subcommand, #359 (@simon04)
 * Fixed: Fix Sonar rules squid:ModifiersOrderCheck and squid:S2444, #254 (@kirill-vlasov)
 * Added: Add testcase for `EnumConverter`, #360 (@jeremysolarz)
+* Fixed: Proper `ParameterException` when `Path` converter fails, #414 (@selliera)
 
 ### 1.58
 2016-09-29

--- a/src/main/java/com/beust/jcommander/converters/PathConverter.java
+++ b/src/main/java/com/beust/jcommander/converters/PathConverter.java
@@ -18,20 +18,28 @@
 
 package com.beust.jcommander.converters;
 
-import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
 
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
  * Convert a string into a path.
- * 
+ *
  * @author samvv
  */
-public class PathConverter implements IStringConverter<Path> {
-  
-  public Path convert(String value) {
-    return Paths.get(value);
+public class PathConverter extends BaseConverter<Path> {
+
+  public PathConverter(String optionName) {
+    super(optionName);
   }
-  
+
+  public Path convert(String value) {
+    try {
+      return Paths.get(value);
+    } catch (InvalidPathException e) {
+      throw new ParameterException(getErrorString(value, "a path"));
+    }
+  }
 }

--- a/src/main/java/com/beust/jcommander/converters/PathConverter.java
+++ b/src/main/java/com/beust/jcommander/converters/PathConverter.java
@@ -39,7 +39,20 @@ public class PathConverter extends BaseConverter<Path> {
     try {
       return Paths.get(value);
     } catch (InvalidPathException e) {
-      throw new ParameterException(getErrorString(value, "a path"));
+      String encoded = escapeUnprintable(value);
+      throw new ParameterException(getErrorString(encoded, "a path"));
     }
+  }
+
+  private static String escapeUnprintable(String value) {
+    StringBuilder bldr = new StringBuilder();
+    for (char c: value.toCharArray()) {
+        if (c < ' ') {
+            bldr.append("\\u").append(String.format("%04X", (int) c));
+        } else {
+            bldr.append(c);
+        }
+    }
+    return bldr.toString();
   }
 }

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -238,13 +238,16 @@ public class JCommanderTest {
     public void converterArgs() {
         ArgsConverter args = new ArgsConverter();
         String fileName = "a";
-        JCommander.newBuilder().addObject(args).build().parse("-file", "/tmp/" + fileName,
+        JCommander.newBuilder().addObject(args).build().parse(
+                "-file", "/tmp/" + fileName,
+                "-path", "/tmp/" + fileName,
                 "-listStrings", "Tuesday,Thursday",
                 "-listInts", "-1,8",
                 "-listBigDecimals", "-11.52,100.12",
                 "-listBigDecimalsWildcardUpper", "-11.52,100.12",
                 "-listBigDecimalsWildcardLower", "-11.52,100.12");
         Assert.assertEquals(args.file.getName(), fileName);
+        Assert.assertEquals(args.path.getFileName().toString(), fileName);
         Assert.assertEquals(args.listStrings.size(), 2);
         Assert.assertEquals(args.listStrings.get(0), "Tuesday");
         Assert.assertEquals(args.listStrings.get(1), "Thursday");
@@ -260,6 +263,13 @@ public class JCommanderTest {
         Assert.assertEquals(args.listBigDecimalsWildcardLower.size(), 2);
         Assert.assertEquals(args.listBigDecimalsWildcardLower.get(0), new BigDecimal("-11.52"));
         Assert.assertEquals(args.listBigDecimalsWildcardLower.get(1), new BigDecimal("100.12"));
+    }
+
+    @Test(expectedExceptions = ParameterException.class)
+    public void pathConverterErr() {
+        ArgsConverter args = new ArgsConverter();
+        // even the most permissive filesystems do not allow file names containing null character
+        JCommander.newBuilder().addObject(args).build().parse("-path", "an\u0000invalid_path ");
     }
 
     public void hiddenConverter() {


### PR DESCRIPTION
When a parameter is of type Path, the PathConverter is used.
If the path is not a valid Path, for instance when the user input is an
uri, a stack trace is shown, where a proper error message is expected.

When converting a path, catch the InvalidPathException that can be
thrown, and format the message as it is done in other converters.