### PR TITLE
Improve support for collections on default values

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -777,8 +777,10 @@ For example, here is a default provider that will assign a default value of 42 f
 ----
 private static final IDefaultProvider DEFAULT_PROVIDER = new IDefaultProvider() {
   @Override
-  public String getDefaultValueFor(String optionName) {
-    return "-debug".equals(optionName) ? "false" : "42";
+  public List<String> getDefaultValueFor(String optionName) {
+    final List<String> result = new ArrayList<>();
+    result.add("-debug".equals(optionName) ? "false" : "42");
+    return result;
   }
 };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1697,8 +1697,10 @@ private String host;</code></pre>
 <div class="content">
 <pre class="prettyprint highlight"><code class="language-java" data-lang="java">private static final IDefaultProvider DEFAULT_PROVIDER = new IDefaultProvider() {
   @Override
-  public String getDefaultValueFor(String optionName) {
-    return "-debug".equals(optionName) ? "false" : "42";
+  public List<String> getDefaultValueFor(String optionName) {
+    final List<String> result = new ArrayList<>();
+    result.add("-debug".equals(optionName) ? "false" : "42");
+    return result;
   }
 };
 

--- a/docs/old-index.html
+++ b/docs/old-index.html
@@ -654,8 +654,10 @@ For example, here is a default provider that will assign a default value of 42 f
 <pre class="brush: java">
 private static final IDefaultProvider DEFAULT_PROVIDER = new IDefaultProvider() {
   @Override
-  public String getDefaultValueFor(String optionName) {
-    return "-debug".equals(optionName) ? "false" : "42";
+  public List<String> getDefaultValueFor(String optionName) {
+    final List<String> result = new ArrayList<>();
+    result.add("-debug".equals(optionName) ? "false" : "42");
+    return result;
   }
 };
 

--- a/src/main/java/com/beust/jcommander/IDefaultProvider.java
+++ b/src/main/java/com/beust/jcommander/IDefaultProvider.java
@@ -18,6 +18,8 @@
 
 package com.beust.jcommander;
 
+import java.util.List;
+
 /**
  * Allows the specification of default values.
  * 
@@ -31,5 +33,5 @@ public interface IDefaultProvider {
    * 
    * @return the default value for this option.
    */
-  String getDefaultValueFor(String optionName);
+  List<String> getDefaultValueFor(String optionName);
 }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -666,13 +666,17 @@ public class JCommander {
 
     private void initializeDefaultValue(ParameterDescription pd) {
         for (String optionName : pd.getParameter().names()) {
-            String def = options.defaultProvider.getDefaultValueFor(optionName);
-            if (def != null) {
-                p("Initializing " + optionName + " with default value:" + def);
-                pd.addValue(def, true /* default */);
-                // remove the parameter from the list of fields to be required
-                requiredFields.remove(pd.getParameterized());
-                return;
+            List<String> defs = options.defaultProvider.getDefaultValueFor(optionName);
+            if (defs != null) {
+                for (String def : defs) {
+                    if (def != null) {
+                        p("Initializing " + optionName + " with default value:" + def);
+                        pd.addValue(def, true /* default */);
+                        // remove the parameter from the list of fields to be required
+                        requiredFields.remove(pd.getParameterized());
+                        return;
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/beust/jcommander/defaultprovider/EnvironmentVariableDefaultProvider.java
+++ b/src/main/java/com/beust/jcommander/defaultprovider/EnvironmentVariableDefaultProvider.java
@@ -20,6 +20,8 @@ package com.beust.jcommander.defaultprovider;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -83,21 +85,27 @@ public final class EnvironmentVariableDefaultProvider implements IDefaultProvide
     }
 
     @Override
-    public final String getDefaultValueFor(final String optionName) {
+    public final List<String> getDefaultValueFor(final String optionName) {
+        final List<String> result = new ArrayList<>();
+
         if (this.environmentVariableValue == null)
-            return null;
+            return result;
         final Matcher matcher = Pattern
                 .compile("(?:(?:.*\\s+)|(?:^))(" + Pattern.quote(optionName) + ")\\s*((?:'[^']*(?='))|(?:\"[^\"]*(?=\"))|(?:[^" + this.optionPrefixesPattern + "\\s]+))?.*")
                 .matcher(this.environmentVariableValue);
         if (!matcher.matches())
-            return null;
+            return result;
         String value = matcher.group(2);
-        if (value == null)
-            return "true";
+        if (value == null) {
+            result.add("true");
+            return result;
+        }
         final char firstCharacter = value.charAt(0);
         if (firstCharacter == '\'' || firstCharacter == '"')
-            value = value.substring(1);
-        return value;
+            result.add(value.substring(1));
+
+
+        return result;
     }
 
 }

--- a/src/main/java/com/beust/jcommander/defaultprovider/PropertyFileDefaultProvider.java
+++ b/src/main/java/com/beust/jcommander/defaultprovider/PropertyFileDefaultProvider.java
@@ -23,6 +23,8 @@ import com.beust.jcommander.ParameterException;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -57,14 +59,20 @@ public class PropertyFileDefaultProvider implements IDefaultProvider {
       throw new ParameterException("Could not open property file: " + fileName);
     }
   }
-  
-  public String getDefaultValueFor(String optionName) {
+
+  @Override
+  public final List<String> getDefaultValueFor(final String optionName) {
+    final List<String> result = new ArrayList<>();
+
     int index = 0;
     while (index < optionName.length() && ! Character.isLetterOrDigit(optionName.charAt(index))) {
       index++;
     }
     String key = optionName.substring(index);
-    return properties.getProperty(key);
+
+    result.add(properties.getProperty(key));
+
+    return result;
   }
 
 }

--- a/src/test/java/com/beust/jcommander/DefaultProviderTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultProviderTest.java
@@ -24,11 +24,16 @@ import com.beust.jcommander.defaultprovider.PropertyFileDefaultProvider;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DefaultProviderTest {
   private static final IDefaultProvider DEFAULT_PROVIDER = new IDefaultProvider() {
 
-    public String getDefaultValueFor(String optionName) {
-      return "-debug".equals(optionName) ? "false" : "42";
+    public List<String> getDefaultValueFor(String optionName) {
+      final List<String> result = new ArrayList<>();
+      result.add("-debug".equals(optionName) ? "false" : "42");
+      return result;
     }
     
   };
@@ -125,8 +130,10 @@ public class DefaultProviderTest {
     }
 
     IDefaultProvider defaultProvider = new IDefaultProvider() {
-      public String getDefaultValueFor(String optionName) {
-        return "-log".equals(optionName) ? "1" : "";
+      public List<String> getDefaultValueFor(String optionName) {
+        final List<String> result = new ArrayList<>();
+        result.add("-log".equals(optionName) ? "1" : "");
+        return result;
       }
     };
 

--- a/src/test/java/com/beust/jcommander/defaultprovider/EnvironmentVariableDefaultProviderTest.java
+++ b/src/test/java/com/beust/jcommander/defaultprovider/EnvironmentVariableDefaultProviderTest.java
@@ -36,11 +36,11 @@ public final class EnvironmentVariableDefaultProviderTest {
 		final IDefaultProvider defaultProvider = new EnvironmentVariableDefaultProvider(null, "-", variableResolver);
 
 		// when
-		final String nonExistentValue = defaultProvider.getDefaultValueFor("--non-existent-option");
-		final String someOption = defaultProvider.getDefaultValueFor("--some-option");
-		final String simpleValue = defaultProvider.getDefaultValueFor("--simple-value");
-		final String quotedValue = defaultProvider.getDefaultValueFor("--quoted-value");
-		final String doubleQuotedValue = defaultProvider.getDefaultValueFor("--double-quoted-value");
+		final String nonExistentValue = defaultProvider.getDefaultValueFor("--non-existent-option").get(0);
+		final String someOption = defaultProvider.getDefaultValueFor("--some-option").get(0);
+		final String simpleValue = defaultProvider.getDefaultValueFor("--simple-value").get(0);
+		final String quotedValue = defaultProvider.getDefaultValueFor("--quoted-value").get(0);
+		final String doubleQuotedValue = defaultProvider.getDefaultValueFor("--double-quoted-value").get(0);
 
 		// then
 		assertNull(nonExistentValue);


### PR DESCRIPTION
The previous interface for ´IDefaultProvider´ assumes that defaults have been represented as a String. Although this is ok for most cases, with Lists the String approach becomes harder to guarantee (e.g. unescaped split on comma) and with Maps it's not even supported.
By having the ´IDefaultProvider´ return a List instead of a plain String simplifies the representation of default values for Lists (e.g. clean object `[1, 2]` instead of CSV String `1,2`) and allows the representation of Maps (e.g. String `a=b`).