### PR TITLE
refactored classes parameterized and parameterDescription for removing the smells and to remove conplex methods

### DIFF
--- a/src/main/java/com/beust/jcommander/ParameterDescription.java
+++ b/src/main/java/com/beust/jcommander/ParameterDescription.java
@@ -235,8 +235,7 @@ public class ParameterDescription {
     if(name == null) {
       name = wrappedParameter.names()[0];
     }
-    if (currentIndex == 00 && assigned && ! isMultiOption() && !jCommander.isParameterOverwritingAllowed()
-            || isNonOverwritableForced()) {
+    if (multipleOptionsAtOnce(currentIndex)) {
       throw new ParameterException("Can only specify option " + name + " once.");
     }
 
@@ -284,6 +283,9 @@ public class ParameterDescription {
 
     return finalValue;
   }
+
+  private boolean multipleOptionsAtOnce(int currentIndex){return  (currentIndex == 00 && assigned && ! isMultiOption() && !jCommander.isParameterOverwritingAllowed()
+          || isNonOverwritableForced());}
 
   private Object value;
 

--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -90,33 +90,33 @@ public class Parameterized {
   }
 
   private static void checkFields(Class<?> cls,List<Parameterized> result){
-    for (Field f : cls.getDeclaredFields()) {
-      Annotation annotation = f.getAnnotation(Parameter.class);
-      Annotation delegateAnnotation = f.getAnnotation(ParametersDelegate.class);
-      Annotation dynamicParameter = f.getAnnotation(DynamicParameter.class);
-      addToResult(annotation,delegateAnnotation,dynamicParameter,result,f,null);
+    for (Field field : cls.getDeclaredFields()) {
+      Annotation annotation = field.getAnnotation(Parameter.class);
+      Annotation delegateAnnotation = field.getAnnotation(ParametersDelegate.class);
+      Annotation dynamicParameter = field.getAnnotation(DynamicParameter.class);
+      addToResult(annotation,delegateAnnotation,dynamicParameter,result,field,null);
     }
   }
   private static void checkMethods(Class<?> cls,List<Parameterized> result){
 
-    for (Method m : cls.getDeclaredMethods()) {
-      m.setAccessible(true);
-      Annotation annotation = m.getAnnotation(Parameter.class);
-      Annotation delegateAnnotation = m.getAnnotation(ParametersDelegate.class);
-      Annotation dynamicParameter = m.getAnnotation(DynamicParameter.class);
-      addToResult(annotation,delegateAnnotation,dynamicParameter,result,null,m);
+    for (Method method : cls.getDeclaredMethods()) {
+      method.setAccessible(true);
+      Annotation annotation = method.getAnnotation(Parameter.class);
+      Annotation delegateAnnotation = method.getAnnotation(ParametersDelegate.class);
+      Annotation dynamicParameter = method.getAnnotation(DynamicParameter.class);
+      addToResult(annotation,delegateAnnotation,dynamicParameter,result,null,method);
     }
   }
-  private static void addToResult(Annotation annotation,Annotation delegateAnnotation,Annotation dynamicParameter,List<Parameterized> result,Field f,Method m){
+  private static void addToResult(Annotation annotation,Annotation delegateAnnotation,Annotation dynamicParameter,List<Parameterized> result,Field field,Method method){
     if (annotation != null) {
       result.add(new Parameterized(new WrappedParameter((Parameter) annotation), null,
-              f, m));
+              field, method));
     } else if (dynamicParameter != null) {
       result.add(new Parameterized(new WrappedParameter((DynamicParameter) dynamicParameter), null,
-              f, m));
+              field, method));
     } else if (delegateAnnotation != null) {
       result.add(new Parameterized(null, (ParametersDelegate) delegateAnnotation,
-              f, m));
+              field, method));
     }
   }
   public static List<Parameterized> parseArg(Object arg) {

--- a/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
@@ -54,21 +54,21 @@ public class ParameterizedParserTest {
     Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
   }
   
-//  @Test
-//  public void jsonParameterizedParsingTest() {
-//    JsonCommandClassExample_01 commandOptions = new JsonCommandClassExample_01();
-//
-//    JCommander jcommander = new JCommander();
-//    jcommander.setParameterizedParser(new JsonAnnotationParameterizedParser());
-//    jcommander.addObject(commandOptions);
-//
-//    testFields(jcommander, EXPECTED_MAP);
-//
-//    jcommander.parse(ARGS);
-//    Assert.assertTrue(EXPECTED_VERSION.equals(commandOptions.version), "Version is not " + EXPECTED_VERSION);
-//    Assert.assertTrue(EXPECTED_STACK_LEVEL == commandOptions.subCommands.stackLevel, "Stack level field is not" + EXPECTED_STACK_LEVEL);
-//    Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
-//  }
+  @Test
+  public void jsonParameterizedParsingTest() {
+    JsonCommandClassExample_01 commandOptions = new JsonCommandClassExample_01();
+    
+    JCommander jcommander = new JCommander();
+    jcommander.setParameterizedParser(new JsonAnnotationParameterizedParser());
+    jcommander.addObject(commandOptions);
+
+    testFields(jcommander, EXPECTED_MAP);
+
+    jcommander.parse(ARGS);
+    Assert.assertTrue(EXPECTED_VERSION.equals(commandOptions.version), "Version is not " + EXPECTED_VERSION);
+    Assert.assertTrue(EXPECTED_STACK_LEVEL == commandOptions.subCommands.stackLevel, "Stack level field is not" + EXPECTED_STACK_LEVEL);
+    Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
+  }
   
   
   public void testFields(JCommander jcommander, Map<String, Boolean> expectedMap) {

--- a/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
@@ -54,21 +54,21 @@ public class ParameterizedParserTest {
     Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
   }
   
-  @Test
-  public void jsonParameterizedParsingTest() {
-    JsonCommandClassExample_01 commandOptions = new JsonCommandClassExample_01();
-    
-    JCommander jcommander = new JCommander();
-    jcommander.setParameterizedParser(new JsonAnnotationParameterizedParser());
-    jcommander.addObject(commandOptions);
-    
-    testFields(jcommander, EXPECTED_MAP);
-
-    jcommander.parse(ARGS);
-    Assert.assertTrue(EXPECTED_VERSION.equals(commandOptions.version), "Version is not " + EXPECTED_VERSION);
-    Assert.assertTrue(EXPECTED_STACK_LEVEL == commandOptions.subCommands.stackLevel, "Stack level field is not" + EXPECTED_STACK_LEVEL);
-    Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
-  }
+//  @Test
+//  public void jsonParameterizedParsingTest() {
+//    JsonCommandClassExample_01 commandOptions = new JsonCommandClassExample_01();
+//
+//    JCommander jcommander = new JCommander();
+//    jcommander.setParameterizedParser(new JsonAnnotationParameterizedParser());
+//    jcommander.addObject(commandOptions);
+//
+//    testFields(jcommander, EXPECTED_MAP);
+//
+//    jcommander.parse(ARGS);
+//    Assert.assertTrue(EXPECTED_VERSION.equals(commandOptions.version), "Version is not " + EXPECTED_VERSION);
+//    Assert.assertTrue(EXPECTED_STACK_LEVEL == commandOptions.subCommands.stackLevel, "Stack level field is not" + EXPECTED_STACK_LEVEL);
+//    Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
+//  }
   
   
   public void testFields(JCommander jcommander, Map<String, Boolean> expectedMap) {


### PR DESCRIPTION
method parseArg in parameterized class is so complex and needs to be split further for maintainability and code readability.
method parseArg is split into checkFields, checkMethods, addToResult, parseArg in the same class. 

method addValue in parameterDescription class has a very complex conditional splitting it further would help in improving the code readability. 

I really look forward to contributing more to the repository in terms of code refactoring and in making code more readable but I am not sure if the maintainers are entertaining these kind of contributions. Through this PR please let me know if i can contribute to the repository with this kind of work i will be more than happy to contribute.