### PR TITLE
Fix regression with removed usage methods

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1023,6 +1023,41 @@ public class JCommander {
         usageFormatter.usage(sb);
         getConsole().println(sb.toString());
     }
+    
+    /**
+     * Display the usage for this command.
+     */
+    public void usage(String commandName) {
+        StringBuilder sb = new StringBuilder();
+        usageFormatter.usage(commandName, sb);
+        getConsole().println(sb.toString());
+    }
+
+    /**
+     * Store the help for the command in the passed string builder.
+     */
+    public void usage(String commandName, StringBuilder out) {
+        usageFormatter.usage(commandName, out, "");
+    }
+
+    /**
+     * Store the help for the command in the passed string builder, indenting
+     * every line with "indent".
+     */
+    public void usage(String commandName, StringBuilder out, String indent) {
+        usageFormatter.usage(commandName, out, indent);
+    }
+    
+    /**
+     * Store the help in the passed string builder.
+     */
+    public void usage(StringBuilder out) {
+        usageFormatter.usage(out, "");
+    }
+
+    public void usage(StringBuilder out, String indent) {
+        usageFormatter.usage(out, indent);
+    }
 
     /**
      * Sets the usage formatter.


### PR DESCRIPTION
Fixes a regression introduced with #408 where various `usage` methods got removed resulting in an API breaking change. Since this  did not get a major version increase, I am thinking this should not happen. I can deprecate those methods and point to the usage formatter documentation and possibly using something like 

```
    DefaultUsageFormatter usage = new DefaultUsageFormatter(jc);
    usage.usage("", sb);
```

instead of those methods, but then the `JCommander#setUsageFormatter(IUsageFormatter)` is kid of redundant and not used/needed.

I only made these changes via online editor so far and did not test/compile them. If someone can do that before merging that would be great of course, otherwise I can try to do it if this gets approved.

Might fix issue #483 (I see an instance of `commander.usage(sb);`)
