### PR TITLE
Fix PositiveInteger validator to reject 0

### DIFF
--- a/src/main/java/com/beust/jcommander/validators/PositiveInteger.java
+++ b/src/main/java/com/beust/jcommander/validators/PositiveInteger.java
@@ -31,7 +31,7 @@ public class PositiveInteger implements IParameterValidator {
   public void validate(String name, String value)
       throws ParameterException {
     int n = Integer.parseInt(value);
-    if (n < 0) {
+    if (!(n>0)) {
       throw new ParameterException("Parameter " + name
           + " should be positive (found " + value +")");
     }


### PR DESCRIPTION
My sense is that the math / software community - in both technical and common use - has settled on the term "positive integer" as excluding 0.

@cbeust - do you disagree that this is the case?  

this commit fixes #438