### PR TITLE
Add capability to set Parameterized Parser at runtime.

### DIFF
--- a/src/main/java/com/beust/jcommander/IParameterizedParser.java
+++ b/src/main/java/com/beust/jcommander/IParameterizedParser.java
@@ -1,0 +1,20 @@
+package com.beust.jcommander;
+
+import java.util.List;
+
+/**
+ *
+ * @author Tim Gallagher
+ */
+public interface IParameterizedParser {
+  
+  /**
+   * Parses the given object for any command line related annotations and returns the list of 
+   * JCommander Parameterized definitions.
+   * 
+   * @param arg the object that contains the annotations.
+   * @return non-null List but may be empty
+   */
+  List<Parameterized> parseArg(Object arg);
+  
+}

--- a/src/main/java/com/beust/jcommander/IParameterizedParser.java
+++ b/src/main/java/com/beust/jcommander/IParameterizedParser.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 /**
  * Thin interface allows the Parameterized parsing mechanism, which reflects an object to find the 
- * JCommander annotations, to be replaced at runtime for cases where the source code can not
+ * JCommander annotations, to be replaced at runtime for cases where the source code cannot
  * be directly annotated with JCommander annotations, but may have other annotations such as 
  * Json annotations that can be used to reflect as JCommander parameters.
  *

--- a/src/main/java/com/beust/jcommander/IParameterizedParser.java
+++ b/src/main/java/com/beust/jcommander/IParameterizedParser.java
@@ -3,6 +3,10 @@ package com.beust.jcommander;
 import java.util.List;
 
 /**
+ * Thin interface allows the Parameterized parsing mechanism, which reflects an object to find the 
+ * JCommander annotations, to be replaced at runtime for cases where the source code can not
+ * be directly annotated with JCommander annotations, but may have other annotations such as 
+ * Json annotations that can be used to reflect as JCommander parameters.
  *
  * @author Tim Gallagher
  */
@@ -12,9 +16,9 @@ public interface IParameterizedParser {
    * Parses the given object for any command line related annotations and returns the list of 
    * JCommander Parameterized definitions.
    * 
-   * @param arg the object that contains the annotations.
+   * @param annotatedObj the object that contains the annotations.
    * @return non-null List but may be empty
    */
-  List<Parameterized> parseArg(Object arg);
+  List<Parameterized> parseArg(Object annotatedObj);
   
 }

--- a/src/main/java/com/beust/jcommander/IParameterizedParser.java
+++ b/src/main/java/com/beust/jcommander/IParameterizedParser.java
@@ -6,7 +6,7 @@ import java.util.List;
  * Thin interface allows the Parameterized parsing mechanism, which reflects an object to find the 
  * JCommander annotations, to be replaced at runtime for cases where the source code cannot
  * be directly annotated with JCommander annotations, but may have other annotations such as 
- * Json annotations that can be used to reflect as JCommander parameters.
+ * JSON annotations that can be used to reflect as JCommander parameters.
  *
  * @author Tim Gallagher
  */

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -18,6 +18,7 @@
 
 package com.beust.jcommander;
 
+import com.beust.jcommander.parser.DefaultParameterizedParser;
 import com.beust.jcommander.FuzzyMap.IKey;
 import com.beust.jcommander.converters.*;
 import com.beust.jcommander.internal.*;
