### PR TITLE
Fixed #471 @Param(default = )

### DIFF
--- a/src/main/java/com/beust/jcommander/Parameter.java
+++ b/src/main/java/com/beust/jcommander/Parameter.java
@@ -47,6 +47,11 @@ public @interface Parameter {
   String description() default "";
 
   /**
+   * Description of default value.
+   */
+  String defaultValueDescription() default "";
+
+  /**
    * Whether this option is required.
    */
   boolean required() default false;

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -168,11 +168,15 @@ public class ParameterDescription {
     return longestName;
   }
 
+  /**
+   * @return defaultValueDescription, if description is empty string, return default Object.
+   */
   public Object getDefault() {
    String defaultDescription = parameterAnnotation.defaultValueDescription();
    if (defaultDescription.isEmpty())
      return defaultObject;
-   return defaultDescription;
+   else
+     return defaultDescription;
   }
 
   public String getDescription() {

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -169,7 +169,10 @@ public class ParameterDescription {
   }
 
   public Object getDefault() {
-   return defaultObject;
+   String defaultDescription = parameterAnnotation.defaultValueDescription();
+   if (defaultDescription.isEmpty())
+     return defaultObject;
+   return defaultDescription;
   }
 
   public String getDescription() {


### PR DESCRIPTION
fixed #471 
I add defaultValueDiscription in Parameter.java (default conficts to the keyword of java). When getDefault() is called, it will check if defaultValueDiscription is a empty string. If not, getDefault() will return defaultValueDiscription instead of defaultObject.