### PR TITLE
Exclude methods which are bridge or synthetic when parsing - Fixes #576

### DIFF
--- a/src/main/java/com/beust/jcommander/Parameterized.java
+++ b/src/main/java/com/beust/jcommander/Parameterized.java
@@ -121,6 +121,9 @@ public class Parameterized {
       // check methods
       for (Method m : cls.getDeclaredMethods()) {
         m.setAccessible(true);
+        if (m.isBridge() || m.isSynthetic()) {
+          continue;
+        }
         Annotation annotation = m.getAnnotation(Parameter.class);
         Annotation delegateAnnotation = m.getAnnotation(ParametersDelegate.class);
         Annotation dynamicParameter = m.getAnnotation(DynamicParameter.class);

--- a/src/test/java/com/beust/jcommander/parameterized/parser/BridgeMethodsExample.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/BridgeMethodsExample.java
@@ -6,11 +6,11 @@ import com.beust.jcommander.Parameter;
  * Because this class extends a class which uses a recursive generic, the compiler will create a bridge method in this
  * class for setBaseProperty that we should ignore when searching for parameterized methods.
  */
-public final class BuilderExample extends BaseBuilder<BuilderExample> {
+public final class BridgeMethodsExample extends BaseBuilder<BridgeMethodsExample> {
     public String directProperty;
 
     @Parameter(names = "--direct-property")
-    public BuilderExample setDirectProperty(String directProperty) {
+    public BridgeMethodsExample setDirectProperty(String directProperty) {
         this.directProperty = directProperty;
         return this;
     }

--- a/src/test/java/com/beust/jcommander/parameterized/parser/BuilderExample.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/BuilderExample.java
@@ -16,11 +16,11 @@ public final class BuilderExample extends BaseBuilder<BuilderExample> {
     }
 }
 
-class BaseBuilder<T extends BaseBuilder<?>> {
+class BaseBuilder<T extends BaseBuilder<T>> {
     public String baseProperty;
 
     @Parameter(names = "--base-property")
-    public BaseBuilder<?> setBaseProperty(String baseProperty) {
+    public T setBaseProperty(String baseProperty) {
         this.baseProperty = baseProperty;
         return (T) this;
     }

--- a/src/test/java/com/beust/jcommander/parameterized/parser/BuilderExample.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/BuilderExample.java
@@ -1,0 +1,27 @@
+package com.beust.jcommander.parameterized.parser;
+
+import com.beust.jcommander.Parameter;
+
+/**
+ * Because this class extends a class which uses a recursive generic, the compiler will create a bridge method in this
+ * class for setBaseProperty that we should ignore when searching for parameterized methods.
+ */
+public final class BuilderExample extends BaseBuilder<BuilderExample> {
+    public String directProperty;
+
+    @Parameter(names = "--direct-property")
+    public BuilderExample setDirectProperty(String directProperty) {
+        this.directProperty = directProperty;
+        return this;
+    }
+}
+
+class BaseBuilder<T extends BaseBuilder<?>> {
+    public String baseProperty;
+
+    @Parameter(names = "--base-property")
+    public BaseBuilder<?> setBaseProperty(String baseProperty) {
+        this.baseProperty = baseProperty;
+        return (T) this;
+    }
+}

--- a/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
@@ -10,7 +10,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-
 /**
  * Tests the Parameterized parser for substituting the original parser looking go @Parameter
  * but can be replaced to look for other annotations that define run-time parameters.
@@ -69,7 +68,18 @@ public class ParameterizedParserTest {
     Assert.assertTrue(EXPECTED_STACK_LEVEL == commandOptions.subCommands.stackLevel, "Stack level field is not" + EXPECTED_STACK_LEVEL);
     Assert.assertTrue(EXPECTED_LOG_LEVEL.equals(commandOptions.subCommands.loggingLevel), "Log level is not " + EXPECTED_LOG_LEVEL);
   }
-  
+
+  @Test
+  public void ignoreBridgeMethodsTest() {
+    BuilderExample builder = new BuilderExample();
+
+    JCommander jCommander = new JCommander();
+    jCommander.addObject(builder);
+
+    jCommander.parse("--direct-property", "SomeDirectProperty", "--base-property", "SomeBaseProperty");
+    Assert.assertEquals("SomeDirectProperty", builder.directProperty);
+    Assert.assertEquals("SomeBaseProperty", builder.baseProperty);
+  }
   
   public void testFields(JCommander jcommander, Map<String, Boolean> expectedMap) {
     Map<Parameterized,ParameterDescription> fields = jcommander.getFields();
@@ -83,7 +93,5 @@ public class ParameterizedParserTest {
     Assert.assertTrue(expectedMap.containsKey(StandardCommandClassExample_01.PARAM_VERSION), "Version field not found");
     Assert.assertTrue(expectedMap.containsKey(StandardCommandClassExample_02.PARAM_STACK_LEVEL), "Stack level field not found");
     Assert.assertTrue(expectedMap.containsKey(StandardCommandClassExample_02.PARAM_LOG_LEVEL), "Log level field not found");
-    
-    
-  }  
+  }
 }

--- a/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
+++ b/src/test/java/com/beust/jcommander/parameterized/parser/ParameterizedParserTest.java
@@ -71,7 +71,7 @@ public class ParameterizedParserTest {
 
   @Test
   public void ignoreBridgeMethodsTest() {
-    BuilderExample builder = new BuilderExample();
+    BridgeMethodsExample builder = new BridgeMethodsExample();
 
     JCommander jCommander = new JCommander();
     jCommander.addObject(builder);


### PR DESCRIPTION
Fixes #576 