@@ -46,6 +47,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class JCommander {
     public static final String DEBUG_PROPERTY = "jcommander.debug";
+    
+    protected IParameterizedParser parameterizedParser = new DefaultParameterizedParser();
 
     /**
      * A map to look up parameter description per option name.
@@ -264,6 +267,10 @@ public class JCommander {
         parse(args);
     }
 
+  public void setParameterizedParser(IParameterizedParser parameterizedParser) {
+    this.parameterizedParser = parameterizedParser;
+  }    
+    
     /**
      * Disables expanding {@code @file}.
      *
@@ -598,7 +605,7 @@ public class JCommander {
     private void addDescription(Object object) {
         Class<?> cls = object.getClass();
 
-        List<Parameterized> parameterizeds = Parameterized.parseArg(object);
+        List<Parameterized> parameterizeds = this.parameterizedParser.parseArg(object);
         for (Parameterized parameterized : parameterizeds) {
             WrappedParameter wp = parameterized.getWrappedParameter();
             if (wp != null && wp.getParameter() != null) {

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -605,7 +605,7 @@ public class JCommander {
     private void addDescription(Object object) {
         Class<?> cls = object.getClass();
 
-        List<Parameterized> parameterizeds = this.parameterizedParser.parseArg(object);
+        List<Parameterized> parameterizeds = parameterizedParser.parseArg(object);
         for (Parameterized parameterized : parameterizeds) {
             WrappedParameter wp = parameterized.getWrappedParameter();
             if (wp != null && wp.getParameter() != null) {

--- a/src/main/java/com/beust/jcommander/parser/DefaultParameterizedParser.java
+++ b/src/main/java/com/beust/jcommander/parser/DefaultParameterizedParser.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.beust.jcommander.parser;
 
 import com.beust.jcommander.IParameterizedParser;
@@ -10,14 +5,22 @@ import com.beust.jcommander.Parameterized;
 import java.util.List;
 
 /**
+ * Pulled from the JCommander where is reflects the object to determine the Parameter annotations.
  *
  * @author Tim Gallagher
  */
 public class DefaultParameterizedParser implements IParameterizedParser {
 
+  /**
+  * Wraps the default parser. 
+  *
+  * @param annotatedObj an instance of the object with Parameter related annotations.
+  *
+  * @author Tim Gallagher
+  */
   @Override
-  public List<Parameterized> parseArg(Object arg) {
-    return Parameterized.parseArg(arg);
+  public List<Parameterized> parseArg(Object annotatedObj) {
+    return Parameterized.parseArg(annotatedObj);
   }
   
 }

--- a/src/main/java/com/beust/jcommander/parser/DefaultParameterizedParser.java
+++ b/src/main/java/com/beust/jcommander/parser/DefaultParameterizedParser.java
@@ -1,0 +1,23 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.beust.jcommander.parser;
+
+import com.beust.jcommander.IParameterizedParser;
+import com.beust.jcommander.Parameterized;
+import java.util.List;
+
+/**
+ *
+ * @author Tim Gallagher
+ */
+public class DefaultParameterizedParser implements IParameterizedParser {
+
+  @Override
+  public List<Parameterized> parseArg(Object arg) {
+    return Parameterized.parseArg(arg);
+  }
+  
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/JsonAnnotationParameterizedParser.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/JsonAnnotationParameterizedParser.java
@@ -243,12 +243,12 @@ public class JsonAnnotationParameterizedParser implements IParameterizedParser {
   /**
    * Basic check for primitive or Java class that should be used directly.
    * 
-   * @param field
+   * @param field non-null java Field
    * @return true if Java primitive or part of the Java or Sun package.
    */
   public boolean isPrimitiveOrString(Field field) {
-    final Class type = field.getType();
-    final String name = type.getName();
+    Class type = field.getType();
+    String name = type.getName();
 
     return type.isPrimitive() || name.startsWith("java") || name.startsWith("sun");
   }

--- a/src/test/java/com/beust/jcommander/parameterized/parser/JsonAnnotationParameterizedParser.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/JsonAnnotationParameterizedParser.java
@@ -1,0 +1,256 @@
+package com.beust.jcommander.parameterized.parser;
+
+import com.beust.jcommander.IParameterizedParser;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameterized;
+import com.beust.jcommander.ParametersDelegate;
+import com.beust.jcommander.WrappedParameter;
+import com.beust.jcommander.converters.CommaParameterSplitter;
+import com.beust.jcommander.converters.NoConverter;
+import com.beust.jcommander.internal.Sets;
+import com.beust.jcommander.validators.NoValidator;
+import com.beust.jcommander.validators.NoValueValidator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import sun.reflect.annotation.AnnotationParser;
+
+/**
+ * Provides building JCommander Parameters based on @ComponentInput and @ComponentConfiguration as
+ * opposed to using JCommander @Parameter.
+ *
+ * @author Cedric Beust <cedric@beust.com>
+ * @author Tim Gallagher
+ */
+public class JsonAnnotationParameterizedParser implements IParameterizedParser {
+
+  public static final String PREFIX_MARKER = "prefix:";
+
+  /**
+   * This is the standard prefix like "--" or "-"
+   */
+  protected final String paramPrefix;
+
+  /**
+   * When a class has a member class and is annotated with JsonProperty, then there couple be fields
+   * that are the same name, for example 'version'. This map allows the parser to define a Parameter
+   * with a prefix in order to avoid the collision.
+   */
+  protected final Map<Class, String> classPrefixes = new HashMap<>();
+
+  /**
+   * This used in auto generation of the prefixes from the JsonDescription. If this, prefix
+   * separator value is not in the descriptions prefix definition, then it will be added. The
+   * default is '.'
+   */
+  protected String prefixSeparator = ".";
+
+  public JsonAnnotationParameterizedParser() {
+    this("");
+  }
+
+  public JsonAnnotationParameterizedParser(String paramPrefix) {
+    this.paramPrefix = paramPrefix;
+  }
+
+  public void addClassPrefix(Class clazz, String prefix) {
+    this.classPrefixes.put(clazz, prefix);
+  }
+
+  public void setPrefixSeparator(String separator) {
+    this.prefixSeparator = separator == null ? "" : separator;
+  }
+
+  /**
+   * Recursive handler for describing the set of classes while using the setOfClasses parameter as a
+   * collector
+   *
+   * @param inputClass the class to analyze
+   * @param setOfClasses the set collector to collect the results
+   */
+  private void describeClassTree(Class<?> inputClass, Set<Class<?>> setOfClasses) {
+    // can't map null class
+    if (inputClass == null) {
+      return;
+    }
+
+    // don't further analyze a class that has been analyzed already
+    if (Object.class.equals(inputClass) || setOfClasses.contains(inputClass)) {
+      return;
+    }
+
+    // add to analysis set
+    setOfClasses.add(inputClass);
+
+    // perform super class analysis
+    describeClassTree(inputClass.getSuperclass(), setOfClasses);
+
+    // perform analysis on interfaces
+    for (Class<?> hasInterface : inputClass.getInterfaces()) {
+      describeClassTree(hasInterface, setOfClasses);
+    }
+  }
+
+  /**
+   * Given an object return the set of classes that it extends or implements.
+   *
+   * @param arg object to describe
+   * @return set of classes that are implemented or extended by that object
+   */
+  private Set<Class<?>> describeClassTree(Class<?> inputClass) {
+    if (inputClass == null) {
+      return Collections.emptySet();
+    }
+
+    // create result collector
+    Set<Class<?>> classes = Sets.newLinkedHashSet();
+
+    // describe tree
+    describeClassTree(inputClass, classes);
+
+    return classes;
+  }
+
+  @Override
+  public List<Parameterized> parseArg(Object arg) {
+    List<Parameterized> result = Parameterized.parseArg(arg);
+
+    Class<?> rootClass = arg.getClass();
+
+    // get the list of types that are extended or implemented by the root class
+    // and all of its parent types
+    Set<Class<?>> types = describeClassTree(rootClass);
+
+    // analyze each type
+    for (Class<?> curClazz : types) {
+      // check fields
+      for (Field field : curClazz.getDeclaredFields()) {
+        JsonProperty fieldAnnotation = (JsonProperty) field.getAnnotation(JsonProperty.class);
+        JsonPropertyDescription descrAnnotation = (JsonPropertyDescription) field.getAnnotation(JsonPropertyDescription.class);
+        MyDelegate myDelegate = (MyDelegate) field.getAnnotation(MyDelegate.class);
+        if (fieldAnnotation != null) {         
+          // this is a map of annotation field names uses to create the Parameter annotation 
+          // at runtime
+          Map<String, Object> map = new HashMap<>();
+
+          /*
+          * For primitive and their derived types, we can use the Parameter annotation, but for
+          * other user classes, we need to add a delegate
+           */
+          if (isPrimitiveOrString(field) || myDelegate == null) {
+            /*
+            * create standard Parameter
+             */
+            String name = fieldAnnotation.value();
+            map.put("names", new String[]{name});
+            map.put("required", fieldAnnotation.required());
+            map.put("descriptionKey", "");
+            // all variable types, even Boolean require 1 following parameter.
+            //if (field.getType() == Boolean.class || field.getType() == boolean.class) {
+            map.put("arity", 1);
+            map.put("variableArity", (field.getType() == List.class));
+            map.put("password", false);
+            map.put("converter", NoConverter.class);
+            map.put("listConverter", NoConverter.class);
+            map.put("hidden", false);
+            map.put("validateWith", new Class[]{NoValidator.class});
+            map.put("validateValueWith", new Class[]{NoValueValidator.class});
+            map.put("splitter", CommaParameterSplitter.class);
+            map.put("echoInput", true);
+            map.put("help", false);
+            map.put("forceNonOverwritable", false);
+            map.put("order", -1);
+            map.put("description", descrAnnotation != null ? descrAnnotation.value() : "");
+
+            Parameter param = (Parameter) AnnotationParser.annotationForMap(Parameter.class, map);
+            result.add(new Parameterized(new WrappedParameter(param), null, field, null));
+          } else {
+            /*
+            * Create ParametersDelegate
+             */
+            ParametersDelegate param = (ParametersDelegate) AnnotationParser.annotationForMap(ParametersDelegate.class, map);
+            result.add(new Parameterized(null, param, field, null));
+          }
+        }
+      }
+
+      /*
+      * This section would be for completeness and although it is not tested it is left here
+      * as a template to use the JsonSetter (or JsonGetter) methods as ways to define parameters
+      * at runtime.
+      */
+//      // check methods
+//      for (Method method : curClazz.getDeclaredMethods()) {
+//        // these only work on setMethods
+//        if (!method.getName().startsWith("set")) {
+//          continue;
+//        }
+//
+//        JsonSetter jsonSetterAnnotation = (JsonSetter) method.getAnnotation(JsonSetter.class);
+//        if (jsonSetterAnnotation != null) {
+//          Map<String, Object> map = new HashMap<String, Object>();
+//
+//          /*
+//          * For primitive and their derived types, we can use the Parameter annotation, but for
+//          * other user classes, we need to add a delegate
+//           */
+// /*
+//            * create standard Parameter
+//           */
+//          String name = jsonSetterAnnotation.value();
+//          map.put("names", new String[]{name});
+//          map.put("required", false);
+//          //
+//          // TODO SET THE DEFAULT VALUE BASED ON THE values() OR valuesEnum()
+//          // map.put("default", annotation.defaultValue());
+//          //
+//          map.put("descriptionKey", "");
+//          // get the parameter type
+//          Class[] paramTypes = method.getParameterTypes();
+//          // there should only be one for a 
+//          // all variable types, even Boolean require 1 following parameter.
+//          //if (paramTypes[0] == Boolean.class || paramTypes[0] == boolean.class) {
+//          map.put("arity", 1);
+//          //} 
+//          map.put("variableArity", (paramTypes[0] == List.class));
+//          map.put("password", false);
+//          map.put("converter", NoConverter.class);
+//          map.put("listConverter", NoConverter.class);
+//          map.put("hidden", false);
+//          map.put("validateWith", new Class[]{NoValidator.class});
+//          map.put("validateValueWith", new Class[]{NoValueValidator.class});
+//          map.put("splitter", CommaParameterSplitter.class);
+//          map.put("echoInput", true);
+//          map.put("help", false);
+//          map.put("forceNonOverwritable", false);
+//          map.put("order", -1);
+//          map.put("description", "");
+//
+//          Parameter param = (Parameter) AnnotationParser.annotationForMap(Parameter.class, map);
+//          result.add(new Parameterized(new WrappedParameter(param), null, null, method));
+//        }
+//      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Basic check for primitive or Java class that should be used directly.
+   * 
+   * @param field
+   * @return true if Java primitive or part of the Java or Sun package.
+   */
+  public boolean isPrimitiveOrString(Field field) {
+    final Class type = field.getType();
+    final String name = type.getName();
+
+    return type.isPrimitive() || name.startsWith("java") || name.startsWith("sun");
+  }
+
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/JsonCommandClassExample_01.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/JsonCommandClassExample_01.java
@@ -1,0 +1,47 @@
+package com.beust.jcommander.parameterized.parser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * This is an arbitrary class to test Parameter values using JSON annotations instead with 
+ * JCommander annotations.
+ *
+ * @author Tim Gallagher
+ */
+public class JsonCommandClassExample_01 {
+
+  public static final String PARAM_VERSION = "version";
+
+  /**
+   * In this example, the JsonProperty annotation does not include enough values to allow us to
+   * indicate a delegated object for JCommander, as the JCommander annotations do.  
+   * However, because the object is not a java.lang or other Java supplied objects, we can assumed 
+   * it is delegated.
+   * 
+   * A more precise way to do this, is to introduce new annotation, MyDelegate in this case,
+   * to simulate JCommander but does not require JCommander for your low level libraries. 
+   * For example, lets say you have a REST component, you could use the JsonProperty and other 
+   * JSON annotations for that service, but add a new annotation so that when you want to pull 
+   * that service component out and into a command line app, you could use that new Annotation
+   * within the context of JCommander.  Here we use a very simple MyDelegate.  But there is no
+   * reason why you can't add more data to it.
+   */
+  @JsonProperty(
+    value = "subCommands"
+  )
+  @MyDelegate
+  public final JsonCommandClassExample_02 subCommands = new JsonCommandClassExample_02();
+
+  /**
+   * In this example, the JsonProperty does not have any description, but there is a 
+   * JsonPropertyDescription annotation that we can take advantage of.
+   */
+  @JsonProperty(
+    value = PARAM_VERSION,
+    required = true
+  )
+  @JsonPropertyDescription("Version of the software to run. eg. \"v38.1.0\"")
+  public String version;
+
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/JsonCommandClassExample_02.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/JsonCommandClassExample_02.java
@@ -1,0 +1,26 @@
+package com.beust.jcommander.parameterized.parser;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This is an arbitrary class to test Parameter values using JSON annotations instead with 
+ * JCommander annotations.
+ *
+ * @author Tim Gallagher
+ */
+public class JsonCommandClassExample_02 {
+
+  public static final String PARAM_STACK_LEVEL = "stackLevel";
+  public static final String PARAM_LOG_LEVEL = "logLevel";
+  
+  @JsonProperty(
+    value = PARAM_STACK_LEVEL
+  )  
+  public int stackLevel;
+  
+  @JsonProperty(
+    value = PARAM_LOG_LEVEL
+  )  
+  public String loggingLevel;
+
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/MyDelegate.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/MyDelegate.java
@@ -1,0 +1,18 @@
+package com.beust.jcommander.parameterized.parser;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is really just a marker with no value to set since the delegated value is true.
+ *
+ * @author Tim Gallagher
+ */
+@Target({ ElementType.FIELD,})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MyDelegate {
+  public boolean delegated() default true;
+  
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
@@ -1,0 +1,89 @@
+package com.beust.jcommander.parameterized.parser;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import com.beust.jcommander.Parameterized;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+
+/**
+ * Tests the Parameterized parser for substituting the original parser looking go @Parameter
+ * but can be replaced to look for other annotations that define run-time parameters.
+ *
+ * @author Tim Gallagher
+ */
+public class ParameterizedParserTest {
+  
+  static final String EXPECTED_VERSION = "v380.1.0";
+  static final int EXPECTED_STACK_LEVEL = 5;
+  static final String EXPECTED_LOG_LEVEL = "DEBUG";
+  static final String[] ARGS = new String[] { "version", EXPECTED_VERSION, 
+    "stackLevel", Integer.toString(EXPECTED_STACK_LEVEL), 
+    "logLevel", EXPECTED_LOG_LEVEL };
+
+  static final Map<String, Boolean> EXPECTED_MAP = new HashMap<>();
+  static {
+    EXPECTED_MAP.put(StandardCommandClassExample_01.PARAM_VERSION, Boolean.FALSE);
+    EXPECTED_MAP.put(StandardCommandClassExample_02.PARAM_STACK_LEVEL, Boolean.FALSE);
+    EXPECTED_MAP.put(StandardCommandClassExample_02.PARAM_LOG_LEVEL, Boolean.FALSE);
+  }
+
+  public ParameterizedParserTest() {
+  }
+
+  /**
+   * This test ensures that the additional IParameterizedParser does not break
+   * current functionality.
+   */
+  @Test
+  public void standardParameterizedParsingTest() {
+    StandardCommandClassExample_01 commandOptions = new StandardCommandClassExample_01();
+    
+    JCommander jcommander = new JCommander(commandOptions);
+    
+    testFields(jcommander, EXPECTED_MAP);
+
+    jcommander.parse(ARGS);
+    Assert.assertTrue(EXPECTED_VERSION.equals(commandOptions.version), "Version is not " + EXPECTED_VERSION);
+    Assert.assertTrue(EXPECTED_STACK_LEVEL == commandOptions.subCommands.stackLevel, "Stack level field is not" + EXPECTED_STACK_LEVEL);
+    Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
+  }
+  
+  @Test
+  public void jsonParameterizedParsingTest() {
+    JsonCommandClassExample_01 commandOptions = new JsonCommandClassExample_01();
+    
+    JCommander jcommander = new JCommander();
+    jcommander.setParameterizedParser(new JsonAnnotationParameterizedParser());
+    jcommander.addObject(commandOptions);
+    
+    testFields(jcommander, EXPECTED_MAP);
+
+    jcommander.parse(ARGS);
+    Assert.assertTrue(EXPECTED_VERSION.equals(commandOptions.version), "Version is not " + EXPECTED_VERSION);
+    Assert.assertTrue(EXPECTED_STACK_LEVEL == commandOptions.subCommands.stackLevel, "Stack level field is not" + EXPECTED_STACK_LEVEL);
+    Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
+  }
+  
+  
+  public void testFields(JCommander jcommander, Map<String, Boolean> expectedMap) {
+    Map<Parameterized,ParameterDescription> fields = jcommander.getFields();
+
+    Collection<ParameterDescription> paramDescs = fields.values();
+    for (ParameterDescription paramDesc : paramDescs) {
+      Assert.assertTrue(expectedMap.containsKey(paramDesc.getNames()), "Parameter not in the expected: " + paramDesc.getNames());
+      expectedMap.put(paramDesc.getNames(), Boolean.TRUE);
+    }
+    
+    Assert.assertTrue(expectedMap.containsKey(StandardCommandClassExample_01.PARAM_VERSION), "Version field not found");
+    Assert.assertTrue(expectedMap.containsKey(StandardCommandClassExample_02.PARAM_STACK_LEVEL), "Stack level field not found");
+    Assert.assertTrue(expectedMap.containsKey(StandardCommandClassExample_02.PARAM_LOG_LEVEL), "Log level field not found");
+    
+    
+  }  
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/StandardCommandClassExample_01.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/StandardCommandClassExample_01.java
@@ -1,0 +1,25 @@
+package com.beust.jcommander.parameterized.parser;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+
+/**
+ * This is an arbitrary class to test Parameter values using standard JCommander annotations.
+ *
+ * @author Tim Gallagher
+ */
+public class StandardCommandClassExample_01 {
+
+  public static final String PARAM_VERSION = "version";
+  
+  @ParametersDelegate
+  public final StandardCommandClassExample_02 subCommands = new StandardCommandClassExample_02();
+
+  @Parameter(
+    names = { PARAM_VERSION },
+    description = "Version of the software to run. eg. \"v38.1.0\"",
+    required = true
+  )
+  public String version;
+
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/StandardCommandClassExample_02.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/StandardCommandClassExample_02.java
@@ -1,0 +1,27 @@
+package com.beust.jcommander.parameterized.parser;
+
+import com.beust.jcommander.Parameter;
+
+/**
+ * This is an arbitrary class to test Parameter values using standard JCommander annotations.
+ *
+ * @author Tim Gallagher
+ */
+public class StandardCommandClassExample_02 {
+
+  public static final String PARAM_STACK_LEVEL = "stackLevel";
+  public static final String PARAM_LOG_LEVEL = "logLevel";
+  
+  @Parameter(
+    names = {PARAM_STACK_LEVEL},
+    description = "When reporting an error, how many lines of stack trace."
+  )
+  public int stackLevel;
+  
+  @Parameter(
+    names = {PARAM_LOG_LEVEL},
+    description = "Determines which logging messages are printed out."
+  )
+  public String loggingLevel;
+
+}


### PR DESCRIPTION
Created an interface that allows the Parameterized parsing mechanism, which reflects an object to find the JCommander annotations, to be replaced at runtime for cases where the source code can not be directly annotated with JCommander annotations, but may have other annotations such as Json annotations that can be used to reflect as JCommander parameters.