### PR TITLE
Keep original exception thrown by the parameter setter method

### DIFF
--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -276,7 +276,7 @@ public class Parameterized {
       if (ex.getTargetException() instanceof ParameterException) {
         throw (ParameterException) ex.getTargetException();
       } else {
-        throw new ParameterException(errorMessage(method, ex));
+        throw new ParameterException(errorMessage(method, ex), ex.getTargetException());
       }
     }
   }

--- a/src/test/java/com/beust/jcommander/MethodSetterTest.java
+++ b/src/test/java/com/beust/jcommander/MethodSetterTest.java
@@ -56,6 +56,24 @@ public class MethodSetterTest {
     Assert.assertTrue(passed, "Should have thrown an exception");
   }
 
+  public void setterThatThrowsKeepsOriginalException() {
+    class Arg {
+      @Parameter(names = "--host")
+      public void setHost(String host) {
+        throw new IllegalArgumentException("Illegal host");
+      }
+    }
+    boolean passed = false;
+    try {
+      JCommander.newBuilder().addObject(new Arg()).build().parse("--host", "host");
+    } catch(ParameterException ex) {
+      Assert.assertEquals(ex.getCause().getClass(), IllegalArgumentException.class);
+      Assert.assertEquals(ex.getCause().getMessage(), "Illegal host");
+      passed = true;
+    }
+    Assert.assertTrue(passed, "Should have thrown an exception");
+  }
+
   public void getterReturningNonString() {
     class Arg {
       private Integer port;


### PR DESCRIPTION
This change adds the exception thrown by a setter method annotated 
with the @Parameter to the ParameterException.

Before this change it was not clear what exactly happened, because
ParameterException did not have the original exception thrown by the 
@Parameter setter method.