### PR TITLE
Avoid printing extra new lines at the end of usage and refactor blank lines

### DIFF
--- a/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
@@ -40,7 +40,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
     public final void usage(String commandName) {
         StringBuilder sb = new StringBuilder();
         usage(commandName, sb);
-        commander.getConsole().println(sb.toString());
+        commander.getConsole().print(sb.toString());
     }
 
     /**
@@ -270,13 +270,18 @@ public class DefaultUsageFormatter implements IUsageFormatter {
             return;
 
         out.append(indent + "  Commands:\n");
-
+        boolean firstCommand = true;
         // The magic value 3 is the number of spaces between the name of the option and its description
         for (Map.Entry<JCommander.ProgramName, JCommander> commands : commander.getRawCommands().entrySet()) {
             Object arg = commands.getValue().getObjects().get(0);
             Parameters p = arg.getClass().getAnnotation(Parameters.class);
 
             if (p == null || !p.hidden()) {
+                if (!firstCommand) {
+                    out.append("\n");
+                } else {
+                    firstCommand = false;
+                }
                 JCommander.ProgramName progName = commands.getKey();
                 String dispName = progName.getDisplayName();
                 String commandDescription = Optional.ofNullable(getCommandDescription(progName.getName()))
@@ -289,7 +294,6 @@ public class DefaultUsageFormatter implements IUsageFormatter {
                 // Options for this command
                 JCommander jc = commander.findCommandByAlias(progName.getName());
                 jc.getUsageFormatter().usage(out, indent + s(6));
-                out.append("\n");
             }
         }
     }

--- a/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
@@ -169,6 +169,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
     public void appendAllParametersDetails(StringBuilder out, int indentCount, String indent,
             List<ParameterDescription> sortedParameters) {
         if (sortedParameters.size() > 0) {
+            out.append("\n");
             out.append(indent).append("  Options:\n");
         }
 
@@ -269,14 +270,21 @@ public class DefaultUsageFormatter implements IUsageFormatter {
         if (hasOnlyHiddenCommands)
             return;
 
+        out.append("\n");
         out.append(indent + "  Commands:\n");
 
+        boolean firstCommand = true;
         // The magic value 3 is the number of spaces between the name of the option and its description
         for (Map.Entry<JCommander.ProgramName, JCommander> commands : commander.getRawCommands().entrySet()) {
             Object arg = commands.getValue().getObjects().get(0);
             Parameters p = arg.getClass().getAnnotation(Parameters.class);
 
             if (p == null || !p.hidden()) {
+                if (!firstCommand) {
+                    out.append("\n");
+                } else {
+                    firstCommand = false;
+                }
                 JCommander.ProgramName progName = commands.getKey();
                 String dispName = progName.getDisplayName();
                 String commandDescription = Optional.ofNullable(getCommandDescription(progName.getName()))

--- a/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
@@ -270,18 +270,13 @@ public class DefaultUsageFormatter implements IUsageFormatter {
             return;
 
         out.append(indent + "  Commands:\n");
-        boolean firstCommand = true;
+
         // The magic value 3 is the number of spaces between the name of the option and its description
         for (Map.Entry<JCommander.ProgramName, JCommander> commands : commander.getRawCommands().entrySet()) {
             Object arg = commands.getValue().getObjects().get(0);
             Parameters p = arg.getClass().getAnnotation(Parameters.class);
 
             if (p == null || !p.hidden()) {
-                if (!firstCommand) {
-                    out.append("\n");
-                } else {
-                    firstCommand = false;
-                }
                 JCommander.ProgramName progName = commands.getKey();
                 String dispName = progName.getDisplayName();
                 String commandDescription = Optional.ofNullable(getCommandDescription(progName.getName()))

--- a/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/DefaultUsageFormatter.java
@@ -67,7 +67,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
 
         if (description != null) {
             out.append(indent).append(description);
-            out.append("\n");
+            out.append('\n');
         }
         jc.getUsageFormatter().usage(out, indent);
     }
@@ -154,7 +154,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
             mainLine.append(" ").append(commander.getMainParameter().getDescription().getDescription());
         }
         wrapDescription(out, indentCount, mainLine.toString());
-        out.append("\n");
+        out.append('\n');
     }
 
     /**
@@ -169,7 +169,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
     public void appendAllParametersDetails(StringBuilder out, int indentCount, String indent,
             List<ParameterDescription> sortedParameters) {
         if (sortedParameters.size() > 0) {
-            out.append("\n");
+            out.append('\n');
             out.append(indent).append("  Options:\n");
         }
 
@@ -183,7 +183,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
                     .append("  ")
                     .append(parameter.required() ? "* " : "  ")
                     .append(pd.getNames())
-                    .append("\n");
+                    .append('\n');
 
             if (hasDescription) {
                 wrapDescription(out, indentCount, s(indentCount) + description);
@@ -242,7 +242,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
                     out.append(possibleValues);
                 }
             }
-            out.append("\n");
+            out.append('\n');
         }
     }
 
@@ -270,10 +270,10 @@ public class DefaultUsageFormatter implements IUsageFormatter {
         if (hasOnlyHiddenCommands)
             return;
 
-        out.append("\n");
+        out.append('\n');
         out.append(indent + "  Commands:\n");
 
-        boolean firstCommand = true;
+        var firstCommand = true;
         // The magic value 3 is the number of spaces between the name of the option and its description
         for (Map.Entry<JCommander.ProgramName, JCommander> commands : commander.getRawCommands().entrySet()) {
             Object arg = commands.getValue().getObjects().get(0);
@@ -281,7 +281,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
 
             if (p == null || !p.hidden()) {
                 if (!firstCommand) {
-                    out.append("\n");
+                    out.append('\n');
                 } else {
                     firstCommand = false;
                 }
@@ -292,7 +292,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
                     .orElse("");
                 String description = indent + s(4) + dispName + commandDescription;
                 wrapDescription(out, indentCount + descriptionIndent, description);
-                out.append("\n");
+                out.append('\n');
 
                 // Options for this command
                 JCommander jc = commander.findCommandByAlias(progName.getName());
@@ -369,7 +369,7 @@ public class DefaultUsageFormatter implements IUsageFormatter {
                     current++;
                 }
             } else {
-                out.append("\n").append(s(indent)).append(word).append(" ");
+                out.append('\n').append(s(indent)).append(word).append(" ");
                 current = indent + word.length() + 1;
             }
         }

--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -1096,7 +1096,7 @@ public class JCommander {
     public void usage() {
         StringBuilder sb = new StringBuilder();
         usageFormatter.usage(sb);
-        getConsole().println(sb.toString());
+        getConsole().print(sb.toString());
     }
     
     /**
@@ -1105,7 +1105,7 @@ public class JCommander {
     public void usage(String commandName) {
         StringBuilder sb = new StringBuilder();
         usageFormatter.usage(commandName, sb);
-        getConsole().println(sb.toString());
+        getConsole().print(sb.toString());
     }
 
     /**

--- a/src/main/java/com/beust/jcommander/UnixStyleUsageFormatter.java
+++ b/src/main/java/com/beust/jcommander/UnixStyleUsageFormatter.java
@@ -102,7 +102,7 @@ public class UnixStyleUsageFormatter extends DefaultUsageFormatter {
             // The magic value 3 is the number of spaces between the name of the option and its description
             // in DefaultUsageFormatter#appendCommands(..)
             wrapDescription(out, indentCount + prefixIndent - 3, initialLinePrefixLength, description);
-            out.append("\n");
+            out.append('\n');
         }
     }
 }

--- a/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
@@ -53,19 +53,24 @@ public class DefaultUsageFormatterTest {
         jc.setConsole(new OutputForwardingConsole(output));
         jc.usage();
         String expected = "Usage: <main class> [options] [command] [command options]\n"
+                + "\n"
                 + "  Options:\n"
                 + "    -a, --a, --a-parameter\n"
                 + "      a parameter\n"
                 + "      Default: 0\n"
+                + "\n"
                 + "  Commands:\n"
                 + "    one      one command\n"
                 + "      Usage: one [options]\n"
+                + "\n"
                 + "        Options:\n"
                 + "          -b, --b, --b-parameter\n"
                 + "            b parameter\n"
                 + "            Default: 0\n"
+                + "\n"
                 + "    two      two command\n"
                 + "      Usage: two [options]\n"
+                + "\n"
                 + "        Options:\n"
                 + "          -c, --c, --c-parameter\n"
                 + "            c parameter\n"
@@ -109,6 +114,7 @@ public class DefaultUsageFormatterTest {
 
         // verify
         String expected = "Usage: <main class> [options]\n"
+                + "\n"
                 + "  Options:\n"
                 + "    --a, -a\n"
                 + "      Default: 0\n"
@@ -358,7 +364,7 @@ public class DefaultUsageFormatterTest {
 
         StringBuilder sb = new StringBuilder();
         c.getUsageFormatter().usage(sb);
-        Assert.assertTrue(sb.toString().contains("[command options]\n  Commands:"));
+        Assert.assertTrue(sb.toString().contains("[command options]\n\n  Commands:"));
     }
 
     @Test
@@ -387,9 +393,11 @@ public class DefaultUsageFormatterTest {
         StringBuilder sb = new StringBuilder();
         c.getUsageFormatter().usage(sb);
         String expected = "Usage: <main class> [command] [command options]\n"
+                + "\n"
                 + "  Commands:\n"
                 + "    a      command a\n"
                 + "      Usage: a command a parameters\n"
+                + "\n"
                 + "    b      command b\n"
                 + "      Usage: b command b parameters\n";
         Assert.assertEquals(sb.toString(), expected);
@@ -424,7 +432,7 @@ public class DefaultUsageFormatterTest {
 
         StringBuilder sb = new StringBuilder();
         c.getUsageFormatter().usage(sb);
-        Assert.assertTrue(sb.toString().contains("command a parameters\n        Commands:"));
+        Assert.assertTrue(sb.toString().contains("command a parameters\n\n        Commands:"));
         Assert.assertTrue(sb.toString().contains("command b\n            Usage:"));
     }
 

--- a/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
@@ -50,7 +50,7 @@ public class DefaultUsageFormatterTest {
                 .addCommand(new TwoCommand())
                 .build();
         StringBuilder output = new StringBuilder();
-        jc.setConsole(new OutputForwardingConsole(output));
+        jc.setConsole(new StringBuilderConsole(output));
         jc.usage();
         String expected = "Usage: <main class> [options] [command] [command options]\n"
                 + "\n"

--- a/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
@@ -39,9 +39,15 @@ public class DefaultUsageFormatterTest {
             @Parameter(names = {"-b", "--b", "--b-parameter"}, description = "b parameter")
             public int b;
         }
+        @Parameters(commandNames = "two", commandDescription = "two command")
+        class TwoCommand {
+            @Parameter(names = {"-c", "--c", "--c-parameter"}, description = "c parameter")
+            public int c;
+        }
         JCommander jc = JCommander.newBuilder()
                 .addObject(new MainParameters())
                 .addCommand(new OneCommand())
+                .addCommand(new TwoCommand())
                 .build();
         StringBuilder output = new StringBuilder();
         jc.setConsole(new OutputForwardingConsole(output));
@@ -57,6 +63,12 @@ public class DefaultUsageFormatterTest {
                 + "        Options:\n"
                 + "          -b, --b, --b-parameter\n"
                 + "            b parameter\n"
+                + "            Default: 0\n"
+                + "    two      two command\n"
+                + "      Usage: two [options]\n"
+                + "        Options:\n"
+                + "          -c, --c, --c-parameter\n"
+                + "            c parameter\n"
                 + "            Default: 0\n";
         Assert.assertEquals(output.toString(), expected);
     }
@@ -378,7 +390,6 @@ public class DefaultUsageFormatterTest {
                 + "  Commands:\n"
                 + "    a      command a\n"
                 + "      Usage: a command a parameters\n"
-                + "\n"
                 + "    b      command b\n"
                 + "      Usage: b command b parameters\n";
         Assert.assertEquals(sb.toString(), expected);

--- a/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/DefaultUsageFormatterTest.java
@@ -5,8 +5,8 @@ import com.beust.jcommander.internal.Maps;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.*;
 import java.util.ResourceBundle;
+import java.util.*;
 
 @Test
 public class DefaultUsageFormatterTest {
@@ -26,6 +26,39 @@ public class DefaultUsageFormatterTest {
     }
 
     private enum TestEnum2 {
+    }
+
+    @Test
+    public void testUsage() {
+        class MainParameters {
+            @Parameter(names = {"-a", "--a", "--a-parameter"}, description = "a parameter")
+            public int a;
+        }
+        @Parameters(commandNames = "one", commandDescription = "one command")
+        class OneCommand {
+            @Parameter(names = {"-b", "--b", "--b-parameter"}, description = "b parameter")
+            public int b;
+        }
+        JCommander jc = JCommander.newBuilder()
+                .addObject(new MainParameters())
+                .addCommand(new OneCommand())
+                .build();
+        StringBuilder output = new StringBuilder();
+        jc.setConsole(new OutputForwardingConsole(output));
+        jc.usage();
+        String expected = "Usage: <main class> [options] [command] [command options]\n"
+                + "  Options:\n"
+                + "    -a, --a, --a-parameter\n"
+                + "      a parameter\n"
+                + "      Default: 0\n"
+                + "  Commands:\n"
+                + "    one      one command\n"
+                + "      Usage: one [options]\n"
+                + "        Options:\n"
+                + "          -b, --b, --b-parameter\n"
+                + "            b parameter\n"
+                + "            Default: 0\n";
+        Assert.assertEquals(output.toString(), expected);
     }
 
     @Test
@@ -341,7 +374,14 @@ public class DefaultUsageFormatterTest {
 
         StringBuilder sb = new StringBuilder();
         c.getUsageFormatter().usage(sb);
-        Assert.assertTrue(sb.toString().contains("command a parameters\n\n    b"));
+        String expected = "Usage: <main class> [command] [command options]\n"
+                + "  Commands:\n"
+                + "    a      command a\n"
+                + "      Usage: a command a parameters\n"
+                + "\n"
+                + "    b      command b\n"
+                + "      Usage: b command b parameters\n";
+        Assert.assertEquals(sb.toString(), expected);
     }
 
     @Test

--- a/src/test/java/com/beust/jcommander/OutputForwardingConsole.java
+++ b/src/test/java/com/beust/jcommander/OutputForwardingConsole.java
@@ -1,0 +1,29 @@
+package com.beust.jcommander;
+
+import com.beust.jcommander.internal.Console;
+
+public class OutputForwardingConsole implements Console {
+
+	public final StringBuilder output;
+
+	public OutputForwardingConsole(StringBuilder output) {
+		this.output = output;
+	}
+
+	@Override
+	public void print(String msg) {
+		output.append(msg);
+	}
+
+	@Override
+	public void println(String msg) {
+		print(msg);
+		output.append("\n");
+	}
+
+	@Override
+	public char[] readPassword(boolean echoInput) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/src/test/java/com/beust/jcommander/StringBuilderConsole.java
+++ b/src/test/java/com/beust/jcommander/StringBuilderConsole.java
@@ -18,7 +18,7 @@ public class StringBuilderConsole implements Console {
 	@Override
 	public void println(String msg) {
 		print(msg);
-		output.append("\n");
+		output.append('\n');
 	}
 
 	@Override

--- a/src/test/java/com/beust/jcommander/StringBuilderConsole.java
+++ b/src/test/java/com/beust/jcommander/StringBuilderConsole.java
@@ -2,11 +2,11 @@ package com.beust.jcommander;
 
 import com.beust.jcommander.internal.Console;
 
-public class OutputForwardingConsole implements Console {
+public class StringBuilderConsole implements Console {
 
 	public final StringBuilder output;
 
-	public OutputForwardingConsole(StringBuilder output) {
+	public StringBuilderConsole(StringBuilder output) {
 		this.output = output;
 	}
 

--- a/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
@@ -331,7 +331,14 @@ public class UnixStyleUsageFormatterTest {
 
         StringBuilder sb = new StringBuilder();
         jc.getUsageFormatter().usage(sb);
-        Assert.assertTrue(sb.toString().contains("command a parameters\n\n    b"));
+        String expected = "Usage: <main class> [command] [command options]\n"
+                + "  Commands:\n"
+                + "    a      command a\n"
+                + "      Usage: a command a parameters\n"
+                + "\n"
+                + "    b      command b\n"
+                + "      Usage: b command b parameters\n";
+        Assert.assertEquals(sb.toString(), expected);
     }
 
     @Test

--- a/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
@@ -302,7 +302,7 @@ public class UnixStyleUsageFormatterTest {
 
         StringBuilder sb = new StringBuilder();
         jc.getUsageFormatter().usage(sb);
-        Assert.assertTrue(sb.toString().contains("[command options]\n  Commands:"));
+        Assert.assertTrue(sb.toString().contains("[command options]\n\n  Commands:"));
     }
 
     @Test
@@ -332,9 +332,11 @@ public class UnixStyleUsageFormatterTest {
         StringBuilder sb = new StringBuilder();
         jc.getUsageFormatter().usage(sb);
         String expected = "Usage: <main class> [command] [command options]\n"
+                + "\n"
                 + "  Commands:\n"
                 + "    a      command a\n"
                 + "      Usage: a command a parameters\n"
+                + "\n"
                 + "    b      command b\n"
                 + "      Usage: b command b parameters\n";
         Assert.assertEquals(sb.toString(), expected);
@@ -370,7 +372,7 @@ public class UnixStyleUsageFormatterTest {
 
         StringBuilder sb = new StringBuilder();
         jc.getUsageFormatter().usage(sb);
-        Assert.assertTrue(sb.toString().contains("command a parameters\n        Commands:"));
+        Assert.assertTrue(sb.toString().contains("command a parameters\n\n        Commands:"));
         Assert.assertTrue(sb.toString().contains("command b\n            Usage:"));
     }
 

--- a/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
+++ b/src/test/java/com/beust/jcommander/UnixStyleUsageFormatterTest.java
@@ -335,7 +335,6 @@ public class UnixStyleUsageFormatterTest {
                 + "  Commands:\n"
                 + "    a      command a\n"
                 + "      Usage: a command a parameters\n"
-                + "\n"
                 + "    b      command b\n"
                 + "      Usage: b command b parameters\n";
         Assert.assertEquals(sb.toString(), expected);


### PR DESCRIPTION
JCommander currently prints (in my examples) two extra empty lines at the end of usage. This makes the usage output look weird in my opinion.

One comes from a new line inserted by `JCommander`, which is not visible in tests, since those use the usage formatter directly.
Another one comes from commands, where the separating empty line was added regardless if there was another command coming.

I initially kept (but fixed) the command separating empty line, but I suggest removing all empty lines. Attached is a PR that removes all empty lines.

If you suggest keeping the empty line between commands, I suggest adding empty lines also after main line usage and options. I made the test code more verbose to see the new style. I also introduced one more test to compare the usage output from `JCommander.usage()` instead of the formatter.