### PR TITLE
bad example for main_parameter

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1380,7 +1380,7 @@ private Integer debug = 1;</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="prettyprint highlight"><code class="language-bash" data-lang="bash">$ java Main -debug file1 file2</code></pre>
+<pre class="prettyprint highlight"><code class="language-bash" data-lang="bash">$ java Main -debug 2 file1 file2</code></pre>
 </div>
 </div>
 <div class="paragraph">


### PR DESCRIPTION
Given that the type of 'debug' is Integer, the parameter needs a value, no?

alternative way to fix this is to change line 1375 into `private boolean debug = false;`