### PR TITLE
Correct javadoc for forceNonOverwritable

### DIFF
--- a/docs/apidocs/com/beust/jcommander/Parameter.html
+++ b/docs/apidocs/com/beust/jcommander/Parameter.html
@@ -135,7 +135,7 @@ loadScripts(document, 'script');</script>
 <div class="col-first odd-row-color"><code>boolean</code></div>
 <div class="col-second odd-row-color"><code><a href="#forceNonOverwritable()" class="member-name-link">forceNonOverwritable</a></code></div>
 <div class="col-last odd-row-color">
-<div class="block">If true, this parameter can be overwritten through a file or another appearance of the parameter</div>
+<div class="block">If true, this parameter can not be overwritten through a file or another appearance of the parameter</div>
 </div>
 <div class="col-first even-row-color"><code>boolean</code></div>
 <div class="col-second even-row-color"><code><a href="#help()" class="member-name-link">help</a></code></div>
@@ -436,7 +436,7 @@ loadScripts(document, 'script');</script>
 <section class="detail" id="forceNonOverwritable()">
 <h3>forceNonOverwritable</h3>
 <div class="member-signature"><span class="return-type">boolean</span>&nbsp;<span class="element-name">forceNonOverwritable</span></div>
-<div class="block">If true, this parameter can be overwritten through a file or another appearance of the parameter</div>
+<div class="block">If true, this parameter can not be overwritten through a file or another appearance of the parameter</div>
 <dl class="notes">
 <dt>Returns:</dt>
 <dd>nc</dd>

--- a/docs/apidocs/index-all.html
+++ b/docs/apidocs/index-all.html
@@ -416,7 +416,7 @@ loadScripts(document, 'script');</script>
 <dd>&nbsp;</dd>
 <dt><a href="com/beust/jcommander/Parameter.html#forceNonOverwritable()" class="member-name-link">forceNonOverwritable()</a> - Element in annotation interface com.beust.jcommander.<a href="com/beust/jcommander/Parameter.html" title="annotation interface in com.beust.jcommander">Parameter</a></dt>
 <dd>
-<div class="block">If true, this parameter can be overwritten through a file or another appearance of the parameter</div>
+<div class="block">If true, this parameter can not be overwritten through a file or another appearance of the parameter</div>
 </dd>
 <dt><a href="com/beust/jcommander/FuzzyMap.html" class="type-name-link" title="class in com.beust.jcommander">FuzzyMap</a> - Class in <a href="com/beust/jcommander/package-summary.html">com.beust.jcommander</a></dt>
 <dd>

--- a/src/main/java/com/beust/jcommander/Parameter.java
+++ b/src/main/java/com/beust/jcommander/Parameter.java
@@ -127,7 +127,7 @@ public @interface Parameter {
   boolean help() default false;
   
   /**
-   * If true, this parameter can be overwritten through a file or another appearance of the parameter
+   * If true, this parameter can not be overwritten through a file or another appearance of the parameter
    * @return nc
    */
   boolean forceNonOverwritable() default false;


### PR DESCRIPTION
forceNonOverwritable has the behavior when set to `true` that a value can not be overwritten.

The javadoc had been written to suggest it has the opposite behavior.