### PR TITLE
enable testng tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,10 @@ dependencies {
         .forEach { testCompile(it) }
 }
 
+tasks.withType<Test> {
+     useTestNG()
+}
+
 //
 // Releases:
 // ./gradlew bintrayUpload (to JCenter)


### PR DESCRIPTION
Without this commit gradle doesn't execute testng tests:
![image](https://user-images.githubusercontent.com/82477955/138935419-174c0a70-b6ec-452e-bc32-ede60e6a0e01.png)
With this commit, it does:
![image](https://user-images.githubusercontent.com/82477955/138935486-a467b20b-4774-4d3d-b1c3-2c135be99ba9.png)
