### PR TITLE
Avoid duplicates on default initialization

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -359,7 +359,7 @@ public class JCommander {
 
     private void initializeDefaultValues() {
         if (options.defaultProvider != null) {
-            for (ParameterDescription pd : descriptions.values()) {
+            for (ParameterDescription pd : new HashSet<>(descriptions.values())) {
                 initializeDefaultValue(pd);
             }
 


### PR DESCRIPTION
Parameters are repeatedly added to the internal state of ´JCommander´ for each alias/name and when fetching defaults values they need to be deduplicated to avoid retrieving the default value multiple times. Although with most parameter types the duplicate fetching would not be a problem (e.g. it would just override itself), with cumulative types such as Lists is actually causes the duplication of content.