### PR TITLE
Next release will be org.jcommander::1.83

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 
 
 object This {
-    val version = "1.82"
+    val version = "1.83"
     val artifactId = "jcommander"
-    val groupId = "com.beust"
+    val groupId = "org.jcommander"
     val description = "Command line parsing library for Java"
     val url = "https://jcommander.org"
     val scm = "github.com/cbeust/jcommander"


### PR DESCRIPTION
@cbeust As we want to publish 1.83 using groupId org.jcommander, we need to change (at least) this file. Do you also want to use org.jcommander as the new package name, or do you want to keep the current package name com.cbeust.jcommander? In the latter case we should increase version to 2.0.0, as this is not backwards compatible.