### PR TITLE
Gradle warning: use testImplementation instead of testCompile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ plugins {
 
 dependencies {
     listOf("org.testng:testng:7.0.0")
-        .forEach { testCompile(it) }
+        .forEach { testImplementation(it) }
 }
 
 //


### PR DESCRIPTION
Gradle warns about the use of the deprecated `testCompile`:

```
./gradlew --warning-mode all clean build

> Configure project :
The testCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testImplementation configuration instead.
        at Build_gradle$4.invoke(build.gradle.kts:63)
```

This PR changes the use of `testCompile` to `testImplementation`.