### PR TITLE
Remove test for deprecated method.

### DIFF
--- a/src/test/java/com/beust/jcommander/StringsTest.java
+++ b/src/test/java/com/beust/jcommander/StringsTest.java
@@ -3,29 +3,20 @@ package com.beust.jcommander;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-
 @Test
 public class StringsTest {
-
-    @Test
-    public void testListJoin() {
-        String expected = "A, B, C  c";
-        String actual = Strings.join(", ", Arrays.asList("A", "B", "C  c"));
-        Assert.assertEquals(expected, actual);
-    }
 
     @Test
     public void testArrayJoinSpaceDelimiter() {
         String expected = "A B C  c";
         String actual = Strings.join(" ", new String[] { "A", "B", "C  c" });
-        Assert.assertEquals(expected, actual);
+        Assert.assertEquals(actual, expected);
     }
 
     @Test
     public void testArrayJoinEmptyDelimiter() {
         String expected = "ABC  c";
         String actual = Strings.join("", new Object[] { "A", "B", "C  c" });
-        Assert.assertEquals(expected, actual);
+        Assert.assertEquals(actual, expected);
     }
 }


### PR DESCRIPTION
Unit test caused warnings in IDE because it tested a deprecated method. Order of assertEquals() arguments was wrong which also caused warnings.
