### PR TITLE
Allow acceptUnknownOption with variableArity

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -527,7 +527,10 @@ public class JCommander {
     }
 
     private boolean isOption(String passedArg) {
-        if (options.acceptUnknownOptions) return true;
+        return (options.acceptUnknownOptions) || isNamedOption(passedArg);
+    }
+
+    private boolean isNamedOption(String passedArg) {
 
         String arg = options.caseSensitiveOptions ? passedArg : passedArg.toLowerCase();
 
@@ -876,7 +879,8 @@ public class JCommander {
         @Override
         public int processVariableArity(String optionName, String[] options) {
             int i = 0;
-            while (i < options.length && !isOption(options[i])) {
+            // For variableArity we consume everything until we hit a known parameter
+            while (i < options.length && !isNamedOption(options[i])) {
                 i++;
             }
             return i;

--- a/src/test/java/com/beust/jcommander/VariableArityTest.java
+++ b/src/test/java/com/beust/jcommander/VariableArityTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 public class VariableArityTest {
 
+
+  @Parameters(separators = "=")
   public static class ModelGenerationConfig {
 
     @Parameter(names = { "-m", "--matrixData" }, variableArity = true,
@@ -64,7 +66,27 @@ public class VariableArityTest {
     Assert.assertEquals(config.j, Arrays.asList("--compilation_level", "WHITESPACE_ONLY", "--language_in=ECMASCRIPT5", "-bar", "baz", "-faz", "--more-options"));
   }
 
+  @Test
+  public void verifyVariableArity_unknownOptions() {
+    String[] input =
+        {"-m", "foo", "--seed", "1024", "-c=foo", "bar", "-f", "foo", "-o=out.txt", "--extra"};
+    ModelGenerationConfig config = new ModelGenerationConfig();
+    JCommander com = new JCommander(config);
+    com.setProgramName("modelgen");
+    com.setAcceptUnknownOptions(true);
+
+    com.parse(input);
+
+    Assert.assertNotEquals(config.seed, 0);
+    Assert.assertEquals(config.modelMatrixFile, Arrays.asList("foo"));
+    Assert.assertEquals(config.featureFile, Arrays.asList("foo"));
+    Assert.assertEquals(config.seed, 1024);
+    Assert.assertEquals(config.outputFile, "out.txt");
+    Assert.assertEquals(config.configFile, Arrays.asList("foo", "bar"));
+  }
+
   public static void main(String[] args) {
     new VariableArityTest().verifyVariableArity();
+    new VariableArityTest().verifyVariableArity_unknownOptions();
   }
 }

--- a/src/test/java/com/beust/jcommander/VariableArityTest.java
+++ b/src/test/java/com/beust/jcommander/VariableArityTest.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 public class VariableArityTest {
 
-
-  @Parameters(separators = "=")
   public static class ModelGenerationConfig {
 
     @Parameter(names = { "-m", "--matrixData" }, variableArity = true,
@@ -66,11 +64,15 @@ public class VariableArityTest {
     Assert.assertEquals(config.j, Arrays.asList("--compilation_level", "WHITESPACE_ONLY", "--language_in=ECMASCRIPT5", "-bar", "baz", "-faz", "--more-options"));
   }
 
+  @Parameters(separators = "=")
+  public static class EqualsModelGenerationConfig extends ModelGenerationConfig {
+  }
+
   @Test
   public void verifyVariableArity_unknownOptions() {
     String[] input =
         {"-m", "foo", "--seed", "1024", "-c=foo", "bar", "-f", "foo", "-o=out.txt", "--extra"};
-    ModelGenerationConfig config = new ModelGenerationConfig();
+    EqualsModelGenerationConfig config = new EqualsModelGenerationConfig();
     JCommander com = new JCommander(config);
     com.setProgramName("modelgen");
     com.setAcceptUnknownOptions(true);


### PR DESCRIPTION
VariableArity makes it difficult to decide whether a token belongs to a preceding variableArity Parameter or is a new unknown parameter.

This commits makes a variableArity Parameter consume all tokens until it encounters a known option.

Fixes: #377