### PR TITLE
Fix usage() for missing description on commands

### DIFF
--- a/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
@@ -254,7 +254,10 @@ public class DefaultUsageFormatter implements IUsageFormatter {
             if (p == null || !p.hidden()) {
                 JCommander.ProgramName progName = commands.getKey();
                 String dispName = progName.getDisplayName();
-                String description = indent + s(4) + dispName + s(6) + getCommandDescription(progName.getName());
+                String commandDescription = Optional.ofNullable(getCommandDescription(progName.getName()))
+                    .map(desc -> s(6) + desc)
+                    .orElse("");
+                String description = indent + s(4) + dispName + commandDescription;
                 wrapDescription(out, indentCount + descriptionIndent, description);
                 out.append("\n");
 


### PR DESCRIPTION
Before this commit, if you supply a command to a JCommander object
and you dont supply a description for the command, then when calling
usage() you will see a line of the following format:
"\<command-name\>      null"

After this commit the string literal "null" will be omitted from the
usage() call if you do not supply a description for the command.

Fixes #480