### PR TITLE
439 expand dynamic arg expands non dynamic args

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -495,7 +495,7 @@ public class JCommander {
         for (ParameterDescription pd : descriptions.values()) {
             if (pd.isDynamicParameter()) {
                 for (String name : pd.getParameter().names()) {
-                    if (arg.startsWith(name) && !arg.equals(name)) {
+                    if (arg.startsWith(name) && !arg.equals(name) && arg.contains(pd.getParameter().getAssignment())) {
                         return Arrays.asList(name, arg.substring(name.length()));
                     }
                 }

--- a/src/test/java/com/beust/jcommander/dynamic/DynamicParameterTest.java
+++ b/src/test/java/com/beust/jcommander/dynamic/DynamicParameterTest.java
@@ -3,7 +3,6 @@ package com.beust.jcommander.dynamic;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.internal.Maps;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -54,5 +53,13 @@ public class DynamicParameterTest {
   public static void main(String[] args) {
     DynamicParameterTest dpt = new DynamicParameterTest();
     dpt.simpleWithSpaces();
+  }
+
+  @Test
+  public void shouldNotBreakSimilarParameter() {
+    ShadowingParameter shadowingParameter = new ShadowingParameter();
+    new JCommander(shadowingParameter).parse("-abc", "abc", "-ab", "a=b");
+    Assert.assertEquals(shadowingParameter.abc, "abc");
+    Assert.assertEquals(shadowingParameter.ab.get("a"), "b");
   }
 }

--- a/src/test/java/com/beust/jcommander/dynamic/ShadowingParameter.java
+++ b/src/test/java/com/beust/jcommander/dynamic/ShadowingParameter.java
@@ -1,0 +1,20 @@
+package com.beust.jcommander.dynamic;
+
+import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.Parameter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ShadowingParameter {
+
+    @Parameter(
+            names = "-abc"
+    )
+    String abc;
+    @DynamicParameter(
+            names = "-ab"
+    )
+    Map<String,String> ab = new HashMap<>();
+
+}


### PR DESCRIPTION
fixes issue #439 

When looking the names loop wasn't duplicated in any validating fashion.
So adding a handlesArg method wouldn't improve anything.
Extracting a method might have been nice, but it would require three arguments.