### PR TITLE
fixed Parameter does not display {},[],: correctly

### DIFF
--- a/src/main/java/com/beust/jcommander/converters/CommaParameterSplitter.java
+++ b/src/main/java/com/beust/jcommander/converters/CommaParameterSplitter.java
@@ -5,8 +5,21 @@ import java.util.List;
 
 public class CommaParameterSplitter implements IParameterSplitter {
 
-  public List<String> split(String value) {
-    return Arrays.asList(value.split(","));
+  @Override
+  public List<String> split(final String value) {
+    return getJsonType(value.trim()) ? Arrays.asList(value) : Arrays.asList(value.split(","));
   }
 
+
+  /**
+   * Check if the parameter is in Json format.
+   *
+   * @param arg the split parameter
+   * @return {@code true} if {@code String} is in Json format
+   */
+  public static boolean getJsonType(final String arg) {
+    final char[] chars = arg.toCharArray();
+    return chars[0] == '{' && chars[chars.length-1] == '}' || chars[0] == '[' && chars[chars.length-1] == ']'
+        ? true : false;
+  }
 }


### PR DESCRIPTION
In fact, the bug is not caused by the input of these symbols in the argument, but by the "splitter" call that splits the String according to ", ". so the input JSON will be split.
I added a method "JSONCheck" in CommParameterSplitter to determine if the parameter is JSON, and if it is, it will not be split according to ",".
fixed #431 