### PR TITLE
Order parameters with the same order by name in usage()

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -179,7 +179,8 @@ public class JCommander {
                 WrappedParameter a0 = p0.getParameter();
                 WrappedParameter a1 = p1.getParameter();
                 if (a0 != null && a0.order() != -1 && a1 != null && a1.order() != -1) {
-                    return Integer.compare(a0.order(), a1.order());
+                    int comp = Integer.compare(a0.order(), a1.order());
+                    return comp != 0 ? comp : p0.getLongestName().compareTo(p1.getLongestName());
                 } else if (a0 != null && a0.order() != -1) {
                     return -1;
                 } else if (a1 != null && a1.order() != -1) {

--- a/src/test/java/com/beust/jcommander/ParameterOrderTest.java
+++ b/src/test/java/com/beust/jcommander/ParameterOrderTest.java
@@ -72,4 +72,32 @@ public class ParameterOrderTest {
     }
     Assert.assertEquals(order, Arrays.asList(expected));
   }
+
+  private static class WithoutOrder {
+    @Parameter(names = "--arg_b")
+    public boolean isB;
+    @Parameter(names = "--arg_c")
+    public boolean isC;
+    @Parameter(names = "--arg_a")
+    public boolean isA;
+  }
+
+  @Test
+  public void parametersWithoutOrder() {
+    testOrder(new WithoutOrder(), "--arg_a", "--arg_b", "--arg_c");
+  }
+
+  private static class WithSameOrder {
+    @Parameter(order=0, names = "--arg_b")
+    public boolean isB;
+    @Parameter(order=0, names = "--arg_c")
+    public boolean isC;
+    @Parameter(order=0, names = "--arg_a")
+    public boolean isA;
+  }
+
+  @Test
+  public void parametersWithSameOrder() {
+    testOrder(new WithSameOrder(), "--arg_a", "--arg_b", "--arg_c");
+  }
 }


### PR DESCRIPTION
Parameters without order are sorted by name, do the same for parameters
with the same order for consistency.