### PR TITLE
Include license and notice in JAR

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,12 @@ tasks {
                 )
             )
         }
+        metaInf {
+            from(rootDir) {
+                include("license.txt")
+                include("notice.md")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Sections 4.a and 4.d of the Apache 2.0 license require that users who redistribute this library include the license and any notices. Most open source projects include these files in the JAR files, to make this requirement easy for users to fulfill. This PR adds these two files to the generated JAR files.