### PR TITLE
Fix UsageFormatter: inherit usage formatter for subcommands

### DIFF
--- a/src/main/java/com/beust/jcommander/IUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/IUsageFormatter.java
@@ -26,30 +26,30 @@ public interface IUsageFormatter {
     /**
      * Display the usage for this command.
      */
-    void usage(String commandName);
+    void usage(JCommander commander, String commandName);
 
     /**
      * Store the help for the command in the passed string builder.
      */
-    void usage(String commandName, StringBuilder out);
+    void usage(JCommander commander, String commandName, StringBuilder out);
 
     /**
      * Store the help in the passed string builder.
      */
-    void usage(StringBuilder out);
+    void usage(JCommander commander, StringBuilder out);
 
     /**
      * Store the help for the command in the passed string builder, indenting every line with "indent".
      */
-    void usage(String commandName, StringBuilder out, String indent);
+    void usage(JCommander commander, String commandName, StringBuilder out, String indent);
 
     /**
      * Stores the help in the passed string builder, with the argument indentation.
      */
-    void usage(StringBuilder out, String indent);
+    void usage(JCommander commander, StringBuilder out, String indent);
 
     /**
      * @return the description of the argument command
      */
-    String getCommandDescription(String commandName);
+    String getCommandDescription(JCommander commander, String commandName);
 }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -110,7 +110,7 @@ public class JCommander {
     /**
      * The usage formatter to use in {@link #usage()}.
      */
-    private IUsageFormatter usageFormatter = new DefaultUsageFormatter(this);
+    private IUsageFormatter usageFormatter = new DefaultUsageFormatter();
 
     private MainParameter mainParameter = null;
 
@@ -1020,12 +1020,42 @@ public class JCommander {
      */
     public void usage() {
         StringBuilder sb = new StringBuilder();
-        usageFormatter.usage(sb);
+        usageFormatter.usage(this, sb);
         getConsole().println(sb.toString());
     }
 
     /**
-     * Sets the usage formatter.
+     * Prints the usage to given {@link StringBuilder} using the underlying {@link #usageFormatter}
+     * @param sb {@link StringBuilder} to append
+     */
+    void usage(StringBuilder sb) {
+        // package access, for tests
+        usageFormatter.usage(this, sb);
+    }
+
+    /**
+     * Prints the usage of subcommand on {@link #getConsole()} using the underlying {@link #usageFormatter}.
+     */
+    public void usage(String commandName) {
+        StringBuilder sb = new StringBuilder();
+        usageFormatter.usage(this, commandName, sb);
+        getConsole().println(sb.toString());
+    }
+
+    void usage(String commandName, StringBuilder sb) {
+        // package access, for tests
+        usageFormatter.usage(this, commandName, sb);
+    }
+
+    /**
+     * @return Get the description of the argument command using the underlying {@link #usageFormatter}
+     */
+    public String getCommandDescription(String commandName) {
+        return usageFormatter.getCommandDescription(this, commandName);
+    }
+
+    /**
+     * Sets the usage formatter. This will set usage formatter for all subcommands recursively.
      *
      * @param usageFormatter the usage formatter
      * @throws IllegalArgumentException if the argument is <tt>null</tt>
@@ -1034,6 +1064,7 @@ public class JCommander {
         if (usageFormatter == null)
             throw new IllegalArgumentException("Argument UsageFormatter must not be null");
         this.usageFormatter = usageFormatter;
+        commands.forEach((programName, commander) -> commander.setUsageFormatter(usageFormatter));
     }
 
     /**
@@ -1393,6 +1424,7 @@ public class JCommander {
         jc.addObject(object);
         jc.createDescriptions();
         jc.setProgramName(name, aliases);
+        jc.setUsageFormatter(usageFormatter);
         ProgramName progName = jc.programName;
         commands.put(progName, jc);
 

--- a/src/main/java/com/beust/jcommander/UnixStyleUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/UnixStyleUsageFormatter.java
@@ -23,26 +23,26 @@ import java.util.List;
 
 /**
  * A unix-style usage formatter. This works by overriding and modifying the output of
- * {@link #appendAllParametersDetails(StringBuilder, int, String, List)} which is inherited from
+ * {@link #appendAllParametersDetails(JCommander, StringBuilder, int, String, List)} which is inherited from
  * {@link DefaultUsageFormatter}.
  */
 public class UnixStyleUsageFormatter extends DefaultUsageFormatter {
 
-    public UnixStyleUsageFormatter(JCommander commander) {
-        super(commander);
-    }
+    public UnixStyleUsageFormatter() { }
 
     /**
      * Appends the details of all parameters in the given order to the argument string builder, indenting every
      * line with <tt>indentCount</tt>-many <tt>indent</tt>.
      *
+     * @param commander the commander
      * @param out the builder to append to
      * @param indentCount the amount of indentation to apply
      * @param indent the indentation
      * @param sortedParameters the parameters to append to the builder
      */
-    public void appendAllParametersDetails(StringBuilder out, int indentCount, String indent,
-            List<ParameterDescription> sortedParameters) {
+    @Override
+    protected void appendAllParametersDetails(JCommander commander, StringBuilder out, int indentCount, String indent,
+                                           List<ParameterDescription> sortedParameters) {
         if (sortedParameters.size() > 0) {
             out.append(indent).append("  Options:\n");
         }
@@ -101,7 +101,7 @@ public class UnixStyleUsageFormatter extends DefaultUsageFormatter {
             // Append description
             // The magic value 3 is the number of spaces between the name of the option and its description
             // in DefaultUsageFormatter#appendCommands(..)
-            wrapDescription(out, indentCount + prefixIndent - 3, initialLinePrefixLength, description);
+            wrapDescription(commander, out, indentCount + prefixIndent - 3, initialLinePrefixLength, description);
             out.append("\n");
         }
     }

--- a/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
@@ -60,7 +60,7 @@ public class DefaultUsageFormatterTest {
                 .build();
 
         // action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         // verify
         String expected = "Usage: <main class> [options]\n"
@@ -104,7 +104,7 @@ public class DefaultUsageFormatterTest {
         StringBuilder sb = new StringBuilder();
 
         //action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         //verify
         for (String line : sb.toString().split("\n")) {
@@ -121,7 +121,7 @@ public class DefaultUsageFormatterTest {
         StringBuilder sb = new StringBuilder();
 
         //action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         //verify
         for (String line : sb.toString().split("\n")) {
@@ -138,7 +138,7 @@ public class DefaultUsageFormatterTest {
                 .build();
 
         //action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         //verify
         for (String line : sb.toString().split("\n")) {
@@ -152,7 +152,7 @@ public class DefaultUsageFormatterTest {
         String programName = "main";
         jcommander.setProgramName(programName);
         StringBuilder sb = new StringBuilder();
-        jcommander.getUsageFormatter().usage(sb);
+        jcommander.usage(sb);
 
         Assert.assertTrue(sb.toString().contains(programName));
         Assert.assertEquals(jcommander.getProgramName(), programName);
@@ -171,7 +171,7 @@ public class DefaultUsageFormatterTest {
                 .build();
         jcommander.setProgramName("main");
         StringBuilder sb = new StringBuilder();
-        jcommander.getUsageFormatter().usage(sb);
+        jcommander.usage(sb);
         Assert.assertEquals(sb.toString().indexOf("options"), -1);
     }
 
@@ -188,7 +188,7 @@ public class DefaultUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(new DSimple())
                 .build();
-        jc.getUsageFormatter().usage(new StringBuilder());
+        jc.usage(new StringBuilder());
     }
 
     /**
@@ -199,7 +199,7 @@ public class DefaultUsageFormatterTest {
         String[] argv = {};
         JCommander jc = JCommander.newBuilder().addObject(new Object()).build();
         jc.parse(argv);
-        jc.getUsageFormatter().getCommandDescription("foo");
+        jc.getCommandDescription("foo");
     }
 
     @Test
@@ -210,7 +210,7 @@ public class DefaultUsageFormatterTest {
                 .build();
         jc.addCommand(new ArgsLongCommandDescription());
         StringBuilder sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         String usage = sb.toString();
         Assert.assertTrue(usage.contains("text"));
     }
@@ -220,7 +220,7 @@ public class DefaultUsageFormatterTest {
         JCommander jCommander = JCommander.newBuilder()
                 .addObject(new ArgsMainParameter1())
                 .build();
-        jCommander.getUsageFormatter().usage(new StringBuilder());
+        jCommander.usage(new StringBuilder());
         // Before fix, this parse would throw an exception, because it calls createDescription, which
         // was already called by usage(), and can only be called once.
         jCommander.parse();
@@ -238,7 +238,7 @@ public class DefaultUsageFormatterTest {
                 .resourceBundle(getResourceBundle())
                 .build();
         // Should be able to display usage without triggering validation
-        jc.getUsageFormatter().usage(new StringBuilder());
+        jc.usage(new StringBuilder());
         try {
             jc.parse("-h");
             Assert.fail("Should have thrown a required parameter exception");
@@ -253,11 +253,11 @@ public class DefaultUsageFormatterTest {
         JCommander jc = JCommander.newBuilder().addObject(new Args1()).build();
         jc.parse("-log", "1");
         StringBuilder sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         String expected = sb.toString();
 
         sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         String actual = sb.toString();
         Assert.assertEquals(actual, expected);
     }
@@ -267,7 +267,7 @@ public class DefaultUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(new ArgsOutOfMemory())
                 .build();
-        jc.getUsageFormatter().usage(new StringBuilder());
+        jc.usage(new StringBuilder());
     }
 
     @Test
@@ -283,7 +283,7 @@ public class DefaultUsageFormatterTest {
 
         StringBuilder sb = new StringBuilder();
 
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         Assert.assertFalse(sb.toString().contains("Default"));
     }
@@ -312,7 +312,7 @@ public class DefaultUsageFormatterTest {
         c.addCommand("b", new ArgCommandB());
 
         StringBuilder sb = new StringBuilder();
-        c.getUsageFormatter().usage(sb);
+        c.usage(sb);
         Assert.assertTrue(sb.toString().contains("[command options]\n  Commands:"));
     }
 
@@ -340,7 +340,7 @@ public class DefaultUsageFormatterTest {
         c.addCommand("b", new ArgCommandB());
 
         StringBuilder sb = new StringBuilder();
-        c.getUsageFormatter().usage(sb);
+        c.usage(sb);
         Assert.assertTrue(sb.toString().contains("command a parameters\n\n    b"));
     }
 
@@ -372,7 +372,7 @@ public class DefaultUsageFormatterTest {
         aCommand.addCommand("b", new ArgCommandB());
 
         StringBuilder sb = new StringBuilder();
-        c.getUsageFormatter().usage(sb);
+        c.usage(sb);
         Assert.assertTrue(sb.toString().contains("command a parameters\n        Commands:"));
         Assert.assertTrue(sb.toString().contains("command b\n            Usage:"));
     }
@@ -388,7 +388,7 @@ public class DefaultUsageFormatterTest {
         JCommander c = JCommander.newBuilder()
                 .addObject(a)
                 .build();
-        c.getUsageFormatter().usage(sb);
+        c.usage(sb);
         Assert.assertTrue(sb.toString().contains("Default: <empty string>"));
     }
 }

--- a/src/test/java/com/beust/jcommander/ParameterOrderTest.java
+++ b/src/test/java/com/beust/jcommander/ParameterOrderTest.java
@@ -61,7 +61,7 @@ public class ParameterOrderTest {
     JCommander commander = new JCommander(cmd);
 
     StringBuilder out = new StringBuilder();
-    commander.getUsageFormatter().usage(out);
+    commander.usage(out);
     String output = out.toString();
     List<String> order = new ArrayList<>();
     for (String line : output.split("[\\n\\r]+")) {

--- a/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
@@ -49,10 +49,10 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(new ArgsTemplate())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
 
         // action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         // verify
         String expected = "Usage: <main class> [options]\n"
@@ -76,11 +76,11 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(new ArgsLongMainParameterDescription())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         StringBuilder sb = new StringBuilder();
 
         //action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         //verify
         for (String line : sb.toString().split("\n")) {
@@ -94,11 +94,11 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addCommand(new ArgsLongCommandDescription())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         StringBuilder sb = new StringBuilder();
 
         //action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         //verify
         for (String line : sb.toString().split("\n")) {
@@ -113,10 +113,10 @@ public class UnixStyleUsageFormatterTest {
         final JCommander jc = JCommander.newBuilder()
                 .addObject(new ArgsLongDescription())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
 
         //action
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         //verify
         for (String line : sb.toString().split("\n")) {
@@ -127,11 +127,11 @@ public class UnixStyleUsageFormatterTest {
     @Test
     public void programName() {
         JCommander jcommander = new JCommander();
-        jcommander.setUsageFormatter(new UnixStyleUsageFormatter(jcommander));
+        jcommander.setUsageFormatter(new UnixStyleUsageFormatter());
         String programName = "main";
         jcommander.setProgramName(programName);
         StringBuilder sb = new StringBuilder();
-        jcommander.getUsageFormatter().usage(sb);
+        jcommander.usage(sb);
 
         Assert.assertTrue(sb.toString().contains(programName));
         Assert.assertEquals(jcommander.getProgramName(), programName);
@@ -148,10 +148,10 @@ public class UnixStyleUsageFormatterTest {
         JCommander jcommander = JCommander.newBuilder()
                 .addObject(template)
                 .build();
-        jcommander.setUsageFormatter(new UnixStyleUsageFormatter(jcommander));
+        jcommander.setUsageFormatter(new UnixStyleUsageFormatter());
         jcommander.setProgramName("main");
         StringBuilder sb = new StringBuilder();
-        jcommander.getUsageFormatter().usage(sb);
+        jcommander.usage(sb);
         Assert.assertEquals(sb.toString().indexOf("options"), -1);
     }
 
@@ -168,8 +168,8 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(new DSimple())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
-        jc.getUsageFormatter().usage(new StringBuilder());
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
+        jc.usage(new StringBuilder());
     }
 
     /**
@@ -179,9 +179,9 @@ public class UnixStyleUsageFormatterTest {
     public void nonexistentCommandShouldThrow() {
         String[] argv = {};
         JCommander jc = JCommander.newBuilder().addObject(new Object()).build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         jc.parse(argv);
-        jc.getUsageFormatter().getCommandDescription("foo");
+        jc.getCommandDescription("foo");
     }
 
     @Test
@@ -190,10 +190,10 @@ public class UnixStyleUsageFormatterTest {
                 .addObject(new ArgsHelp())
                 .resourceBundle(DefaultUsageFormatterTest.getResourceBundle())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         jc.addCommand(new ArgsLongCommandDescription());
         StringBuilder sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         String usage = sb.toString();
         Assert.assertTrue(usage.contains("text"));
     }
@@ -203,8 +203,8 @@ public class UnixStyleUsageFormatterTest {
         JCommander jCommander = JCommander.newBuilder()
                 .addObject(new ArgsMainParameter1())
                 .build();
-        jCommander.setUsageFormatter(new UnixStyleUsageFormatter(jCommander));
-        jCommander.getUsageFormatter().usage(new StringBuilder());
+        jCommander.setUsageFormatter(new UnixStyleUsageFormatter());
+        jCommander.usage(new StringBuilder());
         // Before fix, this parse would throw an exception, because it calls createDescription, which
         // was already called by usage(), and can only be called once.
         jCommander.parse();
@@ -221,9 +221,9 @@ public class UnixStyleUsageFormatterTest {
                 .addObject(new Object[] {argsHelp, new ArgsRequired()})
                 .resourceBundle(DefaultUsageFormatterTest.getResourceBundle())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         // Should be able to display usage without triggering validation
-        jc.getUsageFormatter().usage(new StringBuilder());
+        jc.usage(new StringBuilder());
         try {
             jc.parse("-h");
             Assert.fail("Should have thrown a required parameter exception");
@@ -236,14 +236,14 @@ public class UnixStyleUsageFormatterTest {
     @Test
     public void usageShouldNotChange() {
         JCommander jc = JCommander.newBuilder().addObject(new Args1()).build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         jc.parse("-log", "1");
         StringBuilder sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         String expected = sb.toString();
 
         sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         String actual = sb.toString();
         Assert.assertEquals(actual, expected);
     }
@@ -253,8 +253,8 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(new ArgsOutOfMemory())
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
-        jc.getUsageFormatter().usage(new StringBuilder());
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
+        jc.usage(new StringBuilder());
     }
 
     @Test
@@ -266,12 +266,12 @@ public class UnixStyleUsageFormatterTest {
         Arg args = new Arg();
         String[] argv = {"--help"};
         JCommander jc = JCommander.newBuilder().addObject(args).build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         jc.parse(argv);
 
         StringBuilder sb = new StringBuilder();
 
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
 
         Assert.assertFalse(sb.toString().contains("Default"));
     }
@@ -296,12 +296,12 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(a)
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         jc.addCommand("a", new ArgCommandA());
         jc.addCommand("b", new ArgCommandB());
 
         StringBuilder sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         Assert.assertTrue(sb.toString().contains("[command options]\n  Commands:"));
     }
 
@@ -325,12 +325,12 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(a)
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         jc.addCommand("a", new ArgCommandA());
         jc.addCommand("b", new ArgCommandB());
 
         StringBuilder sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         Assert.assertTrue(sb.toString().contains("command a parameters\n\n    b"));
     }
 
@@ -354,7 +354,7 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(a)
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
         jc.setColumnSize(100);
         jc.addCommand("a", new ArgCommandA());
 
@@ -363,7 +363,7 @@ public class UnixStyleUsageFormatterTest {
         aCommand.addCommand("b", new ArgCommandB());
 
         StringBuilder sb = new StringBuilder();
-        jc.getUsageFormatter().usage(sb);
+        jc.usage(sb);
         Assert.assertTrue(sb.toString().contains("command a parameters\n        Commands:"));
         Assert.assertTrue(sb.toString().contains("command b\n            Usage:"));
     }
@@ -379,8 +379,8 @@ public class UnixStyleUsageFormatterTest {
         JCommander jc = JCommander.newBuilder()
                 .addObject(a)
                 .build();
-        jc.setUsageFormatter(new UnixStyleUsageFormatter(jc));
-        jc.getUsageFormatter().usage(sb);
+        jc.setUsageFormatter(new UnixStyleUsageFormatter());
+        jc.usage(sb);
         Assert.assertTrue(sb.toString().contains("default: <empty string>"));
     }
 }

--- a/src/test/java/com/beust/jcommander/command/CommandAliasTest.java
+++ b/src/test/java/com/beust/jcommander/command/CommandAliasTest.java
@@ -119,15 +119,15 @@ public class CommandAliasTest {
     CommandCommit commit = new CommandCommit();
     jc.addCommand("commit", commit, "ci", "cmt");
     StringBuilder out = new StringBuilder();
-    jc.getUsageFormatter().usage("commit", out);
+    jc.getUsageFormatter().usage(jc, "commit", out);
     patternMatchesTimes("commit\\(ci,cmt\\)", out.toString(), 1);
 
     out = new StringBuilder();
-    jc.getUsageFormatter().usage("ci", out);
+    jc.getUsageFormatter().usage(jc, "ci", out);
     patternMatchesTimes("commit\\(ci,cmt\\)", out.toString(), 1);
 
     out = new StringBuilder();
-    jc.getUsageFormatter().usage("cmt", out);
+    jc.getUsageFormatter().usage(jc, "cmt", out);
     patternMatchesTimes("commit\\(ci,cmt\\)", out.toString(), 1);
   }
 
@@ -138,7 +138,7 @@ public class CommandAliasTest {
     CommandCommit commit = new CommandCommit();
     jc.addCommand("commit", commit, "ci", "cmt");
     StringBuilder out = new StringBuilder();
-    jc.getUsageFormatter().usage(out);
+    jc.getUsageFormatter().usage(jc, out);
     // The usage should display this string twice: one as the command name
     // and one after Usage:
     patternMatchesTimes("commit\\(ci,cmt\\)", out.toString(), 2);
@@ -156,12 +156,12 @@ public class CommandAliasTest {
     CommandCommit commit = new CommandCommit();
     jc.addCommand("commit", commit, "ci", "cmt");
     StringBuilder sb = new StringBuilder();
-    jc.getUsageFormatter().usage(sb);
+    jc.getUsageFormatter().usage(jc, sb);
     System.out.println("--- usage() formatting ---");
     System.out.println(sb.toString());
 
     sb = new StringBuilder();
-    jc.getUsageFormatter().usage("commit", sb);
+    jc.getUsageFormatter().usage(jc, "commit", sb);
     System.out.println("--- usage('commit') formatting ---");
     System.out.println(sb.toString());
   }

--- a/src/test/java/com/beust/jcommander/command/CommandTest.java
+++ b/src/test/java/com/beust/jcommander/command/CommandTest.java
@@ -99,7 +99,7 @@ public class CommandTest {
 
         jc.setProgramName("TestCommander");
         StringBuilder out = new StringBuilder();
-        jc.getUsageFormatter().usage(out);
+        jc.getUsageFormatter().usage(jc, out);
 
         Assert.assertTrue(out.toString().contains("add      Add file contents to the index"));
         Assert.assertFalse(out.toString().contains("hidden      Hidden command to add file contents to the index"));
@@ -114,7 +114,7 @@ public class CommandTest {
 
     jc.setProgramName("TestCommander");
     StringBuilder out = new StringBuilder();
-    jc.getUsageFormatter().usage(out);
+    jc.getUsageFormatter().usage(jc, out);
 
     Assert.assertTrue(out.toString().contains("no-annotation"));
   }
@@ -129,7 +129,7 @@ public class CommandTest {
     jc.addCommand("commit", commit);
     jc.parse("-v", "commit", "--amend", "--author=cbeust", "A.java", "B.java");
     StringBuilder out = new StringBuilder();
-    jc.getUsageFormatter().usage(out);
+    jc.getUsageFormatter().usage(jc, out);
     String firstLine = out.toString().split("\n")[0];
     Assert.assertFalse(firstLine.endsWith(" "), "Usage should not have trailing spaces");
   }

--- a/src/test/java/com/beust/jcommander/dynamic/DynamicParameterTest.java
+++ b/src/test/java/com/beust/jcommander/dynamic/DynamicParameterTest.java
@@ -40,7 +40,7 @@ public class DynamicParameterTest {
     JCommander jc = JCommander.newBuilder()
             .addObject(ds)
             .build();
-    jc.getUsageFormatter().usage(new StringBuilder());
+    jc.getUsageFormatter().usage(jc, new StringBuilder());
   }
 
   public void differentAssignment() {


### PR DESCRIPTION
I was so happy when I found out that JCommander has supported unix-style usage formatting. But when I use it in my project, I am confused about the design of the interface.

```java
JCommander commander = JCommander.newBuilder()
    .setUsageFormatter(new UnixStyleUsageFormatter(/*What should I set here???*/))
    .addObject(options).build();
```

IMO, UsageFormatter should be stateless and should never has a constructor binding to a commander.

Moreover, usage formatter is not inherited by subcommands. So if I set the formatter of root commander to unix-like, `usage()` will output like

```
Usage: <main class> [options] [command] [command options]
  Options:
    [unix style]
  Commands:
    [default style]
```

So I changed almost all methods related to formatter to fix this. 

- [x] Remove field `commander` from DefaultUsageFormatter & UnixStyleUsageFormatter
and adjust IUsageFormatter and its implementations.
- [x] Modify JCommander#setUsageFormatter to set usage formatter for all
subcommands.
- [x] Instantiate subcommand with parent's usage formatter.
- [x] Add @Override annotations on methods inherited from interface or
super class.
- [x] Modify accessibilty of some methods: not every method needs to be
public.
- [x] Revise documents.
- [x] Modify tests.

All tests are passed.