### PR TITLE
Fixed: #563 - JCommander does not recognize command by alias.

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -537,6 +537,9 @@ public class JCommander {
         for (IKey key : commands.keySet()) {
             if (matchArg(arg, key)) return true;
         }
+        for (IKey key : aliasMap.keySet()) {
+            if (matchArg(arg, key)) return true;
+        }
 
         return false;
     }


### PR DESCRIPTION
# Description
Fixes #563

The actual cause of this issue was that the code for checking aliases simply was missing.