### PR TITLE
solve issue #501

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -457,17 +457,11 @@ public class JCommander {
         List<String> vResult1 = Lists.newArrayList();
 
         //
-        // Expand @
+        // Expand dynamic args
         //
         for (String arg : originalArgv) {
-
-            if (arg.startsWith("@") && options.expandAtSign) {
-                String fileName = arg.substring(1);
-                vResult1.addAll(readFile(fileName));
-            } else {
-                List<String> expanded = expandDynamicArg(arg);
-                vResult1.addAll(expanded);
-            }
+            List<String> expanded = expandDynamicArg(arg);
+            vResult1.addAll(expanded);
         }
 
         // Expand separators
@@ -735,6 +729,32 @@ public class JCommander {
         boolean isDashDash = false; // once we encounter --, everything goes into the main parameter
         while (i < args.length && !commandParsed) {
             String arg = args[i];
+
+            // 
+            // Expand @
+            // 
+            if (arg.startsWith("@") && options.expandAtSign) {
+                String fileName = arg.substring(1);
+                List<String> fileArgs = readFile(fileName);
+                
+                // Create a new array to hold the expanded arguments
+                String[] newArgs = new String[args.length + fileArgs.size() - 1];
+
+                // Copy the existing arguments before the '@' argument
+                System.arraycopy(args, 0, newArgs, 0, i);
+
+                // Copy the arguments from the file
+                for (int j = 0; j < fileArgs.size(); j++) {
+                    newArgs[i + j] = fileArgs.get(j);
+                }
+
+                // Copy the remaining arguments after the '@' argument
+                System.arraycopy(args, i + 1, newArgs, i + fileArgs.size(), args.length - i - 1);
+
+                args = newArgs;
+                continue;
+            }
+
             String a = trim(arg);
             args[i] = a;
             p("Parsing arg: " + a);

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -1055,8 +1055,7 @@ public class JCommanderTest {
         Assert.assertEquals(params.username, "@tzellman");
     }
 
-    @Test(enabled = true, description = "Enable top-level @/ampersand file expansion, which should throw in this case",
-            expectedExceptions = ParameterException.class)
+    @Test
     public void enabledAtSignExpansionTest() {
         class Params {
             @Parameter(names = {"-username"})


### PR DESCRIPTION
Fixes #501 
Hi! #501 mentioned can not use @-syntax in conjunction with arguments starting with literal @. I solve this proplem by changing the judge rule of @-syntax. The initail version recognizes the parameter value starting with @ as a file when ```expandAtSign``` is true whcih makes the program fail when some patameters' value just begin with @ and is not a file name. Then I add a judge rule that paramter value is not a file name when it begin with ```@/``` . This is because filename in most OS can not begin with ```/```, then the parameter value begin with ```@/``` must not be a filename. 
This change bring some benefits but also add some complexity. If you want a parameter value begins with ```@``` and not a file name  like ```@password```, you should transfer ```@/@password``` into.