### PR TITLE
Implements #539: `@Parameters(rules = <? extends IRule>)`

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -531,11 +531,11 @@ public static class QuietAndVerboseAreMutualExclusive implements IParametersVali
 }
 ----
 
-Specify the name of a class implementing this interface in the `rules` attribute of your `@Parameters` annotations:
+Specify the name of a class implementing this interface in the `parametersValidators` attribute of your `@Parameters` annotations:
 
 [source,java]
 ----
-@Parameters(rules = QuietAndVerboseAreMutualExclusive.class)
+@Parameters(parametersValidators = QuietAndVerboseAreMutualExclusive.class)
 class Flags {
     @Parameter(names = "--quiet", description = "Do not output anything")
     boolean quiet;
@@ -547,11 +547,11 @@ class Flags {
 
 Attempting to enable `--quiet` and `--verbose` at the same time will cause a `ParameterException` to be thrown.
 
-Multiple rules may be specified:
+Multiple validators may be specified:
 
 [source,java]
 ----
-@Parameters(rules = { QuietAndVerboseAreMutualExclusive.class, VerboseNeedsLevel.class })
+@Parameters(paremetersValidators = { QuietAndVerboseAreMutualExclusive.class, VerboseNeedsLevel.class })
 class Flags {
     @Parameter(names = "--quiet", description = "Do not output anything")
     boolean quiet;

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -502,7 +502,67 @@ private Integer value;
 
 === Global parameter validation
 
-After parsing your parameters with JCommander, you might want to perform additional validation across these parameters, such as making sure that two mutually exclusive parameters are not both specified. Because of all the potential combinations involved in such validation, JCommander does not provide any annotation-based solution to perform this validation because such an approach would necessarily be very limited by the very nature of Java annotations. Instead, you should simply perform this validation in Java on all the arguments that JCommander just parsed.
+After parsing your parameters with JCommander, you might want to perform additional validation across these parameters, such as making sure that two mutually exclusive parameters are not both specified.
+
+[source,java]
+----
+/**
+ * Validate all parameters.
+ *
+ * @param parameters
+ *            Name-value-pairs of all parameters (e.g. "-host":"localhost").
+ *
+ * @throws ParameterException
+ *             Thrown if validation of the parameters fails.
+ */
+void validate(Map<String, Object> parameters) throws ParameterException;
+----
+
+Here is an example implementation that will make sure that the boolean options `--quiet` and `--verbose` are not enabled at the same time:
+
+[source,java]
+----
+public static class QuietAndVerboseAreMutualExclusive implements IRule {
+    @Override
+    public void validate(Map<String, Object> parameters) throws ParameterException {
+        if (parameters.get("--quiet") == TRUE && parameters.get("--verbose") == TRUE)
+            throw new ParameterException("--quiet and --verbose are mutually exclusive");
+    }
+}
+----
+
+Specify the name of a class implementing this interface in the `rules` attribute of your `@Parameters` annotations:
+
+[source,java]
+----
+@Parameters(rules = QuietAndVerboseAreMutualExclusive.class)
+class Flags {
+    @Parameter(names = "--quiet", description = "Do not output anything")
+    boolean quiet;
+
+    @Parameter(names = "--verbose", description = "Output detailed information")
+    boolean verbose;
+}
+----
+
+Attempting to enable `--quiet` and `--verbose` at the same time will cause a `ParameterException` to be thrown.
+
+Multiple rules may be specified:
+
+[source,java]
+----
+@Parameters(rules = { QuietAndVerboseAreMutualExclusive.class, VerboseNeedsLevel.class })
+class Flags {
+    @Parameter(names = "--quiet", description = "Do not output anything")
+    boolean quiet;
+
+    @Parameter(names = "--verbose", description = "Output detailed information")
+    boolean verbose;
+
+    @Parameter(names = "--level", description = "Detail level of verbose information")
+    Integer level;
+}
+----
 
 
 == Main parameter

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -522,7 +522,7 @@ Here is an example implementation that will make sure that the boolean options `
 
 [source,java]
 ----
-public static class QuietAndVerboseAreMutualExclusive implements IRule {
+public static class QuietAndVerboseAreMutualExclusive implements IParametersValidator {
     @Override
     public void validate(Map<String, Object> parameters) throws ParameterException {
         if (parameters.get("--quiet") == TRUE && parameters.get("--verbose") == TRUE)

--- a/src/main/java/com/beust/jcommander/IParametersValidator.java
+++ b/src/main/java/com/beust/jcommander/IParametersValidator.java
@@ -2,7 +2,7 @@ package com.beust.jcommander;
 
 import java.util.Map;
 
-public interface IRule {
+public interface IParametersValidator {
 
     /**
      * Validate all parameters.

--- a/src/main/java/com/beust/jcommander/IRule.java
+++ b/src/main/java/com/beust/jcommander/IRule.java
@@ -1,0 +1,18 @@
+package com.beust.jcommander;
+
+import java.util.Map;
+
+public interface IRule {
+
+    /**
+     * Validate all parameters.
+     *
+     * @param parameters
+     *            Name-value-pairs of all parameters (e.g. "-host":"localhost").
+     *
+     * @throws ParameterException
+     *             Thrown if validation of the parameters fails.
+     */
+    void validate(Map<String, Object> parameters) throws ParameterException;
+
+}

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -128,9 +128,9 @@ public class JCommander {
     private Map<Parameterized, ParameterDescription> requiredFields = Maps.newHashMap();
 
     /**
-     * A set of all the rules to be checked.
+     * A set of all the parameters validators to be applied.
      */
-    private Set<IRule> rules = Sets.newHashSet();
+    private Set<IParametersValidator> parametersValidators = Sets.newHashSet();
 
     /**
      * A map of all the parameterized fields/methods.
@@ -431,8 +431,8 @@ public class JCommander {
             nameValuePairs.put(pd.getLongestName(), pd.getValue());
         }
 
-        for (IRule rule : rules) {
-            rule.validate(nameValuePairs);
+        for (IParametersValidator parametersValidator : parametersValidators) {
+            parametersValidator.validate(nameValuePairs);
         }
     }
 
@@ -621,13 +621,13 @@ public class JCommander {
         Class<?> cls = object.getClass();
 
         Parameters parameters = cls.getAnnotation(Parameters.class);
-        Class<? extends IRule>[] ruleClasses = parameters.rules();
-        for (Class<? extends IRule> ruleClass : ruleClasses) {
+        Class<? extends IParametersValidator>[] parametersValidatorClasses = parameters.parametersValidators();
+        for (Class<? extends IParametersValidator> parametersValidatorClass : parametersValidatorClasses) {
             try {
-                IRule rule = ruleClass.getDeclaredConstructor().newInstance();
-                rules.add(rule);
+                IParametersValidator parametersValidator = parametersValidatorClass.getDeclaredConstructor().newInstance();
+                parametersValidators.add(parametersValidator);
             } catch (ReflectiveOperationException e) {
-                throw new ParameterException("Cannot instantiate rule: " + ruleClass, e);
+                throw new ParameterException("Cannot instantiate rule: " + parametersValidatorClass, e);
             }
         }
 

--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -280,7 +280,15 @@ public class ParameterDescription {
     }
     if (! isDefault) assigned = true;
 
+    this.value = finalValue;
+
     return finalValue;
+  }
+
+  private Object value;
+
+  Object getValue() {
+	  return value;
   }
 
   private Object handleSubParameters(String value, int currentIndex, Class<?> type,

--- a/src/main/java/com/beust/jcommander/Parameters.java
+++ b/src/main/java/com/beust/jcommander/Parameters.java
@@ -69,6 +69,6 @@ public @interface Parameters {
   /**
    * Validate the value for all parameters.
    */
-  Class<? extends IRule>[] rules() default {};
+  Class<? extends IParametersValidator>[] parametersValidators() default {};
 
 }

--- a/src/main/java/com/beust/jcommander/Parameters.java
+++ b/src/main/java/com/beust/jcommander/Parameters.java
@@ -65,4 +65,10 @@ public @interface Parameters {
    * If true, this command won't appear in the usage().
    */
   boolean hidden() default false;
+
+  /**
+   * Validate the value for all parameters.
+   */
+  Class<? extends IRule>[] rules() default {};
+
 }

--- a/src/test/java/com/beust/jcommander/ParametersRulesTest.java
+++ b/src/test/java/com/beust/jcommander/ParametersRulesTest.java
@@ -1,0 +1,35 @@
+package com.beust.jcommander;
+
+import static java.lang.Boolean.TRUE;
+
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+public class ParametersRulesTest {
+
+    @Parameters(rules = QuietAndVerboseAreMutualExclusive.class)
+    class Flags {
+        @Parameter(names = "--quiet", description = "Do not output anything")
+        boolean quiet;
+
+        @Parameter(names = "--verbose", description = "Output detailed information")
+        boolean verbose;
+    }
+
+    public static class QuietAndVerboseAreMutualExclusive implements IRule {
+        @Override
+        public void validate(Map<String, Object> parameters) throws ParameterException {
+            if (parameters.get("--quiet") == TRUE && parameters.get("--verbose") == TRUE)
+                throw new ParameterException("--quiet and --verbose are mutually exclusive");
+        }
+    }
+
+    @Test(expectedExceptions = ParameterException.class,
+          expectedExceptionsMessageRegExp = "--quiet and --verbose are mutually exclusive")
+    public void testParameters() throws Exception {
+        Object o = new Flags();
+        JCommander.newBuilder().addObject(o).build().parse("--quiet", "--verbose");
+    }
+
+}

--- a/src/test/java/com/beust/jcommander/ParametersRulesTest.java
+++ b/src/test/java/com/beust/jcommander/ParametersRulesTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 
 public class ParametersRulesTest {
 
-    @Parameters(rules = QuietAndVerboseAreMutualExclusive.class)
+    @Parameters(parametersValidators = QuietAndVerboseAreMutualExclusive.class)
     class Flags {
         @Parameter(names = "--quiet", description = "Do not output anything")
         boolean quiet;
@@ -17,7 +17,7 @@ public class ParametersRulesTest {
         boolean verbose;
     }
 
-    public static class QuietAndVerboseAreMutualExclusive implements IRule {
+    public static class QuietAndVerboseAreMutualExclusive implements IParametersValidator {
         @Override
         public void validate(Map<String, Object> parameters) throws ParameterException {
             if (parameters.get("--quiet") == TRUE && parameters.get("--verbose") == TRUE)


### PR DESCRIPTION
This PR proposes a solution to #539 by adding the new interface `IRule`, and the new `rules` attribute to `@Paramters`. An example demonstrating mutual exclusive parameters is excluded. Also a test is included.

In contrast to #539 I dediced that it makes more sense to have rules at the `@Parameters` annotation on the class rather than rules on the single `@Parameter` level. The reason is that it would be confusing for the reader if a rule spanning over two parameters is just provided at one parameter annotation. This situation cannot happen if rules can only be given at the class annotation instead of the field annotation.