### PR TITLE
Use return type of method to determine parameter type

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -829,6 +829,13 @@ public class Args {
 
   @Parameter(names = "-debug", description = "Debug mode")
   private boolean debug = false;
+  
+  private Integer setterParameter;
+  @Parameter(names = "-setterParameter", description = "A parameter annotation on a setter method")
+  public void setParameter(Integer value) {
+    this.setterParameter = value;
+  }
+  
 }</code></pre>
 </div>
 </div>

--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -146,7 +146,7 @@ public class Parameterized {
 
   public Class<?> getType() {
     if (method != null) {
-      return method.getParameterTypes()[0];
+      return method.getReturnType();
     } else {
       return field.getType();
     }
@@ -287,7 +287,7 @@ public class Parameterized {
 
   public Type getGenericType() {
     if (method != null) {
-      return method.getGenericParameterTypes()[0];
+      return method.getGenericReturnType();
     } else {
       return field.getGenericType();
     }

--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -146,7 +146,7 @@ public class Parameterized {
 
   public Class<?> getType() {
     if (method != null) {
-      return method.getReturnType();
+      return method.getParameterTypes()[0];
     } else {
       return field.getType();
     }
@@ -287,7 +287,7 @@ public class Parameterized {
 
   public Type getGenericType() {
     if (method != null) {
-      return method.getGenericReturnType();
+      return method.getGenericParameterTypes()[0];
     } else {
       return field.getGenericType();
     }


### PR DESCRIPTION
Shouldn't the return type of the method be used to determine the parameter type? I ran into this issue when experimenting with enums (generic enums to be precise...) and when I tried to annotate methods with `@Parameter` instead of class fields. Using the first parameter of a method call does not make sense to me unless I am missing something. The annotation should be on getters anyways without any method parameters.

Parameters on methods instead of class fields does not seem to be something that is documented, but by the `@Parameter` annotation with `@Target({ FIELD, METHOD })` and from various bug reports and PR's I learned that it is possible.

Test code:

```
  public class TestCmd {

    @Parameter()
    public String getInputFormat() {
      return "";
    }

  }
```

```
    TestCmd cmd = new TestCmd();

    JCommander jc = JCommander.newBuilder().addObject(cmd).build();
    jc.usage();
```

throws a 
```
java.lang.ArrayIndexOutOfBoundsException: 0
	at com.beust.jcommander.Parameterized.getType(Parameterized.java:149)
	at com.beust.jcommander.ParameterDescription.init(ParameterDescription.java:131)
```