### PR TITLE
Replace arrayOf with array literals in Kotlin sample

### DIFF
--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -1020,10 +1020,10 @@ class Args {
     @Parameter
     var targets: List<String> = arrayListOf()
 
-    @Parameter(names = arrayOf("-bf", "--buildFile"), description = "The build file")
+    @Parameter(names = ["-bf", "--buildFile"], description = "The build file")
     var buildFile: String? = null
 
-    @Parameter(names = arrayOf("--checkVersions"),
+    @Parameter(names = ["--checkVersions"],
                description = "Check if there are any newer versions of the dependencies")
     var checkVersions = false
 }

--- a/doc/index.html
+++ b/doc/index.html
@@ -1987,10 +1987,10 @@ You can do this by subclassing <code>IUsageFormatter</code> and then calling <co
     @Parameter
     var targets: List&lt;String&gt; = arrayListOf()
 
-    @Parameter(names = arrayOf("-bf", "--buildFile"), description = "The build file")
+    @Parameter(names = ["-bf", "--buildFile"], description = "The build file")
     var buildFile: String? = null
 
-    @Parameter(names = arrayOf("--checkVersions"),
+    @Parameter(names = ["--checkVersions"],
                description = "Check if there are any newer versions of the dependencies")
     var checkVersions = false
 }</code></pre>


### PR DESCRIPTION
Kotlin 1.2.20 supports array literals in annotations and it's recommended style.
This change updates docs.