### PR TITLE
Enable usage() ordering for DynamicParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Fixed: Java 7 compatibility, #409 (@PureCS)
 * Fixed: Locale-related issues in usage formatter tests, #410 (@PureCS)
 * Added: Documentation for `IUsageFormatter` and related classes, #411 (@PureCS)
+* Added: `order` support for `@DynamicParameter`, #418 (@selliera)
 
 ### 1.58
 2016-09-29

--- a/src/main/java/com/beust/jcommander/DynamicParameter.java
+++ b/src/main/java/com/beust/jcommander/DynamicParameter.java
@@ -47,4 +47,10 @@ public @interface DynamicParameter {
   String assignment() default "=";
 
   Class<? extends IValueValidator>[] validateValueWith() default NoValueValidator.class;
+
+  /**
+   * If specified, this number will be used to order the description of this parameter when usage() is invoked.
+   * @return
+   */
+  int order() default -1;
 }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -176,8 +176,8 @@ public class JCommander {
                 = new Comparator<ParameterDescription>() {
             @Override
             public int compare(ParameterDescription p0, ParameterDescription p1) {
-                Parameter a0 = p0.getParameterAnnotation();
-                Parameter a1 = p1.getParameterAnnotation();
+                WrappedParameter a0 = p0.getParameter();
+                WrappedParameter a1 = p1.getParameter();
                 if (a0 != null && a0.order() != -1 && a1 != null && a1.order() != -1) {
                     return Integer.compare(a0.order(), a1.order());
                 } else if (a0 != null && a0.order() != -1) {
@@ -676,7 +676,7 @@ public class JCommander {
             }
         }
     }
-    
+
     /**
      * Main method that parses the values and initializes the fields accordingly.
      */
@@ -813,7 +813,7 @@ public class JCommander {
     private boolean isBooleanType(Class<?> fieldType) {
       return Boolean.class.isAssignableFrom(fieldType) || boolean.class.isAssignableFrom(fieldType);
     }
-    
+
     private void handleBooleanOption(ParameterDescription pd, Class<?> fieldType) {
       // Flip the value this boolean was initialized with
       Boolean value = (Boolean) pd.getParameterized().get(pd.getObject());

--- a/src/main/java/com/beust/jcommander/WrappedParameter.java
+++ b/src/main/java/com/beust/jcommander/WrappedParameter.java
@@ -51,6 +51,10 @@ public class WrappedParameter {
     return parameter != null ? parameter.variableArity() : false;
   }
 
+  public int order() {
+    return parameter != null ? parameter.order() : dynamicParameter.order();
+  }
+
   public Class<? extends IParameterValidator>[] validateWith() {
     return parameter != null ? parameter.validateWith() : dynamicParameter.validateWith();
   }
@@ -62,7 +66,7 @@ public class WrappedParameter {
   }
 
   public boolean echoInput() {
-	  return parameter != null ? parameter.echoInput() : false;
+    return parameter != null ? parameter.echoInput() : false;
   }
 
   public void addValue(Parameterized parameterized, Object object, Object value) {

--- a/src/test/java/com/beust/jcommander/ParameterOrderTest.java
+++ b/src/test/java/com/beust/jcommander/ParameterOrderTest.java
@@ -1,0 +1,75 @@
+package com.beust.jcommander;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>Test that parameter order specified via order attributes is respected</p>
+ */
+public class ParameterOrderTest {
+
+  private static class ManualOrder1 {
+    @Parameter(order=1, names = "--arg_b")
+    public boolean isB;
+    @Parameter(order=0, names = "--arg_a")
+    public boolean isA;
+    @Parameter(order=2, names = "--arg_c")
+    public boolean isC;
+  }
+
+  @Test
+  public void testOrder1() {
+    testOrder(new ManualOrder1(), "--arg_a","--arg_b","--arg_c");
+  }
+
+  private static class ManualOrder2 {
+    @Parameter(order=1, names = "--arg_b")
+    public boolean isZ;
+    @DynamicParameter(order=0, names = "--arg_a")
+    public Map<String,String> mapA;
+    @Parameter(order=2, names = "--arg_c")
+    public boolean isC;
+  }
+
+  @Test
+  public void testOrder2() {
+    testOrder(new ManualOrder2(), "--arg_a","--arg_b","--arg_c");
+  }
+
+  private static class ManualOrder3 {
+    @Parameter(order=1, names = "--arg_b")
+    public boolean isB;
+    @Parameter(order=0, names = "--arg_a")
+    public boolean isA;
+    @Parameter(names = "--arg_d")
+    public boolean isD;
+    @Parameter(order=2, names = "--arg_c")
+    public boolean isC;
+  }
+
+  @Test
+  public void testOrder3() {
+    testOrder(new ManualOrder3(), "--arg_a","--arg_b","--arg_c", "--arg_d");
+  }
+
+  public void testOrder(Object cmd, String ... expected) {
+    JCommander commander = new JCommander(cmd);
+
+    StringBuilder out = new StringBuilder();
+    commander.getUsageFormatter().usage(out);
+    String output = out.toString();
+    List<String> order = new ArrayList<>();
+    for (String line : output.split("[\\n\\r]+")) {
+      String trimmed = line.trim();
+      if (!trimmed.contains(":")) {
+        order.add(trimmed);
+      }
+    }
+    Assert.assertEquals(order, Arrays.asList(expected));
+  }
+}


### PR DESCRIPTION
When using Parameter.order to order parameters in usage(), one should be
able to use the same "order" in DynamicParameter.
Without this, using order for Parameter will result in all
DynamicParameters being displayed at the end of usage().

If you are fine with this change, I will work on adding a testcase to it before merge.

regards,
antoine