### PR TITLE
usage() hides 'Comments:' header when ONLY hidden commands exist

### DIFF
--- a/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
@@ -244,6 +244,18 @@ public class DefaultUsageFormatter implements IUsageFormatter {
      * @param indent the indentation
      */
     public void appendCommands(StringBuilder out, int indentCount, int descriptionIndent, String indent) {
+        boolean hasOnlyHiddenCommands = true;
+        for (Map.Entry<JCommander.ProgramName, JCommander> commands : commander.getRawCommands().entrySet()) {
+            Object arg = commands.getValue().getObjects().get(0);
+            Parameters p = arg.getClass().getAnnotation(Parameters.class);
+
+            if (p == null || !p.hidden())
+                hasOnlyHiddenCommands = false;
+        }
+
+        if (hasOnlyHiddenCommands)
+            return;
+
         out.append(indent + "  Commands:\n");
 
         // The magic value 3 is the number of spaces between the name of the option and its description


### PR DESCRIPTION
In the case an application **solely** has *hidden* commants, `usage()` won't print an empty `Commands:` section anymore using this PR. Before of that, the `Commands:` header was printed even in that case, which is not nice.