### PR TITLE
Fix an NPE

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1036,8 +1036,9 @@ public class JCommander {
 
     public String getMainParameterDescription() {
         if (descriptions == null) createDescriptions();
-        return mainParameter.annotation != null ? mainParameter.annotation.description()
-                : null;
+    return mainParameter == null
+        ? null
+        : mainParameter.annotation != null ? mainParameter.annotation.description() : null;
     }
 
     /**
@@ -1322,7 +1323,7 @@ public class JCommander {
      * @return the main parameter description or null if none is defined.
      */
     public ParameterDescription getMainParameterValue() {
-        return mainParameter.description;
+        return mainParameter == null ? null : mainParameter.description;
     }
 
     private void p(String string) {

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -31,6 +31,7 @@ import com.beust.jcommander.internal.Maps;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
 import java.io.*;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -31,7 +31,6 @@ import com.beust.jcommander.internal.Maps;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
 import java.io.*;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
@@ -1436,6 +1435,20 @@ public class JCommanderTest {
                 .addObject(args)
                 .args(new String[]{"a"})
                 .build();
+    }
+
+    @Test
+    public void noMainParameter() {
+        class Args {
+            @Parameter(names = "-f")
+            private int f;
+        }
+        Args args = new Args();
+        JCommander jcommander =
+            JCommander.newBuilder().addObject(args).args(new String[] {"-f", "1"}).build();
+        Assert.assertNull(jcommander.getMainParameter());
+        Assert.assertNull(jcommander.getMainParameterDescription());
+        Assert.assertNull(jcommander.getMainParameterValue());
     }
 
     @Test


### PR DESCRIPTION
When mainParameter is null (which is the default), calling
getMainParameterValue()/getMainParameterDescription() throws an NPE because it
tries to access a field on a null object.