### PR TITLE
deprecation warning: use @Parameters instead of @MessageBundle

### DIFF
--- a/src/test/java/com/beust/jcommander/args/ArgsI18N2.java
+++ b/src/test/java/com/beust/jcommander/args/ArgsI18N2.java
@@ -19,10 +19,9 @@
 package com.beust.jcommander.args;
 
 import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ResourceBundle;
+import com.beust.jcommander.Parameters;
 
-@SuppressWarnings("deprecation")
-@ResourceBundle("MessageBundle")
+@Parameters(resourceBundle = "MessageBundle")
 public class ArgsI18N2 {
 
   @Parameter(names = "-host", description = "Host", descriptionKey = "host")


### PR DESCRIPTION
The use of `@MessageBundle` is deprecated, `@Parameters` should be used instead.

This PR fixes this in a single unit test.