### PR TITLE
Fix call to containsKey, that doesn't compile under stricter flags?

### DIFF
--- a/src/main/java/com/beust/jcommander/JCommander.java
+++ b/src/main/java/com/beust/jcommander/JCommander.java
@@ -20,6 +20,7 @@ package com.beust.jcommander;
 
 import com.beust.jcommander.parser.DefaultParameterizedParser;
 import com.beust.jcommander.FuzzyMap.IKey;
+import com.beust.jcommander.StringKey;
 import com.beust.jcommander.converters.*;
 import com.beust.jcommander.internal.*;
 
@@ -675,7 +676,7 @@ public class JCommander {
                 //
                 DynamicParameter dp = wp.getDynamicParameter();
                 for (String name : dp.names()) {
-                    if (descriptions.containsKey(name)) {
+                    if (descriptions.containsKey(new StringKey(name))) {
                         throw new ParameterException("Found the option " + name + " multiple times");
                     }
                     p("Adding description for " + name);


### PR DESCRIPTION
Dear @cbeust, I have been using your repository to learn [Bazel](https://bazel.build/) (my effort is [here](https://github.com/smelc/jcommander/commits/bazelify), but irrelevant for you :smile_cat:). While doing so, I noticed that the Bazel build was failing because of a compilation error, which this commit fixes.

I am not exactly sure why the Gradle build passes right now, probably my Bazel build is using more strict compiler flags, and hence catches this error.

Nevertheless, I thought this was an improvement worth integrating into your main development branch, hence me creating this PR.

Hope this helps!