### PR TITLE
tests: Avoid DoubleBraceInitialization pattern

### DIFF
--- a/src/test/java/com/beust/jcommander/ConverterFactoryTest.java
+++ b/src/test/java/com/beust/jcommander/ConverterFactoryTest.java
@@ -36,9 +36,11 @@ import java.util.Map;
  * @author cbeust
  */
 public class ConverterFactoryTest {
-    private static final Map<Class, Class<? extends IStringConverter<?>>> MAP = new HashMap() {{
-        put(HostPort.class, HostPortConverter.class);
-    }};
+    private static final Map<Class, Class<? extends IStringConverter<?>>> MAP = new HashMap();
+
+    static {
+        MAP.put(HostPort.class, HostPortConverter.class);
+    }
 
     private static final IStringConverterFactory CONVERTER_FACTORY = new IStringConverterFactory() {
 

--- a/src/test/java/com/beust/jcommander/JCommanderTest.java
+++ b/src/test/java/com/beust/jcommander/JCommanderTest.java
@@ -642,11 +642,11 @@ public class JCommanderTest {
     public void handleSets() {
         ArgsWithSet args = new ArgsWithSet();
         JCommander.newBuilder().addObject(args).build().parse("-s", "3,1,2");
-        Assert.assertEquals(args.set, new TreeSet<Integer>() {{
-            add(1);
-            add(2);
-            add(3);
-        }});
+        Set<Integer> expected = new TreeSet<>();
+        expected.add(1);
+        expected.add(2);
+        expected.add(3);
+        Assert.assertEquals(args.set, expected);
     }
 
     private static final List<String> V = Arrays.asList("a", "b", "c", "d");

--- a/src/test/java/com/beust/jcommander/ParametersDelegateTest.java
+++ b/src/test/java/com/beust/jcommander/ParametersDelegateTest.java
@@ -66,12 +66,13 @@ public class ParametersDelegateTest {
     }
     class LeafDelegate {
       @Parameter(names = "--list")
-      public List<String> list = new ArrayList<String>() {{
-        add("value1");
-        add("value2");
-      }};
+      public List<String> list = new ArrayList<>();
       @Parameter(names = "--bool")
       public boolean bool;
+      public LeafDelegate() {
+        list.add("value1");
+        list.add("value2");
+      }
     }
     class NestedDelegate1 {
       @ParametersDelegate
@@ -108,10 +109,10 @@ public class ParametersDelegateTest {
     JCommander cmd = new JCommander(p);
     cmd.parse("--anon-float 1.2 -d 234 --list a --list b -a".split(" "));
     Assert.assertEquals(p.nestedDelegate2.anonymousDelegate.getFloat(), 1.2f);
-    Assert.assertEquals(p.nestedDelegate2.nestedDelegate1.leafDelegate.list, new ArrayList<String>() {{
-      add("a");
-      add("b");
-    }});
+    List<String> expected = new ArrayList<>();
+    expected.add("a");
+    expected.add("b");
+    Assert.assertEquals(p.nestedDelegate2.nestedDelegate1.leafDelegate.list, expected);
     Assert.assertFalse(p.nestedDelegate2.nestedDelegate1.leafDelegate.bool);
     Assert.assertEquals(p.nestedDelegate2.nestedDelegate1.d, Integer.valueOf(234));
     Assert.assertFalse(p.nestedDelegate2.isC);
@@ -156,10 +157,10 @@ public class ParametersDelegateTest {
     cmd.addCommand("command", c);
 
     cmd.parse("command main params".split(" "));
-    Assert.assertEquals(c.delegate.mainParams, new ArrayList<String>() {{
-      add("main");
-      add("params");
-    }});
+    List<String> expected = new ArrayList<>();
+    expected.add("main");
+    expected.add("params");
+    Assert.assertEquals(c.delegate.mainParams, expected);
   }
 
   @Test(expectedExceptions = ParameterException.class,

--- a/src/test/java/com/beust/jcommander/ParametersNotEmptyTest.java
+++ b/src/test/java/com/beust/jcommander/ParametersNotEmptyTest.java
@@ -28,10 +28,9 @@ public class ParametersNotEmptyTest {
         }
         Collections.sort(parameters);
 
-        Assert.assertEquals(parameters, new ArrayList<String>() {{
-            add("-date");
-            add("-debug");
-        }}
-        );
+        List<String> expected = new ArrayList<>();
+        expected.add("-date");
+        expected.add("-debug");
+        Assert.assertEquals(parameters, expected);
     }
 }


### PR DESCRIPTION
Finishing my [Bazel migration](https://github.com/smelc/jcommander) today, I witnessed that the version of the compiler I used locally was detecting some usages of [instance initializers](https://blogs.oracle.com/javamagazine/post/java-instance-initializer-block). Because [this pattern is not recommended](https://errorprone.info/bugpattern/DoubleBraceInitialization), this PR removes them.

I ran the tests locally and they still pass. This change only concerns tests, so it shouldn't break production nor create incompatibilities.