### PR TITLE
Return an empty list when parsing an empty string

### DIFF
--- a/src/main/java/com/beust/jcommander/converters/CommaParameterSplitter.java
+++ b/src/main/java/com/beust/jcommander/converters/CommaParameterSplitter.java
@@ -1,12 +1,15 @@
 package com.beust.jcommander.converters;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class CommaParameterSplitter implements IParameterSplitter {
 
   public List<String> split(String value) {
+    if ("".equals(value)) {
+      return Collections.emptyList();
+    }
     return Arrays.asList(value.split(","));
   }
-
 }

--- a/src/test/java/com/beust/jcommander/converters/CommaParameterSplitterTest.java
+++ b/src/test/java/com/beust/jcommander/converters/CommaParameterSplitterTest.java
@@ -1,0 +1,28 @@
+package com.beust.jcommander.converters;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Test
+public class CommaParameterSplitterTest {
+
+  private static final IParameterSplitter SPLITTER = new CommaParameterSplitter();
+
+  @Test
+  public void testSplit() {
+    // An empty string becomes an empty list.
+    Assert.assertEquals(Collections.emptyList(), SPLITTER.split(""));
+
+    // Whitespace is unaltered.
+    Assert.assertEquals(Collections.singletonList("  "), SPLITTER.split("  "));
+
+    // Single value.
+    Assert.assertEquals(Collections.singletonList("abc"), SPLITTER.split("abc"));
+
+    // Multiple values.
+    Assert.assertEquals(Arrays.asList("a", "b", "c"), SPLITTER.split("a,b,c"));
+  }
+}


### PR DESCRIPTION
Rather than returning a list of size 1 containing an empty string, split an empty string into an empty list.  

This could be done application-side with a custom `IParameterSplitter`, but `"" -> []` is less surprising default behavior than `"" -> [""]`.  This also simplifies downstream parsing within jcommander, as the current behavior would pass an empty string to type converters.